### PR TITLE
Add context param to all database queries

### DIFF
--- a/backend-shared/config/db/applicationstates.go
+++ b/backend-shared/config/db/applicationstates.go
@@ -1,8 +1,11 @@
 package db
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
-func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllApplicationStates() ([]ApplicationState, error) {
+func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllApplicationStates(ctx context.Context) ([]ApplicationState, error) {
 	if dbq.dbConnection == nil {
 		return nil, fmt.Errorf("database connection is nil")
 	}
@@ -12,7 +15,7 @@ func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllApplicationStates() ([]Applic
 	}
 
 	var appStates []ApplicationState
-	err := dbq.dbConnection.Model(&appStates).Select()
+	err := dbq.dbConnection.Model(&appStates).Context(ctx).Select()
 
 	if err != nil {
 		return nil, err
@@ -21,7 +24,7 @@ func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllApplicationStates() ([]Applic
 	return appStates, nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) DeleteApplicationStateById(id string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteApplicationStateById(ctx context.Context, id string) (int, error) {
 
 	if dbq.dbConnection == nil {
 		return 0, fmt.Errorf("database connection is nil")
@@ -39,7 +42,7 @@ func (dbq *PostgreSQLDatabaseQueries) DeleteApplicationStateById(id string) (int
 		Applicationstate_application_id: id,
 	}
 
-	deleteResult, err := dbq.dbConnection.Model(result).WherePK().Delete()
+	deleteResult, err := dbq.dbConnection.Model(result).WherePK().Context(ctx).Delete()
 	if err != nil {
 		return 0, fmt.Errorf("error on deleting application state: %v", err)
 	}

--- a/backend-shared/config/db/clusteruser.go
+++ b/backend-shared/config/db/clusteruser.go
@@ -1,10 +1,11 @@
 package db
 
 import (
+	"context"
 	"fmt"
 )
 
-func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllClusterUsers() ([]ClusterUser, error) {
+func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllClusterUsers(ctx context.Context) ([]ClusterUser, error) {
 	if dbq.dbConnection == nil {
 		return nil, fmt.Errorf("database connection is nil")
 	}
@@ -14,7 +15,7 @@ func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllClusterUsers() ([]ClusterUser
 	}
 
 	var clusterUsers []ClusterUser
-	err := dbq.dbConnection.Model(&clusterUsers).Select()
+	err := dbq.dbConnection.Model(&clusterUsers).Context(ctx).Select()
 
 	if err != nil {
 		return nil, err
@@ -23,7 +24,7 @@ func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllClusterUsers() ([]ClusterUser
 	return clusterUsers, nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) AdminDeleteClusterUserById(id string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) AdminDeleteClusterUserById(ctx context.Context, id string) (int, error) {
 	if dbq.dbConnection == nil {
 		return 0, fmt.Errorf("database connection is nil")
 	}
@@ -36,6 +37,7 @@ func (dbq *PostgreSQLDatabaseQueries) AdminDeleteClusterUserById(id string) (int
 
 	deleteResult, err := dbq.dbConnection.Model(result).
 		Where("clusteruser_id = ?", id).
+		Context(ctx).
 		Delete()
 
 	if err != nil {
@@ -45,7 +47,7 @@ func (dbq *PostgreSQLDatabaseQueries) AdminDeleteClusterUserById(id string) (int
 	return deleteResult.RowsAffected(), nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) CreateClusterUser(obj *ClusterUser) error {
+func (dbq *PostgreSQLDatabaseQueries) CreateClusterUser(ctx context.Context, obj *ClusterUser) error {
 
 	if dbq.dbConnection == nil {
 		return fmt.Errorf("database connection is nil")
@@ -69,7 +71,7 @@ func (dbq *PostgreSQLDatabaseQueries) CreateClusterUser(obj *ClusterUser) error 
 		return fmt.Errorf("user name should not be empty")
 	}
 
-	result, err := dbq.dbConnection.Model(obj).Insert()
+	result, err := dbq.dbConnection.Model(obj).Context(ctx).Insert()
 	if err != nil {
 		return fmt.Errorf("error on inserting cluster user: %v", err)
 	}
@@ -81,11 +83,11 @@ func (dbq *PostgreSQLDatabaseQueries) CreateClusterUser(obj *ClusterUser) error 
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) GetClusterUserByUsername(userName string) (*ClusterUser, error) {
+func (dbq *PostgreSQLDatabaseQueries) GetClusterUserByUsername(ctx context.Context, userName string) (*ClusterUser, error) {
 
 	// TODO: Add an index for this
 
-	if err := validateGenericEntity(userName, dbq); err != nil {
+	if err := validateQueryParams(userName, dbq); err != nil {
 		return nil, err
 	}
 
@@ -93,6 +95,7 @@ func (dbq *PostgreSQLDatabaseQueries) GetClusterUserByUsername(userName string) 
 
 	if err := dbq.dbConnection.Model(&result).
 		Where("cu.user_name = ?", userName).
+		Context(ctx).
 		Select(); err != nil {
 
 		return nil, fmt.Errorf("error on retrieving GetClusterUserByUsername: %v", err)
@@ -109,9 +112,9 @@ func (dbq *PostgreSQLDatabaseQueries) GetClusterUserByUsername(userName string) 
 	return &result[0], nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) GetClusterUserById(id string) (*ClusterUser, error) {
+func (dbq *PostgreSQLDatabaseQueries) GetClusterUserById(ctx context.Context, id string) (*ClusterUser, error) {
 
-	if err := validateGenericEntity(id, dbq); err != nil {
+	if err := validateQueryParams(id, dbq); err != nil {
 		return nil, err
 	}
 
@@ -119,6 +122,7 @@ func (dbq *PostgreSQLDatabaseQueries) GetClusterUserById(id string) (*ClusterUse
 
 	if err := dbq.dbConnection.Model(&result).
 		Where("cu.clusteruser_id = ?", id).
+		Context(ctx).
 		Select(); err != nil {
 
 		return nil, fmt.Errorf("error on retrieving GetClusterUserById: %v", err)

--- a/backend-shared/config/db/deploymenttoapplicationmapping.go
+++ b/backend-shared/config/db/deploymenttoapplicationmapping.go
@@ -1,12 +1,15 @@
 package db
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // TODO: Add context to all database query methods
 
-func (dbq *PostgreSQLDatabaseQueries) GetDeploymentToApplicationMappingById(id string) (*DeploymentToApplicationMapping, error) {
+func (dbq *PostgreSQLDatabaseQueries) GetDeploymentToApplicationMappingById(ctx context.Context, id string) (*DeploymentToApplicationMapping, error) {
 
-	if err := validateGenericEntity(id, dbq); err != nil {
+	if err := validateQueryParams(id, dbq); err != nil {
 		return nil, err
 	}
 
@@ -14,6 +17,7 @@ func (dbq *PostgreSQLDatabaseQueries) GetDeploymentToApplicationMappingById(id s
 
 	if err := dbq.dbConnection.Model(&result).
 		Where("dta.deploymenttoapplicationmapping_uid_id = ?", id).
+		Context(ctx).
 		Select(); err != nil {
 
 		return nil, fmt.Errorf("error on retrieving GetDeploymentToApplicationMappingById: %v", err)
@@ -30,9 +34,9 @@ func (dbq *PostgreSQLDatabaseQueries) GetDeploymentToApplicationMappingById(id s
 	return &(result[0]), nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UnsafeDeleteDeploymentToApplicationMappingById(id string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) UnsafeDeleteDeploymentToApplicationMappingById(ctx context.Context, id string) (int, error) {
 
-	if err := validateUnsafeGenericEntity(id, dbq); err != nil {
+	if err := validateUnsafeQueryParams(id, dbq); err != nil {
 		return 0, err
 	}
 
@@ -40,7 +44,7 @@ func (dbq *PostgreSQLDatabaseQueries) UnsafeDeleteDeploymentToApplicationMapping
 		Deploymenttoapplicationmapping_uid_id: id,
 	}
 
-	deleteResult, err := dbq.dbConnection.Model(entity).WherePK().Delete()
+	deleteResult, err := dbq.dbConnection.Model(entity).WherePK().Context(ctx).Delete()
 	if err != nil {
 		return 0, fmt.Errorf("error on deleting application: %v", err)
 	}
@@ -48,7 +52,7 @@ func (dbq *PostgreSQLDatabaseQueries) UnsafeDeleteDeploymentToApplicationMapping
 	return deleteResult.RowsAffected(), nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) CreateDeploymentToApplicationMapping(obj *DeploymentToApplicationMapping) error {
+func (dbq *PostgreSQLDatabaseQueries) CreateDeploymentToApplicationMapping(ctx context.Context, obj *DeploymentToApplicationMapping) error {
 
 	if dbq.allowTestUuids {
 		if isEmpty(obj.Deploymenttoapplicationmapping_uid_id) {
@@ -62,7 +66,7 @@ func (dbq *PostgreSQLDatabaseQueries) CreateDeploymentToApplicationMapping(obj *
 		obj.Deploymenttoapplicationmapping_uid_id = generateUuid()
 	}
 
-	if err := validateGenericEntity(obj.Deploymenttoapplicationmapping_uid_id, dbq); err != nil {
+	if err := validateQueryParams(obj.Deploymenttoapplicationmapping_uid_id, dbq); err != nil {
 		return err
 	}
 
@@ -70,7 +74,7 @@ func (dbq *PostgreSQLDatabaseQueries) CreateDeploymentToApplicationMapping(obj *
 		return fmt.Errorf("application id should not be empty")
 	}
 
-	result, err := dbq.dbConnection.Model(obj).Insert()
+	result, err := dbq.dbConnection.Model(obj).Context(ctx).Insert()
 	if err != nil {
 		return fmt.Errorf("error on inserting DeploymentToApplicationMapping %v", err)
 	}

--- a/backend-shared/config/db/queries.go
+++ b/backend-shared/config/db/queries.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -15,19 +16,19 @@ import (
 //
 // These should not be used, except by test code.
 type UnsafeDatabaseQueries interface {
-	UnsafeDeleteGitopsEngineInstanceById(id string) (int, error)
-	UnsafeDeleteManagedEnvironmentById(id string) (int, error)
-	UnsafeGetClusterCredentialsById(id string) (*ClusterCredentials, error)
-	UnsafeListAllApplications() ([]Application, error)
-	UnsafeListAllApplicationStates() ([]ApplicationState, error)
-	UnsafeListAllClusterAccess() ([]ClusterAccess, error)
-	UnsafeListAllClusterCredentials() ([]ClusterCredentials, error)
-	UnsafeListAllClusterUsers() ([]ClusterUser, error)
-	UnsafeGetApplicationById(id string) (*Application, error)
-	UnsafeListAllGitopsEngineClusters() ([]GitopsEngineCluster, error)
-	UnsafeListAllGitopsEngineInstances() ([]GitopsEngineInstance, error)
-	UnsafeListAllManagedEnvironments() ([]ManagedEnvironment, error)
-	UnsafeListAllOperations() ([]Operation, error)
+	UnsafeDeleteGitopsEngineInstanceById(ctx context.Context, id string) (int, error)
+	UnsafeDeleteManagedEnvironmentById(ctx context.Context, id string) (int, error)
+	UnsafeGetClusterCredentialsById(ctx context.Context, id string) (*ClusterCredentials, error)
+	UnsafeListAllApplications(ctx context.Context) ([]Application, error)
+	UnsafeListAllApplicationStates(ctx context.Context) ([]ApplicationState, error)
+	UnsafeListAllClusterAccess(ctx context.Context) ([]ClusterAccess, error)
+	UnsafeListAllClusterCredentials(ctx context.Context) ([]ClusterCredentials, error)
+	UnsafeListAllClusterUsers(ctx context.Context) ([]ClusterUser, error)
+	UnsafeGetApplicationById(ctx context.Context, id string) (*Application, error)
+	UnsafeListAllGitopsEngineClusters(ctx context.Context) ([]GitopsEngineCluster, error)
+	UnsafeListAllGitopsEngineInstances(ctx context.Context) ([]GitopsEngineInstance, error)
+	UnsafeListAllManagedEnvironments(ctx context.Context) ([]ManagedEnvironment, error)
+	UnsafeListAllOperations(ctx context.Context) ([]Operation, error)
 }
 
 type AllDatabaseQueries interface {
@@ -36,42 +37,42 @@ type AllDatabaseQueries interface {
 }
 
 type DatabaseQueries interface {
-	AdminDeleteClusterCredentialsById(id string) (int, error)
-	AdminDeleteClusterUserById(id string) (int, error)
-	AdminDeleteGitopsEngineClusterById(id string) (int, error)
+	AdminDeleteClusterCredentialsById(ctx context.Context, id string) (int, error)
+	AdminDeleteClusterUserById(ctx context.Context, id string) (int, error)
+	AdminDeleteGitopsEngineClusterById(ctx context.Context, id string) (int, error)
 
-	CreateApplication(obj *Application, ownerId string) error
-	CreateClusterAccess(obj *ClusterAccess) error
-	CreateClusterCredentials(obj *ClusterCredentials) error
-	CreateClusterUser(obj *ClusterUser) error
-	CreateDeploymentToApplicationMapping(obj *DeploymentToApplicationMapping) error
-	CreateGitopsEngineCluster(obj *GitopsEngineCluster) error
-	CreateGitopsEngineInstance(obj *GitopsEngineInstance) error
-	CreateManagedEnvironment(obj *ManagedEnvironment) error
-	CreateOperation(obj *Operation, ownerId string) error
+	CreateApplication(ctx context.Context, obj *Application, ownerId string) error
+	CreateClusterAccess(ctx context.Context, obj *ClusterAccess) error
+	CreateClusterCredentials(ctx context.Context, obj *ClusterCredentials) error
+	CreateClusterUser(ctx context.Context, obj *ClusterUser) error
+	CreateDeploymentToApplicationMapping(ctx context.Context, obj *DeploymentToApplicationMapping) error
+	CreateGitopsEngineCluster(ctx context.Context, obj *GitopsEngineCluster) error
+	CreateGitopsEngineInstance(ctx context.Context, obj *GitopsEngineInstance) error
+	CreateManagedEnvironment(ctx context.Context, obj *ManagedEnvironment) error
+	CreateOperation(ctx context.Context, obj *Operation, ownerId string) error
 
-	DeleteApplicationStateById(id string) (int, error)
-	DeleteApplicationById(id string) (int, error)
+	DeleteApplicationStateById(ctx context.Context, id string) (int, error)
+	DeleteApplicationById(ctx context.Context, id string) (int, error)
 
-	DeleteClusterAccessById(userId string, managedEnvironmentId string, gitopsEngineInstanceId string) (int, error)
-	DeleteGitopsEngineInstanceById(id string, ownerId string) (int, error)
-	DeleteManagedEnvironmentById(id string, ownerId string) (int, error)
-	DeleteOperationById(id string, ownerId string) (int, error)
+	DeleteClusterAccessById(ctx context.Context, userId string, managedEnvironmentId string, gitopsEngineInstanceId string) (int, error)
+	DeleteGitopsEngineInstanceById(ctx context.Context, id string, ownerId string) (int, error)
+	DeleteManagedEnvironmentById(ctx context.Context, id string, ownerId string) (int, error)
+	DeleteOperationById(ctx context.Context, id string, ownerId string) (int, error)
 
-	GetClusterCredentialsById(id string, ownerId string) (*ClusterCredentials, error)
-	GetClusterCredentialsByHost(hostName string, ownerId string) ([]ClusterCredentials, error)
-	GetClusterUserById(id string) (*ClusterUser, error)
-	GetClusterUserByUsername(userName string) (*ClusterUser, error)
-	GetGitopsEngineClusterById(id string, ownerId string) (*GitopsEngineCluster, error)
-	GetGitopsEngineClusterByCredentialId(credentialId string, ownerId string) ([]GitopsEngineCluster, error)
-	GetManagedEnvironmentByClusterCredentials(clusterCredentialId string, ownerId string) ([]ManagedEnvironment, error)
-	GetGitopsEngineInstanceById(id string, ownerId string) (*GitopsEngineInstance, error)
-	GetManagedEnvironmentById(id string, ownerId string) (*ManagedEnvironment, error)
-	GetOperationById(id string, ownerId string) (*Operation, error)
-	GetDeploymentToApplicationMappingById(id string) (*DeploymentToApplicationMapping, error)
+	GetClusterCredentialsById(ctx context.Context, id string, ownerId string) (*ClusterCredentials, error)
+	GetClusterCredentialsByHost(ctx context.Context, hostName string, ownerId string) ([]ClusterCredentials, error)
+	GetClusterUserById(ctx context.Context, id string) (*ClusterUser, error)
+	GetClusterUserByUsername(ctx context.Context, userName string) (*ClusterUser, error)
+	GetGitopsEngineClusterById(ctx context.Context, id string, ownerId string) (*GitopsEngineCluster, error)
+	GetGitopsEngineClusterByCredentialId(ctx context.Context, credentialId string, ownerId string) ([]GitopsEngineCluster, error)
+	GetManagedEnvironmentByClusterCredentials(ctx context.Context, clusterCredentialId string, ownerId string) ([]ManagedEnvironment, error)
+	GetGitopsEngineInstanceById(ctx context.Context, id string, ownerId string) (*GitopsEngineInstance, error)
+	GetManagedEnvironmentById(ctx context.Context, id string, ownerId string) (*ManagedEnvironment, error)
+	GetOperationById(ctx context.Context, id string, ownerId string) (*Operation, error)
+	GetDeploymentToApplicationMappingById(ctx context.Context, id string) (*DeploymentToApplicationMapping, error)
 
 	// TODO: Should this be Get*, or should some of the Get* be List* (Get implies it returns a single result.)
-	ListAllGitopsEngineInstancesByGitopsEngineCluster(engineClusterId string, ownerId string) ([]GitopsEngineInstance, error)
+	ListAllGitopsEngineInstancesByGitopsEngineCluster(ctx context.Context, engineClusterId string, ownerId string) ([]GitopsEngineInstance, error)
 
 	CloseDatabase()
 }

--- a/backend-shared/config/db/types_test.go
+++ b/backend-shared/config/db/types_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -9,6 +10,8 @@ import (
 )
 
 func testSetup(t *testing.T) {
+
+	ctx := context.Background()
 
 	// 'testSetup' deletes all database rows that start with 'test-' in the primary key of the row.
 	// This ensures a clean slate for the test run.
@@ -19,11 +22,11 @@ func testSetup(t *testing.T) {
 	}
 	defer dbq.CloseDatabase()
 
-	applicationStates, err := dbq.UnsafeListAllApplicationStates()
+	applicationStates, err := dbq.UnsafeListAllApplicationStates(ctx)
 	assert.NoError(t, err)
 	for _, applicationState := range applicationStates {
 		if strings.HasPrefix(applicationState.Applicationstate_application_id, "test-") {
-			rowsAffected, err := dbq.DeleteApplicationStateById(applicationState.Applicationstate_application_id)
+			rowsAffected, err := dbq.DeleteApplicationStateById(ctx, applicationState.Applicationstate_application_id)
 			assert.NoError(t, err)
 			if err == nil {
 				assert.Equal(t, rowsAffected, 1)
@@ -31,32 +34,32 @@ func testSetup(t *testing.T) {
 		}
 	}
 
-	operations, err := dbq.UnsafeListAllOperations()
+	operations, err := dbq.UnsafeListAllOperations(ctx)
 	assert.NoError(t, err)
 	for _, operation := range operations {
 
 		if strings.HasPrefix(operation.Operation_id, "test-") {
-			rowsAffected, err := dbq.DeleteOperationById(operation.Operation_id, operation.Operation_owner_user_id)
+			rowsAffected, err := dbq.DeleteOperationById(ctx, operation.Operation_id, operation.Operation_owner_user_id)
 			assert.Equal(t, rowsAffected, 1)
 			assert.NoError(t, err)
 		}
 	}
 
-	applications, err := dbq.UnsafeListAllApplications()
+	applications, err := dbq.UnsafeListAllApplications(ctx)
 	assert.NoError(t, err)
 	for _, application := range applications {
 		if strings.HasPrefix(application.Application_id, "test-") {
-			rowsAffected, err := dbq.DeleteApplicationById(application.Application_id)
+			rowsAffected, err := dbq.DeleteApplicationById(ctx, application.Application_id)
 			assert.Equal(t, rowsAffected, 1)
 			assert.NoError(t, err)
 		}
 	}
 
-	clusterAccess, err := dbq.UnsafeListAllClusterAccess()
+	clusterAccess, err := dbq.UnsafeListAllClusterAccess(ctx)
 	assert.NoError(t, err)
 	for _, clusterAccess := range clusterAccess {
 		if strings.HasPrefix(clusterAccess.Clusteraccess_managed_environment_id, "test-") {
-			rowsAffected, err := dbq.DeleteClusterAccessById(clusterAccess.Clusteraccess_user_id,
+			rowsAffected, err := dbq.DeleteClusterAccessById(ctx, clusterAccess.Clusteraccess_user_id,
 				clusterAccess.Clusteraccess_managed_environment_id,
 				clusterAccess.Clusteraccess_gitops_engine_instance_id)
 			assert.NoError(t, err)
@@ -66,12 +69,12 @@ func testSetup(t *testing.T) {
 		}
 	}
 
-	engineInstances, err := dbq.UnsafeListAllGitopsEngineInstances()
+	engineInstances, err := dbq.UnsafeListAllGitopsEngineInstances(ctx)
 	assert.NoError(t, err)
 	for _, gitopsEngineInstance := range engineInstances {
 		if strings.HasPrefix(gitopsEngineInstance.Gitopsengineinstance_id, "test-") {
 
-			rowsAffected, err := dbq.UnsafeDeleteGitopsEngineInstanceById(gitopsEngineInstance.Gitopsengineinstance_id)
+			rowsAffected, err := dbq.UnsafeDeleteGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id)
 
 			if !assert.NoError(t, err) {
 				return
@@ -82,11 +85,11 @@ func testSetup(t *testing.T) {
 		}
 	}
 
-	engineClusters, err := dbq.UnsafeListAllGitopsEngineClusters()
+	engineClusters, err := dbq.UnsafeListAllGitopsEngineClusters(ctx)
 	assert.NoError(t, err)
 	for _, engineCluster := range engineClusters {
 		if strings.HasPrefix(engineCluster.Gitopsenginecluster_id, "test-") {
-			rowsAffected, err := dbq.AdminDeleteGitopsEngineClusterById(engineCluster.Gitopsenginecluster_id)
+			rowsAffected, err := dbq.AdminDeleteGitopsEngineClusterById(ctx, engineCluster.Gitopsenginecluster_id)
 			assert.NoError(t, err)
 			if err == nil {
 				assert.Equal(t, rowsAffected, 1)
@@ -94,21 +97,21 @@ func testSetup(t *testing.T) {
 		}
 	}
 
-	managedEnvironments, err := dbq.UnsafeListAllManagedEnvironments()
+	managedEnvironments, err := dbq.UnsafeListAllManagedEnvironments(ctx)
 	assert.NoError(t, err)
 	for _, managedEnvironment := range managedEnvironments {
 		if strings.HasPrefix(managedEnvironment.Managedenvironment_id, "test-") {
-			rowsAffected, err := dbq.UnsafeDeleteManagedEnvironmentById(managedEnvironment.Managedenvironment_id)
+			rowsAffected, err := dbq.UnsafeDeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
 			assert.Equal(t, rowsAffected, 1)
 			assert.NoError(t, err)
 		}
 	}
 
-	clusterCredentials, err := dbq.UnsafeListAllClusterCredentials()
+	clusterCredentials, err := dbq.UnsafeListAllClusterCredentials(ctx)
 	assert.NoError(t, err)
 	for _, clusterCredential := range clusterCredentials {
 		if strings.HasPrefix(clusterCredential.Clustercredentials_cred_id, "test-") {
-			rowsAffected, err := dbq.AdminDeleteClusterCredentialsById(clusterCredential.Clustercredentials_cred_id)
+			rowsAffected, err := dbq.AdminDeleteClusterCredentialsById(ctx, clusterCredential.Clustercredentials_cred_id)
 			assert.NoError(t, err)
 			if err == nil {
 				assert.Equal(t, rowsAffected, 1)
@@ -116,17 +119,17 @@ func testSetup(t *testing.T) {
 		}
 	}
 
-	users, err := dbq.UnsafeListAllClusterUsers()
+	users, err := dbq.UnsafeListAllClusterUsers(ctx)
 	assert.NoError(t, err)
 	for _, user := range users {
 		if strings.HasPrefix(user.Clusteruser_id, "test-") {
-			rowsAffected, err := dbq.AdminDeleteClusterUserById((user.Clusteruser_id))
+			rowsAffected, err := dbq.AdminDeleteClusterUserById(ctx, (user.Clusteruser_id))
 			assert.Equal(t, rowsAffected, 1)
 			assert.NoError(t, err)
 		}
 	}
 
-	err = dbq.CreateClusterUser(testClusterUser)
+	err = dbq.CreateClusterUser(ctx, testClusterUser)
 	assert.NoError(t, err)
 
 }
@@ -140,6 +143,7 @@ func TestSelectOnAllTables(t *testing.T) {
 
 	testSetup(t)
 	defer testTeardown(t)
+	ctx := context.Background()
 
 	dbq, err := NewUnsafePostgresDBQueries(true, true)
 	if !assert.NoError(t, err) {
@@ -147,31 +151,31 @@ func TestSelectOnAllTables(t *testing.T) {
 	}
 	defer dbq.CloseDatabase()
 
-	_, err = dbq.UnsafeListAllApplicationStates()
+	_, err = dbq.UnsafeListAllApplicationStates(ctx)
 	assert.NoError(t, err)
 
-	_, err = dbq.UnsafeListAllApplications()
+	_, err = dbq.UnsafeListAllApplications(ctx)
 	assert.NoError(t, err)
 
-	_, err = dbq.UnsafeListAllClusterAccess()
+	_, err = dbq.UnsafeListAllClusterAccess(ctx)
 	assert.NoError(t, err)
 
-	_, err = dbq.UnsafeListAllClusterCredentials()
+	_, err = dbq.UnsafeListAllClusterCredentials(ctx)
 	assert.NoError(t, err)
 
-	_, err = dbq.UnsafeListAllClusterUsers()
+	_, err = dbq.UnsafeListAllClusterUsers(ctx)
 	assert.NoError(t, err)
 
-	_, err = dbq.UnsafeListAllGitopsEngineClusters()
+	_, err = dbq.UnsafeListAllGitopsEngineClusters(ctx)
 	assert.NoError(t, err)
 
-	_, err = dbq.UnsafeListAllGitopsEngineInstances()
+	_, err = dbq.UnsafeListAllGitopsEngineInstances(ctx)
 	assert.NoError(t, err)
 
-	_, err = dbq.UnsafeListAllManagedEnvironments()
+	_, err = dbq.UnsafeListAllManagedEnvironments(ctx)
 	assert.NoError(t, err)
 
-	_, err = dbq.UnsafeListAllOperations()
+	_, err = dbq.UnsafeListAllOperations(ctx)
 	assert.NoError(t, err)
 
 }
@@ -186,6 +190,8 @@ func TestCreateApplication(t *testing.T) {
 	}
 	defer dbq.CloseDatabase()
 
+	ctx := context.Background()
+
 	managedEnv, _, engineInstance, clusterAccess, err := createSampleData(t, dbq)
 	if !assert.NoError(t, err) {
 		return
@@ -199,12 +205,12 @@ func TestCreateApplication(t *testing.T) {
 		Managed_environment_id:  managedEnv.Managedenvironment_id,
 	}
 
-	err = dbq.CreateApplication(application, clusterAccess.Clusteraccess_user_id)
+	err = dbq.CreateApplication(ctx, application, clusterAccess.Clusteraccess_user_id)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	applicationRes, err := dbq.UnsafeGetApplicationById(application.Application_id)
+	applicationRes, err := dbq.UnsafeGetApplicationById(ctx, application.Application_id)
 	if !assert.Equal(t, application.Application_id, applicationRes.Application_id) {
 		return
 	}
@@ -212,7 +218,7 @@ func TestCreateApplication(t *testing.T) {
 		return
 	}
 
-	rowsAffected, err := dbq.DeleteApplicationById(application.Application_id)
+	rowsAffected, err := dbq.DeleteApplicationById(ctx, application.Application_id)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -220,7 +226,7 @@ func TestCreateApplication(t *testing.T) {
 		return
 	}
 
-	applicationRes, err = dbq.UnsafeGetApplicationById(application.Application_id)
+	applicationRes, err = dbq.UnsafeGetApplicationById(ctx, application.Application_id)
 	if !assert.Nil(t, applicationRes) {
 		return
 	}
@@ -234,6 +240,7 @@ func TestDeploymentToApplicationMapping(t *testing.T) {
 
 	testSetup(t)
 	defer testTeardown(t)
+	ctx := context.Background()
 
 	dbq, err := NewUnsafePostgresDBQueries(true, true)
 	if !assert.NoError(t, err) {
@@ -241,7 +248,7 @@ func TestDeploymentToApplicationMapping(t *testing.T) {
 	}
 	defer dbq.CloseDatabase()
 
-	res, err := dbq.GetDeploymentToApplicationMappingById("meow")
+	res, err := dbq.GetDeploymentToApplicationMappingById(ctx, "meow")
 	fmt.Println(res, err)
 
 }
@@ -256,13 +263,14 @@ func TestGitopsEngineInstanceAndCluster(t *testing.T) {
 		return
 	}
 	defer dbq.CloseDatabase()
+	ctx := context.Background()
 
 	_, engineCluster, engineInstance, _, err := createSampleData(t, dbq)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	result, err := dbq.GetGitopsEngineClusterById(engineCluster.Gitopsenginecluster_id, testClusterUser.Clusteruser_id)
+	result, err := dbq.GetGitopsEngineClusterById(ctx, engineCluster.Gitopsenginecluster_id, testClusterUser.Clusteruser_id)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -270,45 +278,47 @@ func TestGitopsEngineInstanceAndCluster(t *testing.T) {
 		return
 	}
 
-	rowsAffected, err := dbq.DeleteGitopsEngineInstanceById(engineInstance.Gitopsengineinstance_id, testClusterUser.Clusteruser_id)
+	rowsAffected, err := dbq.DeleteGitopsEngineInstanceById(ctx, engineInstance.Gitopsengineinstance_id, testClusterUser.Clusteruser_id)
 	assert.Equal(t, rowsAffected, 1)
 	assert.NoError(t, err)
 
 	// Get should return no found, after the delete
-	_, err = dbq.GetGitopsEngineInstanceById(engineCluster.Gitopsenginecluster_id, testClusterUser.Clusteruser_id)
+	_, err = dbq.GetGitopsEngineInstanceById(ctx, engineCluster.Gitopsenginecluster_id, testClusterUser.Clusteruser_id)
 	if !assert.Error(t, err) {
 		return
 	}
 	assert.True(t, IsResultNotFoundError(err))
 
-	rowsAffected, err = dbq.AdminDeleteGitopsEngineClusterById(engineCluster.Gitopsenginecluster_id)
+	rowsAffected, err = dbq.AdminDeleteGitopsEngineClusterById(ctx, engineCluster.Gitopsenginecluster_id)
 	assert.Equal(t, rowsAffected, 1)
 	assert.NoError(t, err)
 
-	_, err = dbq.GetGitopsEngineClusterById(engineCluster.Gitopsenginecluster_id, testClusterUser.Clusteruser_id)
+	_, err = dbq.GetGitopsEngineClusterById(ctx, engineCluster.Gitopsenginecluster_id, testClusterUser.Clusteruser_id)
 	assert.Error(t, err)
 	assert.True(t, IsResultNotFoundError(err))
 }
 
 func createSampleData(t *testing.T, dbq AllDatabaseQueries) (*ManagedEnvironment, *GitopsEngineCluster, *GitopsEngineInstance, *ClusterAccess, error) {
 
+	ctx := context.Background()
+
 	var err error
 
 	managedEnvironment, engineCluster, engineInstance, clusterAccess := generateSampleData()
 
-	if err = dbq.CreateManagedEnvironment(&managedEnvironment); err != nil {
+	if err = dbq.CreateManagedEnvironment(ctx, &managedEnvironment); err != nil {
 		return nil, nil, nil, nil, err
 	}
 
-	if err = dbq.CreateClusterAccess(&clusterAccess); err != nil {
+	if err = dbq.CreateClusterAccess(ctx, &clusterAccess); err != nil {
 		return nil, nil, nil, nil, err
 	}
 
-	if err = dbq.CreateGitopsEngineCluster(&engineCluster); err != nil {
+	if err = dbq.CreateGitopsEngineCluster(ctx, &engineCluster); err != nil {
 		return nil, nil, nil, nil, err
 	}
 
-	if err = dbq.CreateGitopsEngineInstance(&engineInstance); err != nil {
+	if err = dbq.CreateGitopsEngineInstance(ctx, &engineInstance); err != nil {
 		return nil, nil, nil, nil, err
 	}
 
@@ -319,6 +329,7 @@ func createSampleData(t *testing.T, dbq AllDatabaseQueries) (*ManagedEnvironment
 func TestManagedEnvironment(t *testing.T) {
 	testSetup(t)
 	defer testTeardown(t)
+	ctx := context.Background()
 
 	dbq, err := NewUnsafePostgresDBQueries(true, true)
 	if !assert.NoError(t, err) {
@@ -331,24 +342,24 @@ func TestManagedEnvironment(t *testing.T) {
 		return
 	}
 
-	result, err := dbq.GetManagedEnvironmentById(managedEnvironment.Managedenvironment_id, testClusterUser.Clusteruser_id)
+	result, err := dbq.GetManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id, testClusterUser.Clusteruser_id)
 	assert.NoError(t, err)
 	if err == nil {
 		assert.Equal(t, managedEnvironment.Name, result.Name)
 	}
 
-	_, err = dbq.GetManagedEnvironmentById(managedEnvironment.Managedenvironment_id, "another-user")
+	_, err = dbq.GetManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id, "another-user")
 	assert.NotNil(t, err) // deleting from another user should fail
 	assert.True(t, IsResultNotFoundError(err))
 
-	rowsAffected, _ := dbq.DeleteManagedEnvironmentById(managedEnvironment.Managedenvironment_id, "another-user")
+	rowsAffected, _ := dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id, "another-user")
 	assert.Equal(t, rowsAffected, 0) // deleting from another user should not return any rows
 
-	rowsAffected, err = dbq.DeleteManagedEnvironmentById(managedEnvironment.Managedenvironment_id, testClusterUser.Clusteruser_id)
+	rowsAffected, err = dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id, testClusterUser.Clusteruser_id)
 	assert.Equal(t, rowsAffected, 1)
 	assert.NoError(t, err)
 
-	_, err = dbq.GetManagedEnvironmentById(managedEnvironment.Managedenvironment_id, testClusterUser.Clusteruser_id)
+	_, err = dbq.GetManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id, testClusterUser.Clusteruser_id)
 	assert.NotNil(t, err)
 	assert.True(t, IsResultNotFoundError(err))
 
@@ -369,6 +380,8 @@ func TestOperation(t *testing.T) {
 		return
 	}
 
+	ctx := context.Background()
+
 	operation := &Operation{
 		Instance_id:             engineInstance.Gitopsengineinstance_id,
 		Resource_id:             "fake resource id",
@@ -377,26 +390,26 @@ func TestOperation(t *testing.T) {
 		Operation_owner_user_id: testClusterUser.Clusteruser_id,
 	}
 
-	err = dbq.CreateOperation(operation, "some-other-user")
+	err = dbq.CreateOperation(ctx, operation, "some-other-user")
 	assert.Error(t, err)
 
-	err = dbq.CreateOperation(operation, operation.Operation_owner_user_id)
+	err = dbq.CreateOperation(ctx, operation, operation.Operation_owner_user_id)
 	assert.NoError(t, err)
 
-	result, err := dbq.GetOperationById(operation.Operation_id, operation.Operation_owner_user_id)
+	result, err := dbq.GetOperationById(ctx, operation.Operation_id, operation.Operation_owner_user_id)
 	assert.NoError(t, err)
 	assert.Equal(t, result.Operation_id, operation.Operation_id)
 
-	_, err = dbq.GetOperationById(operation.Operation_id, "another-user")
+	_, err = dbq.GetOperationById(ctx, operation.Operation_id, "another-user")
 	if !assert.Error(t, err) {
 		return
 	}
 	assert.True(t, IsResultNotFoundError(err))
 
-	rowsAffected, _ := dbq.DeleteOperationById(operation.Operation_id, "another-user")
+	rowsAffected, _ := dbq.DeleteOperationById(ctx, operation.Operation_id, "another-user")
 	assert.Equal(t, rowsAffected, 0)
 
-	rowsAffected, err = dbq.DeleteOperationById(operation.Operation_id, operation.Operation_owner_user_id)
+	rowsAffected, err = dbq.DeleteOperationById(ctx, operation.Operation_id, operation.Operation_owner_user_id)
 	assert.Equal(t, rowsAffected, 1)
 	assert.NoError(t, err)
 }
@@ -405,6 +418,7 @@ func TestClusterUser(t *testing.T) {
 
 	testSetup(t)
 	defer testTeardown(t)
+	ctx := context.Background()
 
 	dbq, err := NewUnsafePostgresDBQueries(true, true)
 	if !assert.NoError(t, err) {
@@ -416,24 +430,24 @@ func TestClusterUser(t *testing.T) {
 		Clusteruser_id: "test-my-cluster-user-2",
 		User_name:      "cluster-mccluster",
 	}
-	err = dbq.CreateClusterUser(&clusterUser)
+	err = dbq.CreateClusterUser(ctx, &clusterUser)
 	assert.NoError(t, err)
 
-	retrievedClusterUser, err := dbq.GetClusterUserById(clusterUser.Clusteruser_id)
+	retrievedClusterUser, err := dbq.GetClusterUserById(ctx, clusterUser.Clusteruser_id)
 	assert.NoError(t, err)
 	assert.Equal(t, clusterUser.User_name, retrievedClusterUser.User_name)
 
-	rowsAffected, err := dbq.AdminDeleteClusterUserById(clusterUser.Clusteruser_id)
+	rowsAffected, err := dbq.AdminDeleteClusterUserById(ctx, clusterUser.Clusteruser_id)
 	assert.Equal(t, rowsAffected, 1)
 	assert.NoError(t, err)
 
-	_, err = dbq.GetClusterUserById(clusterUser.Clusteruser_id)
+	_, err = dbq.GetClusterUserById(ctx, clusterUser.Clusteruser_id)
 	if !assert.Error(t, err) {
 		return
 	}
 	assert.True(t, IsResultNotFoundError(err))
 
-	_, err = dbq.GetClusterUserById("does-not-exist")
+	_, err = dbq.GetClusterUserById(ctx, "does-not-exist")
 	if !assert.Error(t, err) {
 		return
 	}
@@ -451,6 +465,7 @@ func TestClusterCredentials(t *testing.T) {
 		return
 	}
 	defer dbq.CloseDatabase()
+	ctx := context.Background()
 
 	clusterCredentials := ClusterCredentials{
 		Clustercredentials_cred_id:  "test-cluster-creds-test",
@@ -461,7 +476,7 @@ func TestClusterCredentials(t *testing.T) {
 		Serviceaccount_ns:           "Serviceaccount_ns",
 	}
 
-	err = dbq.CreateClusterCredentials(&clusterCredentials)
+	err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)
 	assert.NoError(t, err)
 
 	// Create managed environment, and cluster access, so the non-unsafe get works below
@@ -472,7 +487,7 @@ func TestClusterCredentials(t *testing.T) {
 			Clustercredentials_id: clusterCredentials.Clustercredentials_cred_id,
 			Name:                  "my env",
 		}
-		err = dbq.CreateManagedEnvironment(&managedEnvironment)
+		err = dbq.CreateManagedEnvironment(ctx, &managedEnvironment)
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -483,14 +498,13 @@ func TestClusterCredentials(t *testing.T) {
 			Clusteraccess_gitops_engine_instance_id: "fake-engine-instance-id",
 		}
 
-		err = dbq.CreateClusterAccess(&clusterAccess)
+		err = dbq.CreateClusterAccess(ctx, &clusterAccess)
 		if !assert.NoError(t, err) {
 			return
 		}
-
 	}
 
-	retrievedClusterCredentials, err := dbq.UnsafeGetClusterCredentialsById(clusterCredentials.Clustercredentials_cred_id)
+	retrievedClusterCredentials, err := dbq.UnsafeGetClusterCredentialsById(ctx, clusterCredentials.Clustercredentials_cred_id)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -498,7 +512,7 @@ func TestClusterCredentials(t *testing.T) {
 	assert.Equal(t, clusterCredentials.Kube_config, retrievedClusterCredentials.Kube_config)
 	assert.Equal(t, clusterCredentials.Kube_config_context, retrievedClusterCredentials.Kube_config_context)
 
-	retrievedClusterCredentials, err = dbq.GetClusterCredentialsById(clusterCredentials.Clustercredentials_cred_id, testClusterUser.Clusteruser_id)
+	retrievedClusterCredentials, err = dbq.GetClusterCredentialsById(ctx, clusterCredentials.Clustercredentials_cred_id, testClusterUser.Clusteruser_id)
 	if !assert.NoError(t, err) ||
 		!assert.NotNil(t, retrievedClusterCredentials) {
 		return
@@ -508,11 +522,11 @@ func TestClusterCredentials(t *testing.T) {
 	assert.Equal(t, clusterCredentials.Kube_config, retrievedClusterCredentials.Kube_config)
 	assert.Equal(t, clusterCredentials.Kube_config_context, retrievedClusterCredentials.Kube_config_context)
 
-	rowsAffected, err := dbq.AdminDeleteClusterCredentialsById(clusterCredentials.Clustercredentials_cred_id)
+	rowsAffected, err := dbq.AdminDeleteClusterCredentialsById(ctx, clusterCredentials.Clustercredentials_cred_id)
 	assert.Equal(t, rowsAffected, 1)
 	assert.NoError(t, err)
 
-	_, err = dbq.UnsafeGetClusterCredentialsById(clusterCredentials.Clustercredentials_cred_id)
+	_, err = dbq.UnsafeGetClusterCredentialsById(ctx, clusterCredentials.Clustercredentials_cred_id)
 	if !assert.Error(t, err) {
 		return
 	}

--- a/backend-shared/config/db/utils.go
+++ b/backend-shared/config/db/utils.go
@@ -5,8 +5,8 @@ import (
 	"runtime/debug"
 )
 
-// validateGenericEntity is common, simple validation logic shared by most entities
-func validateGenericEntity(entityId string, dbq *PostgreSQLDatabaseQueries) error {
+// validateQueryParams is common, simple validation logic shared by most entities
+func validateQueryParams(entityId string, dbq *PostgreSQLDatabaseQueries) error {
 	if dbq.dbConnection == nil {
 		return fmt.Errorf("database connection is nil")
 	}
@@ -19,10 +19,10 @@ func validateGenericEntity(entityId string, dbq *PostgreSQLDatabaseQueries) erro
 	return nil
 }
 
-// validateGenericEntity is common, simple validation logic shared by most entities
-func validateUnsafeGenericEntity(entityId string, dbq *PostgreSQLDatabaseQueries) error {
+// validateUnsafeQueryParams is common, simple validation logic shared by most entities
+func validateUnsafeQueryParams(entityId string, dbq *PostgreSQLDatabaseQueries) error {
 
-	if err := validateGenericEntity(entityId, dbq); err != nil {
+	if err := validateQueryParams(entityId, dbq); err != nil {
 		return err
 	}
 
@@ -34,7 +34,7 @@ func validateUnsafeGenericEntity(entityId string, dbq *PostgreSQLDatabaseQueries
 }
 
 // validateGenericEntity is common, simple validation logic shared by most entities
-func validateUnsafeGenericEntityNoPK(dbq *PostgreSQLDatabaseQueries) error {
+func validateUnsafeQueryParamsNoPK(dbq *PostgreSQLDatabaseQueries) error {
 
 	if dbq.dbConnection == nil {
 		return fmt.Errorf("database connection is nil")


### PR DESCRIPTION
Add context parameter to all database queries, allowing us to support timeout and cancel functions on goroutines that are invoking the database.