### PR TITLE
Fix golangci for cluster-agent

### DIFF
--- a/cluster-agent/controllers/managed-gitops/suite_test.go
+++ b/cluster-agent/controllers/managed-gitops/suite_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
@@ -37,7 +36,6 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 


### PR DESCRIPTION
While I was testing #51 my my `golangci-linter` errors out for this:

```
[drpaneas@pgeorgia-mac cluster-agent (main ✗)]$ golangci-lint run ./...
controllers/managed-gitops/suite_test.go:40:5: `cfg` is unused (deadcode)
var cfg *rest.Config
    ^
```

This is because the PR is adding linting for the `cluster-agent` repo, which was previously missing. See https://github.com/redhat-appstudio/managed-gitops/pull/51/files#diff-33f2778a5bb1ccf0ce7a73eeeeb02daf6023c2bdb47ff841fcf782fc3e469404R55

This issue was not detected by the CI, because changes in the CI take effect _after_ they are merged. So, this PR is required to me merged prior to #51 . Otherwise the Ci will be broken afterwards.