### PR TITLE
Add app-scoped DB query, app-scoped disposable resources, and remove cascade delete from schema

### DIFF
--- a/backend-shared/config/db/apicrtodatabasemapping.go
+++ b/backend-shared/config/db/apicrtodatabasemapping.go
@@ -140,9 +140,9 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedListAPICRToDatabaseMappingByAPINa
 	return nil
 }
 
-var _ DisposableResource = &APICRToDatabaseMapping{}
+var _ AppScopedDisposableResource = &APICRToDatabaseMapping{}
 
-func (dbMapping *APICRToDatabaseMapping) Dispose(ctx context.Context, dbq DatabaseQueries) error {
+func (dbMapping *APICRToDatabaseMapping) DisposeAppScoped(ctx context.Context, dbq ApplicationScopedQueries) error {
 
 	if err := isEmptyValues("APICRToDatabaseMappingDispose", "dbq", dbq); err != nil {
 		return err

--- a/backend-shared/config/db/deploymenttoapplicationmapping.go
+++ b/backend-shared/config/db/deploymenttoapplicationmapping.go
@@ -77,6 +77,39 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedGetDeploymentToApplicationMapping
 	return nil
 }
 
+func (dbq *PostgreSQLDatabaseQueries) UncheckedGetDeploymentToApplicationMappingByApplicationId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping) error {
+
+	if err := validateQueryParamsEntity(deplToAppMappingParam, dbq); err != nil {
+		return err
+	}
+
+	if isEmpty(deplToAppMappingParam.Application_id) {
+		return fmt.Errorf("UncheckedGetDeploymentToApplicationMappingByApplicationId: param is nil")
+	}
+
+	var dbResults []DeploymentToApplicationMapping
+
+	if err := dbq.dbConnection.Model(&dbResults).
+		Where("dta.application_id = ?", deplToAppMappingParam.Application_id). // TODO: PERF - Index this
+		Context(ctx).
+		Select(); err != nil {
+
+		return fmt.Errorf("error on retrieving UncheckedGetDeploymentToApplicationMappingByApplicationId: %v", err)
+	}
+
+	if len(dbResults) > 1 {
+		return fmt.Errorf("multiple results returned from UncheckedGetDeploymentToApplicationMappingByApplicationId")
+	}
+
+	if len(dbResults) == 0 {
+		return NewResultNotFoundError("UncheckedGetDeploymentToApplicationMappingByApplicationId")
+	}
+
+	*deplToAppMappingParam = dbResults[0]
+
+	return nil
+}
+
 func (dbq *PostgreSQLDatabaseQueries) GetDeploymentToApplicationMappingByDeplId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping, ownerId string) error {
 
 	if err := validateQueryParamsEntity(deplToAppMappingParam, dbq); err != nil {

--- a/backend-shared/config/db/gitopsengineinstance.go
+++ b/backend-shared/config/db/gitopsengineinstance.go
@@ -169,7 +169,7 @@ func (dbq *PostgreSQLDatabaseQueries) DeleteGitopsEngineInstanceById(ctx context
 
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UnsafeDeleteGitopsEngineInstanceById(ctx context.Context, id string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteGitopsEngineInstanceById(ctx context.Context, id string) (int, error) {
 
 	return dbq.internalDeleteGitopsEngineInstanceById(ctx, id, "", true)
 

--- a/backend-shared/config/db/managedenvironment.go
+++ b/backend-shared/config/db/managedenvironment.go
@@ -175,7 +175,7 @@ func (dbq *PostgreSQLDatabaseQueries) DeleteManagedEnvironmentById(ctx context.C
 }
 
 // This method does NOT check whether the user has access
-func (dbq *PostgreSQLDatabaseQueries) UnsafeDeleteManagedEnvironmentById(ctx context.Context, id string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteManagedEnvironmentById(ctx context.Context, id string) (int, error) {
 
 	if err := validateUnsafeQueryParams(id, dbq); err != nil {
 		return 0, err

--- a/backend-shared/config/db/queries.go
+++ b/backend-shared/config/db/queries.go
@@ -166,6 +166,8 @@ type ApplicationScopedQueries interface {
 	UncheckedGetDeploymentToApplicationMappingByDeplId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping) error
 	UncheckedListDeploymentToApplicationMappingByNamespaceAndName(ctx context.Context, deploymentName string, deploymentNamespace string, workspaceUID string, deplToAppMappingParam *[]DeploymentToApplicationMapping) error
 	UncheckedDeleteDeploymentToApplicationMappingByDeplId(ctx context.Context, id string) (int, error)
+
+	UpdateSyncOperationRemoveApplicationField(ctx context.Context, applicationId string) (int, error)
 }
 
 type CloseableQueries interface {

--- a/backend-shared/config/db/syncoperation.go
+++ b/backend-shared/config/db/syncoperation.go
@@ -100,6 +100,30 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteSyncOperationById(ctx conte
 	return deleteResult.RowsAffected(), nil
 }
 
+func (dbq *PostgreSQLDatabaseQueries) UpdateSyncOperationRemoveApplicationField(ctx context.Context, applicationId string) (int, error) {
+
+	if err := validateQueryParamsNoPK(dbq); err != nil {
+		return 0, err
+	}
+
+	if err := isEmptyValues("UpdateOperationRemoveApplicationField",
+		"applicationId", applicationId); err != nil {
+		return 0, err
+	}
+
+	operation := SyncOperation{
+		Application_id: applicationId,
+	}
+
+	res, err := dbq.dbConnection.Model(&operation).Set("application_id = ?", nil).Where("application_id = ?", applicationId).Update()
+
+	if err != nil {
+		return 0, err
+	}
+
+	return res.RowsAffected(), err
+}
+
 var _ AppScopedDisposableResource = &SyncOperation{}
 
 func (obj *SyncOperation) DisposeAppScoped(ctx context.Context, dbq ApplicationScopedQueries) error {

--- a/backend-shared/config/db/syncoperation.go
+++ b/backend-shared/config/db/syncoperation.go
@@ -100,9 +100,9 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteSyncOperationById(ctx conte
 	return deleteResult.RowsAffected(), nil
 }
 
-var _ DisposableResource = &SyncOperation{}
+var _ AppScopedDisposableResource = &SyncOperation{}
 
-func (obj *SyncOperation) Dispose(ctx context.Context, dbq DatabaseQueries) error {
+func (obj *SyncOperation) DisposeAppScoped(ctx context.Context, dbq ApplicationScopedQueries) error {
 	if dbq == nil {
 		return fmt.Errorf("missing database interface in syncoperation dispose")
 	}

--- a/backend-shared/config/db/types.go
+++ b/backend-shared/config/db/types.go
@@ -141,6 +141,11 @@ const (
 	OperationState_Failed      = "Failed"
 )
 
+const (
+	OperationResourceType_SyncOperation = "SyncOperation"
+	OperationResourceType_Application   = "Application"
+)
+
 type Operation struct {
 
 	//lint:ignore U1000 used by go-pg
@@ -268,6 +273,12 @@ type DeploymentToApplicationMapping struct {
 	SeqID int64 `pg:"seq_id"`
 }
 
+const (
+	APICRToDatabaseMapping_ResourceType_GitOpsDeploymentSyncRun = "GitOpsDeploymentSyncRun"
+
+	APICRToDatabaseMapping_DBRelationType_SyncOperation = "SyncOperation"
+)
+
 type APICRToDatabaseMapping struct {
 
 	//lint:ignore U1000 used by go-pg
@@ -337,4 +348,8 @@ type SyncOperation struct {
 // TODO: DEBT - Add comment.
 type DisposableResource interface {
 	Dispose(ctx context.Context, dbq DatabaseQueries) error
+}
+
+type AppScopedDisposableResource interface {
+	DisposeAppScoped(ctx context.Context, dbq ApplicationScopedQueries) error
 }

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -109,8 +109,8 @@ build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go 
-	# --zap-log-level 10
+	go run ./main.go --zap-log-level debug 
+	# more on controller log level configuration: https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/
 
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .

--- a/backend/eventloop/eventloopinternal.go
+++ b/backend/eventloop/eventloopinternal.go
@@ -395,7 +395,7 @@ func (a *workspaceEventLoopRunner_Action) workspaceEventLoopRunner_handleSyncRun
 
 		// createdResources is a list of database entries created in this function; if an error occurs, we delete them
 		// in reverse order.
-		var createdResources []db.DisposableResource
+		var createdResources []db.AppScopedDisposableResource
 
 		// Create sync operation
 		syncOperation := &db.SyncOperation{
@@ -424,7 +424,7 @@ func (a *workspaceEventLoopRunner_Action) workspaceEventLoopRunner_handleSyncRun
 			actionLog.Error(err, "unable to create api to db mapping in database")
 
 			// If we were unable to retrieve the client, delete the resources we created in the previous steps
-			sharedutil.DisposeResources(ctx, createdResources, dbQueries, actionLog)
+			sharedutil.DisposeApplicationScopedResources(ctx, createdResources, dbQueries, actionLog)
 
 			return err
 		}
@@ -435,7 +435,7 @@ func (a *workspaceEventLoopRunner_Action) workspaceEventLoopRunner_handleSyncRun
 			actionLog.Error(err, "unable to retrieve gitopsengine instance from handleSyncRunModified")
 
 			// If we were unable to retrieve the client, delete the resources we created in the previous steps
-			sharedutil.DisposeResources(ctx, createdResources, dbQueries, actionLog)
+			sharedutil.DisposeApplicationScopedResources(ctx, createdResources, dbQueries, actionLog)
 
 			// Return the original error
 			return err
@@ -452,7 +452,7 @@ func (a *workspaceEventLoopRunner_Action) workspaceEventLoopRunner_handleSyncRun
 			actionLog.Error(err, "could not create operation", "namespace", sharedutil.GitOpsEngineSingleInstanceNamespace)
 
 			// If we were unable to create the operation, delete the resources we created in the previous steps
-			sharedutil.DisposeResources(ctx, createdResources, dbQueries, actionLog)
+			sharedutil.DisposeApplicationScopedResources(ctx, createdResources, dbQueries, actionLog)
 
 			return err
 		}
@@ -461,11 +461,11 @@ func (a *workspaceEventLoopRunner_Action) workspaceEventLoopRunner_handleSyncRun
 		actionLog.Info("STUB: Not waiting for create Sync Run operation to complete, in handleNewSyncRunModified")
 
 		if err := cleanupOperation(ctx, *dbOperation, *k8sOperation, sharedutil.GitOpsEngineSingleInstanceNamespace, dbQueries, operationClient, actionLog); err != nil {
-			sharedutil.DisposeResources(ctx, createdResources, dbQueries, actionLog)
+			sharedutil.DisposeApplicationScopedResources(ctx, createdResources, dbQueries, actionLog)
 			return err
 		}
 
-		sharedutil.DisposeResources(ctx, createdResources, dbQueries, actionLog)
+		sharedutil.DisposeApplicationScopedResources(ctx, createdResources, dbQueries, actionLog)
 		return nil
 	}
 

--- a/db-schema.sql
+++ b/db-schema.sql
@@ -50,7 +50,7 @@ CREATE TABLE GitopsEngineCluster (
 	-- Foreign key to: ClusterCredentials.clustercredentials_cred_id
 	
 	clustercredentials_id VARCHAR (48) NOT NULL,
-	CONSTRAINT fk_cluster_credential FOREIGN KEY(clustercredentials_id) REFERENCES ClusterCredentials(clustercredentials_cred_id) ON DELETE CASCADE ON UPDATE CASCADE
+	CONSTRAINT fk_cluster_credential FOREIGN KEY(clustercredentials_id) REFERENCES ClusterCredentials(clustercredentials_cred_id) ON DELETE NO ACTION ON UPDATE NO ACTION
 
 );
 
@@ -67,7 +67,7 @@ CREATE TABLE GitopsEngineInstance (
 	-- Reference to the Argo CD cluster containing the instance
 	-- Foreign key to: GitopsEngineCluster.gitopsenginecluster_id
 	enginecluster_id VARCHAR(48) NOT NULL,
-	CONSTRAINT fk_gitopsengine_cluster FOREIGN KEY (enginecluster_id) REFERENCES GitopsEngineCluster(gitopsenginecluster_id) ON DELETE CASCADE ON UPDATE CASCADE
+	CONSTRAINT fk_gitopsengine_cluster FOREIGN KEY (enginecluster_id) REFERENCES GitopsEngineCluster(gitopsenginecluster_id) ON DELETE NO ACTION ON UPDATE NO ACTION
 	
 );
 
@@ -84,7 +84,7 @@ CREATE TABLE ManagedEnvironment (
 	-- pointer to credentials for the cluster
 	-- Foreign key to: ClusterCredentials.clustercredentials_cred_id
 	clustercredentials_id VARCHAR (48) NOT NULL,
-	CONSTRAINT fk_cluster_credential FOREIGN KEY (clustercredentials_id) REFERENCES ClusterCredentials(clustercredentials_cred_id) ON DELETE CASCADE ON UPDATE CASCADE
+	CONSTRAINT fk_cluster_credential FOREIGN KEY (clustercredentials_id) REFERENCES ClusterCredentials(clustercredentials_cred_id) ON DELETE NO ACTION ON UPDATE NO ACTION
 );
 
 
@@ -110,17 +110,17 @@ CREATE TABLE ClusterAccess (
 	-- Describes whose cluster this is (UID)
 	-- Foreign key to: ClusterUser.clusteruser_id
 	clusteraccess_user_id VARCHAR (48),
-	CONSTRAINT fk_clusteruser_id FOREIGN KEY (clusteraccess_user_id) REFERENCES ClusterUser(clusteruser_id) ON DELETE CASCADE ON UPDATE CASCADE,
+	CONSTRAINT fk_clusteruser_id FOREIGN KEY (clusteraccess_user_id) REFERENCES ClusterUser(clusteruser_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
 
 	-- Describes which managed environment the user has access to (UID)
 	-- Foreign key to: ManagedEnvironment.managedenvironment_id
 	clusteraccess_managed_environment_id VARCHAR (48),
-	CONSTRAINT fk_managedenvironment_id FOREIGN KEY (clusteraccess_managed_environment_id) REFERENCES ManagedEnvironment(managedenvironment_id) ON DELETE CASCADE ON UPDATE CASCADE,
+	CONSTRAINT fk_managedenvironment_id FOREIGN KEY (clusteraccess_managed_environment_id) REFERENCES ManagedEnvironment(managedenvironment_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
 
 	-- Which Argo CD instance is managing the cluster?
 	-- Foreign key to: GitopsEngineInstance.gitopsengineinstance_id
 	clusteraccess_gitops_engine_instance_id VARCHAR (48),
-	CONSTRAINT fk_gitopsengineinstance_id FOREIGN KEY (clusteraccess_gitops_engine_instance_id) REFERENCES GitopsEngineInstance(gitopsengineinstance_id) ON DELETE CASCADE ON UPDATE CASCADE,
+	CONSTRAINT fk_gitopsengineinstance_id FOREIGN KEY (clusteraccess_gitops_engine_instance_id) REFERENCES GitopsEngineInstance(gitopsengineinstance_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
 	
 	seq_id serial,
 	
@@ -145,7 +145,7 @@ CREATE TABLE Operation (
 	-- Specifies which Argo CD instance is this operation against
 	-- Foreign key to: GitopsEngineInstance.gitopsengineinstance_id
 	instance_id VARCHAR(48) NOT NULL,
-	CONSTRAINT fk_gitopsengineinstance_id FOREIGN KEY (instance_id) REFERENCES GitopsEngineInstance(gitopsengineinstance_id) ON DELETE CASCADE ON UPDATE CASCADE,
+	CONSTRAINT fk_gitopsengineinstance_id FOREIGN KEY (instance_id) REFERENCES GitopsEngineInstance(gitopsengineinstance_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
 
 	-- ID of the database resource that was modified (usually a database table primary key)
 	resource_id VARCHAR(48) NOT NULL,
@@ -153,7 +153,7 @@ CREATE TABLE Operation (
 	-- The user that initiated the operation.
 	-- Foreign key to: ClusterUser.clusteruser_id
 	operation_owner_user_id VARCHAR(48),
-	CONSTRAINT fk_clusteruser_id FOREIGN KEY (operation_owner_user_id) REFERENCES ClusterUser(clusteruser_id) ON DELETE CASCADE ON UPDATE CASCADE,
+	CONSTRAINT fk_clusteruser_id FOREIGN KEY (operation_owner_user_id) REFERENCES ClusterUser(clusteruser_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
 
 	-- Resource type of the resource that was modified
 	-- This value lets the operation know which table contains the resource.
@@ -204,12 +204,12 @@ CREATE TABLE Application (
 	
 	-- Which Argo CD instance it's hosted on
 	engine_instance_inst_id VARCHAR(48) NOT NULL,
-	CONSTRAINT fk_gitopsengineinstance_id FOREIGN KEY (engine_instance_inst_id) REFERENCES GitopsEngineInstance(gitopsengineinstance_id) ON DELETE CASCADE ON UPDATE CASCADE,
+	CONSTRAINT fk_gitopsengineinstance_id FOREIGN KEY (engine_instance_inst_id) REFERENCES GitopsEngineInstance(gitopsengineinstance_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
 
 	-- Which managed environment it is targetting
 	-- Foreign key to: ManagedEnvironment.managedenvironment_id
 	managed_environment_id VARCHAR(48) NOT NULL,
-	CONSTRAINT fk_managedenvironment_id FOREIGN KEY (managed_environment_id) REFERENCES ManagedEnvironment(managedenvironment_id) ON DELETE CASCADE ON UPDATE CASCADE
+	CONSTRAINT fk_managedenvironment_id FOREIGN KEY (managed_environment_id) REFERENCES ManagedEnvironment(managedenvironment_id) ON DELETE NO ACTION ON UPDATE NO ACTION
 	
 );
 
@@ -219,7 +219,7 @@ CREATE TABLE ApplicationState (
 
 	-- Also a foreign key to Application.application_id
 	applicationstate_application_id  VARCHAR ( 48 ) PRIMARY KEY,
-	CONSTRAINT fk_app_id FOREIGN KEY (applicationstate_application_id) REFERENCES Application(application_id) ON DELETE CASCADE ON UPDATE CASCADE,
+	CONSTRAINT fk_app_id FOREIGN KEY (applicationstate_application_id) REFERENCES Application(application_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
 
 	-- CONSTRAINT fk_app_id  PRIMARY KEY  FOREIGN KEY(app_id)  REFERENCES Application(appl_id),
 
@@ -257,7 +257,7 @@ CREATE TABLE DeploymentToApplicationMapping (
 
 	-- Foreign key to: Application.application_id
 	application_id VARCHAR ( 48 ) NOT NULL UNIQUE,
-	CONSTRAINT fk_app_id FOREIGN KEY (application_id) REFERENCES Application(application_id) ON DELETE CASCADE ON UPDATE CASCADE,
+	CONSTRAINT fk_app_id FOREIGN KEY (application_id) REFERENCES Application(application_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
 
 	seq_id serial
 
@@ -324,10 +324,10 @@ CREATE TABLE SyncOperation (
 	syncoperation_id  VARCHAR(48) NOT NULL PRIMARY KEY,
 
 	application_id VARCHAR(48) NOT NULL,
-	CONSTRAINT fk_so_app_id FOREIGN KEY (application_id) REFERENCES Application(application_id) ON DELETE CASCADE ON UPDATE CASCADE,
+	CONSTRAINT fk_so_app_id FOREIGN KEY (application_id) REFERENCES Application(application_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
 
 	operation_id VARCHAR(48) NOT NULL,
-	-- CONSTRAINT fk_so_operation_id FOREIGN KEY (operation_id) REFERENCES Operation(operation_id) ON DELETE CASCADE ON UPDATE CASCADE
+	-- CONSTRAINT fk_so_operation_id FOREIGN KEY (operation_id) REFERENCES Operation(operation_id) ON DELETE NO ACTION ON UPDATE NO ACTION
 
 	deployment_name VARCHAR(256) NOT NULL,
 

--- a/db-schema.sql
+++ b/db-schema.sql
@@ -323,7 +323,7 @@ CREATE TABLE SyncOperation (
 
 	syncoperation_id  VARCHAR(48) NOT NULL PRIMARY KEY,
 
-	application_id VARCHAR(48) NOT NULL,
+	application_id VARCHAR(48),
 	CONSTRAINT fk_so_app_id FOREIGN KEY (application_id) REFERENCES Application(application_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
 
 	operation_id VARCHAR(48) NOT NULL,


### PR DESCRIPTION
This PR:
- Adds applications scoped DB resources, which are resources that are are not shared between gitopsdeployments
- Adds application-scoped disposable resources
- Removes cascade delete from the schema (and fixes tests to match)