### PR TITLE
Make create-dev-env.sh podman compatible

### DIFF
--- a/create-dev-env.sh
+++ b/create-dev-env.sh
@@ -3,15 +3,15 @@
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 # Create docker network if one doesn't exist yet
-if [ $(docker network ls --filter "name=gitops-net" -q |wc -l) == 0 ]; then
+if [ "$(docker network ls --filter 'name=gitops-net' -q |wc -l)" == 0 ]; then
     echo "* Creating docker network 'gitops-net'"
     docker network create gitops-net
-	echo 
+	echo
 fi
 
 
 # Map the docker data directory into a temporary directory
-POSTGRES_DATA_DIR=`mktemp -d -t postgres-XXXXXXXXXX`
+POSTGRES_DATA_DIR=$(mktemp -d -t postgres-XXXXXXXXXX)
 
 echo "* Starting postgresql"
 
@@ -21,7 +21,7 @@ echo "* Starting postgresql"
 # - username: postgres
 # - password: gitops
 docker run --name managed-gitops-postgres \
-	-v $POSTGRES_DATA_DIR:/var/lib/postgresql/data:Z \
+	-v "$POSTGRES_DATA_DIR":/var/lib/postgresql/data:Z \
 	-e POSTGRES_PASSWORD=gitops	\
 	-p 5432:5432 \
 	--network gitops-net \


### PR DESCRIPTION
I've edited the create-dev-env.sh script to 
* get rid of deprecated `--link` flag in docker run in favor of `--network`. Now the script checks for gitops-net network and creates one if it's not present and then use it.
* uses port 8080 instead of 80 (not allowed with rootless podman)
* Improve the output by printing useful infor at the end of the script
* Address some issues shellcheck found with in this script.