### PR TITLE
Enable weekly automatic dependency PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,88 @@
+# https://github.com/dependabot
+# Configuration options for dependency updates
+# See: https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      timezone: Europe/Berlin
+      time: "08:00"
+    assignees:
+      - "drpaneas"
+    # Allow up to 10 open pull requests for GitHub dependencies
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "🔼:"
+      prefix-development: "🔼"
+    labels:
+      - "🔼 dependencies"
+
+  # Maintain Go dependencies for backend repo
+  - package-ecosystem: "gomod"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      timezone: Europe/Berlin
+      time: "08:00"
+      assignees:
+        - "drpaneas"
+      open-pull-requests-limit: 10
+      commit-message:
+        prefix: "🔼:"
+      labels:
+        - "🔼 dependencies"
+
+  # Maintain Go dependencies for backend-shared repo
+  - package-ecosystem: "gomod"
+    directory: "/backend-shared"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      timezone: Europe/Berlin
+      time: "08:00"
+      assignees:
+        - "drpaneas"
+      open-pull-requests-limit: 10
+      commit-message:
+        prefix: "🔼:"
+      labels:
+        - "🔼 dependencies"
+
+  # Maintain Go dependencies for cluster-agent repo
+  - package-ecosystem: "gomod"
+    directory: "/cluster-agent"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      timezone: Europe/Berlin
+      time: "08:00"
+      assignees:
+        - "drpaneas"
+      open-pull-requests-limit: 10
+      commit-message:
+        prefix: "🔼:"
+      labels:
+        - "🔼 dependencies"
+
+  # Maintain Go dependencies for load-test repo
+  - package-ecosystem: "gomod"
+    directory: "/utilities/load-test/loadtest"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      timezone: Europe/Berlin
+      time: "08:00"
+      assignees:
+        - "drpaneas"
+      open-pull-requests-limit: 10
+      commit-message:
+        prefix: "🔼:"
+      labels:
+        - "🔼 dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,15 +13,6 @@ updates:
       day: "sunday"
       timezone: Europe/Berlin
       time: "08:00"
-    assignees:
-      - "drpaneas"
-    # Allow up to 10 open pull requests for GitHub dependencies
-    open-pull-requests-limit: 10
-    commit-message:
-      prefix: "🔼:"
-      prefix-development: "🔼"
-    labels:
-      - "🔼 dependencies"
 
   # Maintain Go dependencies for backend repo
   - package-ecosystem: "gomod"
@@ -31,13 +22,7 @@ updates:
       day: "sunday"
       timezone: Europe/Berlin
       time: "08:00"
-      assignees:
-        - "drpaneas"
-      open-pull-requests-limit: 10
-      commit-message:
-        prefix: "🔼:"
-      labels:
-        - "🔼 dependencies"
+
 
   # Maintain Go dependencies for backend-shared repo
   - package-ecosystem: "gomod"
@@ -47,13 +32,6 @@ updates:
       day: "sunday"
       timezone: Europe/Berlin
       time: "08:00"
-      assignees:
-        - "drpaneas"
-      open-pull-requests-limit: 10
-      commit-message:
-        prefix: "🔼:"
-      labels:
-        - "🔼 dependencies"
 
   # Maintain Go dependencies for cluster-agent repo
   - package-ecosystem: "gomod"
@@ -63,14 +41,7 @@ updates:
       day: "sunday"
       timezone: Europe/Berlin
       time: "08:00"
-      assignees:
-        - "drpaneas"
-      open-pull-requests-limit: 10
-      commit-message:
-        prefix: "🔼:"
-      labels:
-        - "🔼 dependencies"
-
+      
   # Maintain Go dependencies for load-test repo
   - package-ecosystem: "gomod"
     directory: "/utilities/load-test/loadtest"
@@ -79,10 +50,4 @@ updates:
       day: "sunday"
       timezone: Europe/Berlin
       time: "08:00"
-      assignees:
-        - "drpaneas"
-      open-pull-requests-limit: 10
-      commit-message:
-        prefix: "🔼:"
-      labels:
-        - "🔼 dependencies"
+


### PR DESCRIPTION
Dependabot is nowadays bought by GitHub. This configuration does the following:

* Updates the GitHub actions
* Updates the `go.mod` for every Golang based sub-repo here.

The bot is going to wake up every Sunday at 08:00 (Berlin timezone), check if there are new versions, and submit PRs, tagged with "🔼:" commit-message and also adding the "🔼 dependencies". I have put myself as the assignee so I can review how this goes.

Reason is that refreshing the libraries and be update it a good thing, but I am mostly interested in the security vulnerabilities introduced by specific versions we use. Dependabot is reviewing those and creates PRs with their new patched versions.