### PR TITLE
Add UncheckedGetOrCreateManagedEnvironmentByNamespaceUID function for use by cluster-agent and backend

### DIFF
--- a/backend-shared/config/db/clusteruser.go
+++ b/backend-shared/config/db/clusteruser.go
@@ -76,7 +76,7 @@ func (dbq *PostgreSQLDatabaseQueries) CreateClusterUser(ctx context.Context, obj
 
 func (dbq *PostgreSQLDatabaseQueries) GetClusterUserByUsername(ctx context.Context, clusterUser *ClusterUser) error {
 
-	// TODO: Add an index for this, if anything actually calls it
+	// TODO: PERF - Add an index for this, if anything actually calls it
 
 	if err := validateQueryParamsEntity(clusterUser, dbq); err != nil {
 		return err

--- a/backend-shared/config/db/gitopsenginecluster.go
+++ b/backend-shared/config/db/gitopsenginecluster.go
@@ -104,7 +104,7 @@ func (dbq *PostgreSQLDatabaseQueries) ListGitopsEngineClusterByCredentialId(ctx 
 		Where("gitops_engine_cluster.clustercredentials_id = ?", credentialId).
 		Context(ctx).
 		Select(); err != nil {
-		// TODO: Add an index for this function, if it's actually used for anything
+		// TODO: PERF -  Add an index for this function, if it's actually used for anything
 
 		return fmt.Errorf("error on retrieving GetGitopsEngineClusterByCredentialId: %v", err)
 	}

--- a/backend-shared/config/db/kubernetesresourcetodbresourcemapping.go
+++ b/backend-shared/config/db/kubernetesresourcetodbresourcemapping.go
@@ -43,7 +43,7 @@ func (dbq *PostgreSQLDatabaseQueries) GetDBResourceMappingForKubernetesResource(
 	var result []KubernetesToDBResourceMapping
 
 	if err := dbq.dbConnection.Model(&result).
-		// TODO: Performance: Add a DB index for this
+		// TODO: PERF - Add a DB index for this
 		Where("ktdbrm.kubernetes_resource_type = ?", obj.KubernetesResourceType).
 		Where("ktdbrm.kubernetes_resource_uid = ?", obj.KubernetesResourceUID).
 		Where("ktdbrm.db_relation_type = ?", obj.DBRelationType).
@@ -73,8 +73,9 @@ const (
 	K8sToDBMapping_Namespace = "Namespace"
 
 	// Supported DB tables:
+	K8sToDBMapping_ManagedEnvironment   = "ManagedEnvironment"
 	K8sToDBMapping_GitopsEngineCluster  = "GitopsEngineCluster"
-	K8sToDBMapping_GitOpsEngineInstance = "GitOpsEngineInstance"
+	K8sToDBMapping_GitopsEngineInstance = "GitopsEngineInstance"
 )
 
 func (dbq *PostgreSQLDatabaseQueries) CreateKubernetesResourceToDBResourceMapping(ctx context.Context, obj *KubernetesToDBResourceMapping) error {

--- a/backend-shared/config/db/managedenvironment.go
+++ b/backend-shared/config/db/managedenvironment.go
@@ -78,6 +78,39 @@ func (dbq *PostgreSQLDatabaseQueries) ListManagedEnvironmentForClusterCredential
 	return nil
 }
 
+func (dbq *PostgreSQLDatabaseQueries) UncheckedGetManagedEnvironmentById(ctx context.Context, managedEnvironment *ManagedEnvironment) error {
+
+	if err := validateQueryParamsEntity(managedEnvironment, dbq); err != nil {
+		return err
+	}
+
+	if isEmpty(managedEnvironment.Managedenvironment_id) {
+		return fmt.Errorf("managedenvironment_id is empty in GetManagedEnvironmentById")
+	}
+
+	var dbResults []ManagedEnvironment
+
+	if err := dbq.dbConnection.Model(&dbResults).
+		Where("me.managedenvironment_id = ?", managedEnvironment.Managedenvironment_id).
+		Context(ctx).
+		Select(); err != nil {
+
+		return fmt.Errorf("error on retrieving ManagedEnvironment by id '%s': %v", managedEnvironment.Managedenvironment_id, err)
+	}
+
+	if len(dbResults) >= 2 {
+		return fmt.Errorf("multiple results returned from GetManagedEnvironmentById")
+	}
+
+	if len(dbResults) == 0 {
+		return NewResultNotFoundError("error on retrieving GetGitopsEngineInstanceById")
+	}
+
+	*managedEnvironment = dbResults[0]
+
+	return nil
+}
+
 func (dbq *PostgreSQLDatabaseQueries) GetManagedEnvironmentById(ctx context.Context, managedEnvironment *ManagedEnvironment, ownerId string) error {
 
 	if err := validateQueryParamsEntity(managedEnvironment, dbq); err != nil {

--- a/db-schema.sql
+++ b/db-schema.sql
@@ -149,7 +149,7 @@ CREATE TABLE Operation (
 
 	-- The user that initiated the operation.
 	-- Foreign key to: ClusterUser.clusteruser_id
-	operation_owner_user_id VARCHAR(48) NOT NULL,	
+	operation_owner_user_id VARCHAR(48),
 	-- TODO: Add foreign key
 
 	-- Resource type of the resource that was updated. 


### PR DESCRIPTION
This PR:
- Adds `UncheckedGetOrCreateManagedEnvironmentByNamespaceUID` function, for use by cluster-agent and backend
- Adds additional unchecked DatabaseQueries interface methods to support that
- Misc comments and cleanup