### PR TITLE
Use red hat supported postgresql image

### DIFF
--- a/manifests/postgresql-staging/README.md
+++ b/manifests/postgresql-staging/README.md
@@ -1,21 +1,16 @@
-# PostgreSQL GitOps Staging YAML
+# PostgreSQL Database for GitOps 
 
-For Postgresql, there are a few ways to install it on Kubernetes, so we have some options for how we want to install it to the staging environment. We could use a PostgreSQL operator, Helm chart, or just flat YAML.
+## Support
 
-Here, I'm suggesting we just use plain YAML to install PostgreSQL, but for sake of simplicity that plain YAML file will be rendered from the Postgresql Helm Chart from Bitnami.
+The Red Hat suported image `registry.redhat.io/rhel8/postgresql-10:latest` is used in this setup via the `ImageStreamTag` made
+available for all OpenShift Container Platform users.
 
-Thus I have created a script to convert Helm chart (plus values.yaml file) into a YAML file, and then we check that YAML file into the repository (rather than invoking Helm directly in order to install postgres).
-
-
-## To regenerate the YAML to the latest Helm chart
-
-The 'regenerate-manifests.sh' file will download the Helm chart, look in the values.yaml for parameters to use, and then output the result to `postgres-staging.yaml`.
 
 ## Installation
 
 Then, to install PostgreSQL onto the cluster, all someone needs to do is:
 ```
-kubectl create namespace gitops-postgresql
-kubectl apply -n gitops-postgresql postgresql-staging.yaml
+kubectl apply postgresql-staging.yaml
 ```
 
+The installation yaml could also be checked into a GitOps respository, subject to careful handling of credentials.

--- a/manifests/postgresql-staging/postgresql-staging.yaml
+++ b/manifests/postgresql-staging/postgresql-staging.yaml
@@ -1,213 +1,131 @@
----
-# Source: postgresql/templates/secrets.yaml
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitops-postgresql
+spec:
+  finalizers:
+  - kubernetes
+---
 kind: Secret
+apiVersion: v1
 metadata:
-  name: gitops-postgresql-staging
-  labels:
-    app.kubernetes.io/name: postgresql
-    helm.sh/chart: postgresql-10.12.2
-    app.kubernetes.io/instance: gitops-postgresql-staging
-    app.kubernetes.io/managed-by: Helm
+  name: postgresql
   namespace: gitops-postgresql
-type: Opaque
 data:
-  postgresql-password: "a2Q5NWNWWnNiQg=="
+  database-name: cG9zdGdyZXM=
+  database-password: Z2l0b3Bz
+  database-user: cG9zdGdyZXM=
 ---
-# Source: postgresql/templates/svc-headless.yaml
-apiVersion: v1
 kind: Service
+apiVersion: v1
 metadata:
-  name: gitops-postgresql-staging-headless
-  labels:
-    app.kubernetes.io/name: postgresql
-    helm.sh/chart: postgresql-10.12.2
-    app.kubernetes.io/instance: gitops-postgresql-staging
-    app.kubernetes.io/managed-by: Helm
-    # Use this annotation in addition to the actual publishNotReadyAddresses
-    # field below because the annotation will stop being respected soon but the
-    # field is broken in some versions of Kubernetes:
-    # https://github.com/kubernetes/kubernetes/issues/58662
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  name: postgresql
   namespace: gitops-postgresql
 spec:
-  type: ClusterIP
-  clusterIP: None
-  # We want all pods in the StatefulSet to have their addresses published for
-  # the sake of the other Postgresql pods even before they're ready, since they
-  # have to be able to talk to each other in order to become ready.
-  publishNotReadyAddresses: true
+  ipFamilies:
+    - IPv4
   ports:
-    - name: tcp-postgresql
+    - name: postgresql
+      protocol: TCP
       port: 5432
-      targetPort: tcp-postgresql
-  selector:
-    app.kubernetes.io/name: postgresql
-    app.kubernetes.io/instance: gitops-postgresql-staging
----
-# Source: postgresql/templates/svc.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: gitops-postgresql-staging
-  labels:
-    app.kubernetes.io/name: postgresql
-    helm.sh/chart: postgresql-10.12.2
-    app.kubernetes.io/instance: gitops-postgresql-staging
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-  namespace: gitops-postgresql
-spec:
+      targetPort: 5432
+  internalTrafficPolicy: Cluster
   type: ClusterIP
-  ports:
-    - name: tcp-postgresql
-      port: 5432
-      targetPort: tcp-postgresql
+  ipFamilyPolicy: SingleStack
+  sessionAffinity: None
   selector:
-    app.kubernetes.io/name: postgresql
-    app.kubernetes.io/instance: gitops-postgresql-staging
-    role: primary
+    name: postgresql
 ---
-# Source: postgresql/templates/statefulset.yaml
+kind: Deployment
 apiVersion: apps/v1
-kind: StatefulSet
 metadata:
-  name: gitops-postgresql-staging-postgresql
-  labels:
-    app.kubernetes.io/name: postgresql
-    helm.sh/chart: postgresql-10.12.2
-    app.kubernetes.io/instance: gitops-postgresql-staging
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: primary
-  annotations:
+  name: postgresql
   namespace: gitops-postgresql
 spec:
-  serviceName: gitops-postgresql-staging-headless
   replicas: 1
-  updateStrategy:
-    type: RollingUpdate
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/name: postgresql
-      app.kubernetes.io/instance: gitops-postgresql-staging
-      role: primary
+      app: postgresql
   template:
     metadata:
-      name: gitops-postgresql-staging
+      creationTimestamp: null
       labels:
-        app.kubernetes.io/name: postgresql
-        helm.sh/chart: postgresql-10.12.2
-        app.kubernetes.io/instance: gitops-postgresql-staging
-        app.kubernetes.io/managed-by: Helm
-        role: primary
-        app.kubernetes.io/component: primary
-    spec:      
-      affinity:
-        podAffinity:
-          
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/name: postgresql
-                    app.kubernetes.io/instance: gitops-postgresql-staging
-                    app.kubernetes.io/component: primary
-                namespaces:
-                  - "gitops-postgresql"
-                topologyKey: kubernetes.io/hostname
-              weight: 1
-        nodeAffinity:
-          
-      securityContext:
-        fsGroup: 1001
-      automountServiceAccountToken: false
+        name: postgresql
+    spec:
+      volumes:
+        - name: postgresql-data
+          persistentVolumeClaim:
+            claimName: postgresql
       containers:
-        - name: gitops-postgresql-staging
-          image: docker.io/bitnami/postgresql:11.13.0-debian-10-r40
-          imagePullPolicy: "IfNotPresent"
-          resources:
-            requests:
-              cpu: 250m
-              memory: 256Mi
-          securityContext:
-            runAsUser: 1001
-          env:
-            - name: BITNAMI_DEBUG
-              value: "false"
-            - name: POSTGRESQL_PORT_NUMBER
-              value: "5432"
-            - name: POSTGRESQL_VOLUME_DIR
-              value: "/bitnami/postgresql"
-            - name: PGDATA
-              value: "/bitnami/postgresql/data"
-            - name: POSTGRES_USER
-              value: "postgres"
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: gitops-postgresql-staging
-                  key: postgresql-password
-            - name: POSTGRESQL_ENABLE_LDAP
-              value: "no"
-            - name: POSTGRESQL_ENABLE_TLS
-              value: "no"
-            - name: POSTGRESQL_LOG_HOSTNAME
-              value: "false"
-            - name: POSTGRESQL_LOG_CONNECTIONS
-              value: "false"
-            - name: POSTGRESQL_LOG_DISCONNECTIONS
-              value: "false"
-            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
-              value: "off"
-            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
-              value: "error"
-            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
-              value: "pgaudit"
-          ports:
-            - name: tcp-postgresql
-              containerPort: 5432
-          livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - exec pg_isready -U "postgres" -h 127.0.0.1 -p 5432
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-            successThreshold: 1
-            failureThreshold: 6
+        - resources:
+            limits:
+              memory: 512Mi
           readinessProbe:
             exec:
               command:
-                - /bin/sh
-                - -c
-                - -e
-                - |
-                  exec pg_isready -U "postgres" -h 127.0.0.1 -p 5432
-                  [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
+                - /usr/libexec/check-container
             initialDelaySeconds: 5
+            timeoutSeconds: 1
             periodSeconds: 10
-            timeoutSeconds: 5
             successThreshold: 1
-            failureThreshold: 6
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          name: postgresql
+          livenessProbe:
+            exec:
+              command:
+                - /usr/libexec/check-container
+                - '--live'
+            initialDelaySeconds: 120
+            timeoutSeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          env:
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql
+                  key: database-user
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql
+                  key: database-password
+            - name: POSTGRESQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql
+                  key: database-name
+          securityContext:
+            capabilities: {}
+            privileged: false
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          imagePullPolicy: IfNotPresent
           volumeMounts:
-            - name: dshm
-              mountPath: /dev/shm
-            - name: data
-              mountPath: /bitnami/postgresql
-              subPath: 
-      volumes:
-        - name: dshm
-          emptyDir:
-            medium: Memory
-  volumeClaimTemplates:
-    - metadata:
-        name: data
-      spec:
-        accessModes:
-          - "ReadWriteOnce"
-        resources:
-          requests:
-            storage: "8Gi"
+            - name: postgresql-data
+              mountPath: /var/lib/pgsql/data
+          terminationMessagePolicy: File
+          image: postgresql:10-el8
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: postgresql
+  namespace: gitops-postgresql
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: gp2
+  volumeMode: Filesystem

--- a/manifests/postgresql-staging/regenerate-manifests.sh
+++ b/manifests/postgresql-staging/regenerate-manifests.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Call this script file in order to regenerate the postgresql file to the latest version from the Helm chart
-
-helm repo add bitnami https://charts.bitnami.com/bitnami
-
-helm template gitops-postgresql-staging bitnami/postgresql -f values.yaml -n gitops-postgresql > postgresql-staging.yaml
-

--- a/manifests/postgresql-staging/values.yaml
+++ b/manifests/postgresql-staging/values.yaml
@@ -1,5 +1,0 @@
-values.yaml:
-  postgresqlDatabase: my-database
-  postgresqlUsername: my-user
-  postgresqlPassword: my-password
-


### PR DESCRIPTION
Hi,

Didn't mean to be disruptive :) I wanted to put in something that could eventually be moved into a Red Hat supported staging/prod.

* Removed the helm chart generated manifests since they were not OpenShift friendly ( was running as a specific user, was using a bitnami image)
* Replaced the manifests with those generated from supported OpenShift Templates - now using the `registry.redhat.io/rhel8/postgresql-10:latest` with the default restricted scc.

https://github.com/openshift/library/blob/master/official/postgresql/templates/postgresql-persistent.json