### PR TITLE
Use GOBIN instead of ~/go/bin/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
 MAKEFILE_ROOT=$(shell pwd)
+GOBIN=$(shell go env GOPATH)/bin
 help: ## Display this help menu
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
@@ -11,7 +12,7 @@ install-argo: ## Ensure that the Argo CD namespace exists, and that CRDs we are 
 	kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-cd/release-2.2/manifests/crds/application-crd.yaml
 
 start: ## Start all the components, compile & run (ensure goreman is installed, with 'go install github.com/mattn/goreman@latest')
-	~/go/bin/goreman start
+	$(GOBIN)/goreman start
 
 build: build-backend build-cluster-agent ## Build all the components - note: you do not need to do this before running start
 

--- a/README.md
+++ b/README.md
@@ -4,35 +4,34 @@
 
 For an introduction to the project, and project details, see [Google Drive](https://drive.google.com/drive/u/0/folders/1p_yIOJ1WLu-lqz-BVDn076l1K1pEOc1d).
 
-
 ### Components
 
 There are 4 separated, tighly-coupled components contained within this repository:
+
 - **Backend**: Simple Go module for listening for REST requests
 - **Backend Shared**: Simple Go module for sharing backend schema between operator and backend
 - **Cluster Agent**: A Kubernetes controller/operator that lives on the cluster and handles cluster operations.
-    - Based on operator-sdk v1.11
+  - Based on operator-sdk v1.11
 - **Frontend**: [PatternFly](https://www.patternfly.org/)/React-based UI, based on PatternFly React Seed
 - **Utilities**: Standalone utilities for working with the project.
 
 ### Development Environment
 
 To setup and run your development environment:
+
 - Ensure you are targetting a local Kubernetes cluster (I personally use [kubectx/kubens](https://github.com/ahmetb/kubectx) to manage Kubernetes context)
 - Run `make install-argo` to ensure that the target cluster has the appropriate GitOps service CRs installed, and that Argo CD is installed in the 'argocd' namespae.
 - Run `create-dev-env.sh` to start Postgresql (see `make reset-db` if you want to reset this to a clean slate)
 - To start the GitOps service components, use `make start`. (Ensure you have [goreman](https://github.com/mattn/goreman) installed!)
 
-
 This repository contains scripts which may be used to setup/run the database environment:
-- **`create-dev-env.sh`**: Start up PostgreSQL in a docker container, with the database initialized. 
-    - Also starts `pg-admin`, a web-based tool for viewing and administering PostgreSQL database.
+
+- **`create-dev-env.sh`**: Start up PostgreSQL in a docker container, with the database initialized.
+  - Also starts `pg-admin`, a web-based tool for viewing and administering PostgreSQL database.
     - See `create-dev-env.sh` for login/password and connection info.
 - **`(delete/stop)-dev-env.sh`**: Stop or delete the database.
 - **`db-schema.sql`**: The database schema used by the components
 - **`psql.sh`**: Allows you to interact with the DB from the command line. Requires `psql` CLI util to be installed on your local machine (for example, by installing PostgreSQL)
-    - Once inside the psql CLI, you may issue SQL statements, such as `select * from application;` (don't forget the semi-colon at the end, `;`!)
+  - Once inside the psql CLI, you may issue SQL statements, such as `select * from application;` (don't forget the semi-colon at the end, `;`!)
 
-See also, the targets in `Makefile` for additional available operations. Plus, within each of the components is a `Makefile`, which can be used for local development of that component.     
-
-
+See also, the targets in `Makefile` for additional available operations. Plus, within each of the components is a `Makefile`, which can be used for local development of that component.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There are 4 separated, tighly-coupled components contained within this repositor
 
 To setup and run your development environment:
 - Ensure you are targetting a local Kubernetes cluster (I personally use [kubectx/kubens](https://github.com/ahmetb/kubectx) to manage Kubernetes context)
-- Run `make install` to ensure that the target cluster has the appropriate GitOps service CRs installed, and that Argo CD is installed in the 'argocd' namespae.
+- Run `make install-argo` to ensure that the target cluster has the appropriate GitOps service CRs installed, and that Argo CD is installed in the 'argocd' namespae.
 - Run `create-dev-env.sh` to start Postgresql (see `make reset-db` if you want to reset this to a clean slate)
 - To start the GitOps service components, use `make start`. (Ensure you have [goreman](https://github.com/mattn/goreman) installed!)
 


### PR DESCRIPTION
When I tried `make start` it failed because the makefile expects `goreman` to be located at `~/go/bin`. I am not using `~/go/bin` for the go binaries but I do use `GOBIN` env variable to handle them. GOBIN is basically `GOPATH/bin` which is the place here the go binaries go after running `go install`. Would that work for you?

Also modified the readme at there is no more `make install` target and did some syntax cleanup.