### PR TITLE
Add support for running backend+cluster-agent as a single unit, using goreman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MAKEFILE_ROOT=$(shell pwd)
 help: ## Display this help menu
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 # install: Ensure that the Argo CD namespace exists, that Argo CD is installed, and that CRDs we are using are applied to the current cluster
-install:
+install-argo: ## Ensure that the Argo CD namespace exists, and that CRDs we are using are applied to the current cluster
 	kubectl apply -f $(MAKEFILE_ROOT)/backend/config/crd/bases
 	kubectl apply -f $(MAKEFILE_ROOT)/backend-shared/config/crd/bases/managed-gitops.redhat.com_operations.yaml
 	kubectl create ns argocd || true
@@ -14,28 +14,33 @@ install:
 start:
 	~/go/bin/goreman start
 
-# build: build all the components (note: you do not need to do this before running start; 'start' will compile and run)
-build:
-	cd $(MAKEFILE_ROOT)/backend && make build
-	cd $(MAKEFILE_ROOT)/cluster-agent && make build
+build: build-backend build-cluster-agent ## Build all the components - note: you do not need to do this before running start
 
-# test: run tests for each component
-test:
+build-backend: ## Build backend only
+	cd $(MAKEFILE_ROOT)/backend && make build
+
+build-cluster-agent: ## Build cluster-agent only
+	cd $(MAKEFILE_ROOT)/cluster-agent && make build
+test: test-backend test-backend-shared test-cluster-agent ## Run tests for all components
+
+test-backend: ## Run tests for backend only
 	cd $(MAKEFILE_ROOT)/backend && make test
-	cd $(MAKEFILE_ROOT)/backend-shared && make test	
+
+test-backend-shared: ## Run test for backend-shared only
+	cd $(MAKEFILE_ROOT)/backend-shared && make test
+
+test-cluster-agent: ## Run test for cluster-agent only
 	cd $(MAKEFILE_ROOT)/cluster-agent && make test
 
-# download-deps: Download goreman to ~/go/bin
-download-deps:
+download-deps: ## Download goreman to ~/go/bin
 	go install github.com/mattn/goreman@latest
 
 
-# reset-db: Erase the current database, and reset it scratch; useful during development if you want a clean slate.
-reset-db:
+reset-db: ## Erase the current database, and reset it scratch; useful during development if you want a clean slate.
 	$(MAKEFILE_ROOT)/delete-dev-env.sh
 	$(MAKEFILE_ROOT)/create-dev-env.sh
 
-vendor:
+vendor: ## Clone locally the dependencies - off-line
 	cd $(MAKEFILE_ROOT)/backend-shared && go mod vendor
 	cd $(MAKEFILE_ROOT)/backend && go mod vendor
 	cd $(MAKEFILE_ROOT)/cluster-agent && go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
 
 MAKEFILE_ROOT=$(shell pwd)
 
-# install: Ensure that the Argo CD namespace exists, and that CRDs we are using are applied to the current cluster
+# install: Ensure that the Argo CD namespace exists, that Argo CD is installed, and that CRDs we are using are applied to the current cluster
 install:
-	kubectl create ns argocd || true
 	kubectl apply -f $(MAKEFILE_ROOT)/backend/config/crd/bases
 	kubectl apply -f $(MAKEFILE_ROOT)/backend-shared/config/crd/bases/managed-gitops.redhat.com_operations.yaml
+	kubectl create ns argocd || true
 	kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-cd/release-2.2/manifests/crds/application-crd.yaml
 
 # start: start all the components
+# ensure goreman is installed, with 'go install github.com/mattn/goreman@latest'
 start:
 	~/go/bin/goreman start
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 MAKEFILE_ROOT=$(shell pwd)
 help: ## Display this help menu
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
 # install: Ensure that the Argo CD namespace exists, that Argo CD is installed, and that CRDs we are using are applied to the current cluster
 install-argo: ## Ensure that the Argo CD namespace exists, and that CRDs we are using are applied to the current cluster
 	kubectl apply -f $(MAKEFILE_ROOT)/backend/config/crd/bases
@@ -9,9 +10,7 @@ install-argo: ## Ensure that the Argo CD namespace exists, and that CRDs we are 
 	kubectl create ns argocd || true
 	kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-cd/release-2.2/manifests/crds/application-crd.yaml
 
-# start: start all the components
-# ensure goreman is installed, with 'go install github.com/mattn/goreman@latest'
-start:
+start: ## Start all the components, compile & run (ensure goreman is installed, with 'go install github.com/mattn/goreman@latest')
 	~/go/bin/goreman start
 
 build: build-backend build-cluster-agent ## Build all the components - note: you do not need to do this before running start
@@ -35,7 +34,6 @@ test-cluster-agent: ## Run test for cluster-agent only
 
 download-deps: ## Download goreman to ~/go/bin
 	go install github.com/mattn/goreman@latest
-
 
 reset-db: ## Erase the current database, and reset it scratch; useful during development if you want a clean slate.
 	$(MAKEFILE_ROOT)/delete-dev-env.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+
+MAKEFILE_ROOT=$(shell pwd)
+
+# install: Ensure that the Argo CD namespace exists, and that CRDs we are using are applied to the current cluster
+install:
+	kubectl create ns argocd || true
+	kubectl apply -f $(MAKEFILE_ROOT)/backend/config/crd/bases
+	kubectl apply -f $(MAKEFILE_ROOT)/backend-shared/config/crd/bases/managed-gitops.redhat.com_operations.yaml
+	kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-cd/release-2.2/manifests/crds/application-crd.yaml
+
+# start: start all the components
+start:
+	~/go/bin/goreman start
+
+# build: build all the components (note: you do not need to do this before running start; 'start' will compile and run)
+build:
+	cd $(MAKEFILE_ROOT)/backend && make build
+	cd $(MAKEFILE_ROOT)/cluster-agent && make build
+
+# test: run tests for each component
+test:
+	cd $(MAKEFILE_ROOT)/backend && make test
+	cd $(MAKEFILE_ROOT)/backend-shared && make test	
+	cd $(MAKEFILE_ROOT)/cluster-agent && make test
+
+# download-deps: Download goreman to ~/go/bin
+download-deps:
+	go install github.com/mattn/goreman@latest
+
+
+# reset-db: Erase the current database, and reset it scratch; useful during development if you want a clean slate.
+reset-db:
+	$(MAKEFILE_ROOT)/delete-dev-env.sh
+	$(MAKEFILE_ROOT)/create-dev-env.sh
+
+vendor:
+	cd $(MAKEFILE_ROOT)/backend-shared && go mod vendor
+	cd $(MAKEFILE_ROOT)/backend && go mod vendor
+	cd $(MAKEFILE_ROOT)/cluster-agent && go mod vendor
+

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 MAKEFILE_ROOT=$(shell pwd)
-
+help: ## Display this help menu
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 # install: Ensure that the Argo CD namespace exists, that Argo CD is installed, and that CRDs we are using are applied to the current cluster
 install:
 	kubectl apply -f $(MAKEFILE_ROOT)/backend/config/crd/bases

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ build-backend: ## Build backend only
 
 build-cluster-agent: ## Build cluster-agent only
 	cd $(MAKEFILE_ROOT)/cluster-agent && make build
+
 test: test-backend test-backend-shared test-cluster-agent ## Run tests for all components
 
 test-backend: ## Run tests for backend only

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+backend: cd backend && make run
+cluster-agent: cd cluster-agent && make run

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ This repository contains scripts which may be used to setup/run the development 
 - **`(delete/stop)-dev-env.sh`**: Stop or delete the database.
 - **`db-schema.sql`**: The database schema used by the components
 - **`psql.sh`**: Allows you to interact with the DB from the command line. Requires `psql` CLI util to be installed on your local machine (for example, by installing PostgreSQL)
-
+    - Once inside psqli CLI, you may issue SQL statements, such as `select * from application;` (don't forget the semi-colon at the end, `;`!)

--- a/README.md
+++ b/README.md
@@ -17,11 +17,20 @@ There are 4 separated, tighly-coupled components contained within this repositor
 
 ### Development Environment
 
-This repository contains scripts which may be used to setup/run the development environment:
+To setup and run your development environment:
+- Ensure you are targetting a local Kubernetes cluster (I personally use [kubectx/kubens](https://github.com/ahmetb/kubectx) to manage Kubernetes context)
+- Run `make install` to ensure that the target cluster has the appropriate GitOps service CRs installed, and that Argo CD is installed in the 'argocd' namespae.
+- Run `create-dev-env.sh` to start Postgresql (see `make reset-db` if you want to reset this to a clean slate)
+
+This repository contains scripts which may be used to setup/run the database environment:
 - **`create-dev-env.sh`**: Start up PostgreSQL in a docker container, with the database initialized. 
     - Also starts `pg-admin`, a web-based tool for viewing and administering PostgreSQL database.
     - See `create-dev-env.sh` for login/password and connection info.
 - **`(delete/stop)-dev-env.sh`**: Stop or delete the database.
 - **`db-schema.sql`**: The database schema used by the components
 - **`psql.sh`**: Allows you to interact with the DB from the command line. Requires `psql` CLI util to be installed on your local machine (for example, by installing PostgreSQL)
-    - Once inside psqli CLI, you may issue SQL statements, such as `select * from application;` (don't forget the semi-colon at the end, `;`!)
+    - Once inside the psql CLI, you may issue SQL statements, such as `select * from application;` (don't forget the semi-colon at the end, `;`!)
+
+See also, the targets in `Makefile` for additional available operations. Plus, within each of the components is a `Makefile`, which can be used for local development of that component.     
+
+

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ To setup and run your development environment:
 - Ensure you are targetting a local Kubernetes cluster (I personally use [kubectx/kubens](https://github.com/ahmetb/kubectx) to manage Kubernetes context)
 - Run `make install` to ensure that the target cluster has the appropriate GitOps service CRs installed, and that Argo CD is installed in the 'argocd' namespae.
 - Run `create-dev-env.sh` to start Postgresql (see `make reset-db` if you want to reset this to a clean slate)
+- To start the GitOps service components, use `make start`. (Ensure you have [goreman](https://github.com/mattn/goreman) installed!)
+
 
 This repository contains scripts which may be used to setup/run the database environment:
 - **`create-dev-env.sh`**: Start up PostgreSQL in a docker container, with the database initialized. 

--- a/cluster-agent/main.go
+++ b/cluster-agent/main.go
@@ -56,8 +56,8 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8082", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8083", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")


### PR DESCRIPTION
Similar to how Argo CD uses a goreman + a Procfile to invoke the various Argo CD services simultaneously in a local development environment, we can do the same here.

Plus I've added a `Makefile` to contain targets that operate on multiple components simultaneously, such as this new goreman invocation via `make start`.