### PR TITLE
Add test framework code for testing database tests (Solves: GITOPS-1634)

### DIFF
--- a/backend-shared/config/db/ephemeralPostgres.go
+++ b/backend-shared/config/db/ephemeralPostgres.go
@@ -182,3 +182,27 @@ func NewEphemeralCreateTestFramework() (EphemeralDB, error) {
 
 	return res, nil
 }
+
+// NewEphemeralCleanTestFramework will clean a docker container,
+// and network. This is merely defined for testing purpose
+func NewEphemeralCleanTestFramework(dockerContainerID string, tempNetworkName string) error {
+
+	dockerCmd := "docker rm -f %s"
+	fmt.Println("\nRunning: ", fmt.Sprintf(dockerCmd, dockerContainerID))
+
+	// To get the output of the command
+	_, err := exec.Command("docker", "rm", "-f", dockerContainerID).Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	dockerNetworkcmd := "docker network rm %s"
+	fmt.Println("\nRunning: ", fmt.Sprintf(dockerNetworkcmd, tempNetworkName))
+
+	// To get the output of the command
+	_, err = exec.Command("docker", "network", "rm", tempNetworkName).Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return nil
+}

--- a/backend-shared/config/db/ephemeralPostgres.go
+++ b/backend-shared/config/db/ephemeralPostgres.go
@@ -32,7 +32,7 @@ func NewEphemeralCreateTestFramework() (EphemeralDB, error) {
 	// To print which command is running
 	fmt.Println("\nRunning: ", s)
 
-	// To get the output of the command
+	// #nosec G204
 	dockerNetwork := exec.Command("docker", "network", "create", tempNetworkName)
 	dockerNetworkerr := dockerNetwork.Run()
 	if dockerNetworkerr != nil {
@@ -66,6 +66,7 @@ func NewEphemeralCreateTestFramework() (EphemeralDB, error) {
 	var dockerContainerID []byte
 	var errDockerRun error
 	errWait := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+		// #nosec G204
 		dockerContainerID, errDockerRun = exec.Command("docker", "run", "--name", dockerName,
 			"-v", string(tempDatabaseDir)+":/var/lib/postgresql/data:Z",
 			"-e", "POSTGRES_PASSWORD=gitops",
@@ -84,6 +85,7 @@ func NewEphemeralCreateTestFramework() (EphemeralDB, error) {
 			return false, errDockerRun
 		}
 		// check for container status
+		// #nosec G204
 		status, _ := exec.Command("docker", "container", "inspect", "-f", "{{.State.Status}}", string(dockerContainerID)).Output()
 		if string(status) == "running" {
 			return true, nil
@@ -102,6 +104,7 @@ func NewEphemeralCreateTestFramework() (EphemeralDB, error) {
 	fmt.Println("\nRunning: ", s)
 	// To get the output of the command
 	errWait = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+		// #nosec G204
 		psqlcmd := exec.Command("psql", "-h", "localhost", "-d", tempDBName, "-U", "postgres", "-p", "6432", "-c", "select 1")
 		psqlcmd.Env = os.Environ()
 		psqlcmd.Env = append(psqlcmd.Env, "PGPASSWORD=gitops")

--- a/backend-shared/config/db/ephemeralPostgres.go
+++ b/backend-shared/config/db/ephemeralPostgres.go
@@ -1,0 +1,184 @@
+package db
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type EphemeralDB struct {
+	db            *PostgreSQLDatabaseQueries
+	dbContainerID string
+	dockerNetwork string
+}
+
+// NewEphemeralCreateTestFramework will create a docker container,
+// network, connect to database and populate the schema. This is
+// merely defined for testing purpose
+func NewEphemeralCreateTestFramework() (EphemeralDB, error) {
+	dockerName := "managed-gitops-postgres-test"
+	dockerNetworkcmd := "docker network create %s"
+	uuid := uuid.New().String()
+	tempDBName := "db-" + uuid
+	tempNetworkName := "gitops-net-" + uuid
+	s := fmt.Sprintf(dockerNetworkcmd, tempNetworkName)
+	// To print which command is running
+	fmt.Println("\nRunning: ", s)
+
+	// To get the output of the command
+	dockerNetwork := exec.Command("docker", "network", "create", tempNetworkName)
+	dockerNetworkerr := dockerNetwork.Run()
+	if dockerNetworkerr != nil {
+		log.Fatal(dockerNetworkerr)
+	}
+
+	tempDatabaseDircmd := "mktemp -d -t postgres-XXXXXXXXXX"
+	s = fmt.Sprintf(tempDatabaseDircmd)
+	fmt.Println("\nRunning: ", s)
+
+	// To actually run the command (runs in background)
+	tempDatabaseDir, err_run := exec.Command("mktemp", "-d", "-t", "postgres-XXXXXXXXXX").Output()
+	if err_run != nil {
+		log.Fatal(err_run)
+	}
+
+	// running a docker container
+	dockerContainerIDcmd := `docker run --name ` + dockerName + ` \
+	-v ` + string(tempDatabaseDir) + `:/var/lib/postgresql/data:Z \
+	-e POSTGRES_PASSWORD=gitops \
+	-e POSTGRES_DB=` + tempDBName + ` \
+	-p 6432:5432 \
+	--network ` + tempNetworkName + ` \
+	-d \
+	postgres:13 \
+	-c log_statement='all' \
+	-c log_min_duration_statement=0`
+
+	fmt.Println("\nRunning:", dockerContainerIDcmd)
+
+	var dockerContainerID []byte
+	var errDockerRun error
+	errWait := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+		dockerContainerID, errDockerRun = exec.Command("docker", "run", "--name", dockerName,
+			"-v", string(tempDatabaseDir)+":/var/lib/postgresql/data:Z",
+			"-e", "POSTGRES_PASSWORD=gitops",
+			"-e", "POSTGRES_DB="+tempDBName,
+			"-p", "6432:5432",
+			"--network", "gitops-net-"+uuid,
+			"-d",
+			"postgres:13",
+			"-c", "log_statement=all",
+			"-c", "log_min_duration_statement=0").Output()
+
+		if errDockerRun != nil {
+			log.Fatal(errDockerRun)
+		}
+		if dockerContainerID == nil {
+			return false, errDockerRun
+		}
+		// check for container status
+		status, _ := exec.Command("docker", "container", "inspect", "-f", "{{.State.Status}}", string(dockerContainerID)).Output()
+		if string(status) == "running" {
+			return true, nil
+		}
+		// Todo: Once verified removed these print statements in order to maintain code coverage
+		fmt.Println("Docker Container ID: " + string(dockerContainerID))
+		return true, nil
+	})
+	if errWait != nil {
+		log.Fatal("error in executing docker run command: ", errWait)
+	}
+
+	dbcmd := "PGPASSWORD=gitops psql -h localhost -d %s -U postgres -p 6432 -c 'select 1'"
+	s = fmt.Sprintf(dbcmd, tempDBName)
+
+	fmt.Println("\nRunning: ", s)
+	// To get the output of the command
+	errWait = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+		psqlcmd := exec.Command("psql", "-h", "localhost", "-d", tempDBName, "-U", "postgres", "-p", "6432", "-c", "select 1")
+		psqlcmd.Env = os.Environ()
+		psqlcmd.Env = append(psqlcmd.Env, "PGPASSWORD=gitops")
+		var outb, errb bytes.Buffer
+		psqlcmd.Stdout = &outb
+		psqlcmd.Stderr = &errb
+
+		psqlErr := psqlcmd.Run()
+
+		if errb.String() != "" {
+			// log.Fatal(errb.String())
+			return false, fmt.Errorf(errb.String())
+		}
+		if psqlErr != nil {
+			return false, psqlErr
+		}
+		fmt.Printf("%s database is ready to use\n", tempDBName)
+		return true, nil
+	})
+	if errWait != nil {
+		log.Fatal("error in executing docker run command: ", errWait)
+	}
+
+	// creating a new database
+	newDBName := "postgres"
+	dbcmd = "PGPASSWORD=gitops psql -h localhost -d %s -U postgres -p 6432"
+	s = fmt.Sprintf(dbcmd, newDBName)
+	fmt.Println("\nRunning: ", s)
+
+	psqlcmd := exec.Command("psql", "-h", "localhost", "-d", newDBName, "-U", "postgres", "-p", "6432")
+	psqlcmd.Env = os.Environ()
+	psqlcmd.Env = append(psqlcmd.Env, "PGPASSWORD=gitops")
+	var errConnection bytes.Buffer
+	psqlcmd.Stderr = &errConnection
+	psqlErr := psqlcmd.Run()
+	if errConnection.String() != "" {
+		log.Fatal(errConnection.String())
+	}
+	if psqlErr != nil {
+		log.Fatal("error in creation: ", "\nCommand Error: ", psqlErr, "\nDatabase Error: ", errConnection.String())
+	}
+
+	fmt.Printf("the %s database is created and ready to use\n", newDBName)
+
+	// Following command is used to populate the database tables from the db-schema.sql (defined in the monorepo)
+	dbcmd = "PGPASSWORD=gitops psql -h localhost -d %s -U postgres -p 6432 -q -f ../../../db-schema.sql"
+	s = fmt.Sprintf(dbcmd, newDBName)
+	fmt.Println("\nRunning: ", s)
+	psqlcmd = exec.Command("psql", "-h", "localhost", "-d", newDBName, "-U", "postgres", "-p", "6432", "-q", "-f", "../../../db-schema.sql")
+	var errSchema bytes.Buffer
+	psqlcmd.Stderr = &errSchema
+	psqlcmd.Env = os.Environ()
+	psqlcmd.Env = append(psqlcmd.Env, "PGPASSWORD=gitops")
+	psqlErr = psqlcmd.Run()
+
+	if errSchema.String() != "" {
+		log.Fatal(errSchema.String())
+	}
+	if psqlErr != nil {
+		log.Fatal(psqlErr)
+	}
+	fmt.Printf("db schema executed in the %s database\n", newDBName)
+
+	// connect the go code with the database
+	database, err := ConnectToDatabase(true, newDBName, 6432)
+	if err != nil {
+		return EphemeralDB{}, err
+	}
+
+	dbq := &PostgreSQLDatabaseQueries{
+		dbConnection:   database,
+		allowTestUuids: false,
+		allowUnsafe:    true,
+	}
+
+	fmt.Printf("* WARNING: Unsafe PostgreSQLDB object was created. You should never see this outside of test suites, or personal development.\n")
+	res := EphemeralDB{db: dbq, dbContainerID: strings.TrimSpace(string(dockerContainerID)), dockerNetwork: tempNetworkName}
+
+	return res, nil
+}

--- a/backend-shared/config/db/ephemeralPostgres_test.go
+++ b/backend-shared/config/db/ephemeralPostgres_test.go
@@ -24,6 +24,6 @@ func TestEphemeralCode(t *testing.T) {
 	err = dbq.UnsafeListAllApplicationStates(ctx, &applicationStates)
 	assert.NoError(t, err)
 
-	errClean := NewEphemeralCleanTestFramework(ephemeralDB.dbContainerID, ephemeralDB.dockerNetwork)
+	errClean := ephemeralDB.Dispose()
 	assert.NoError(t, errClean)
 }

--- a/backend-shared/config/db/ephemeralPostgres_test.go
+++ b/backend-shared/config/db/ephemeralPostgres_test.go
@@ -1,0 +1,29 @@
+// +build !skip
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEphemeralCode(t *testing.T) {
+
+	ctx := context.Background()
+	// Create ephemeral DB
+	ephemeralDB, err := NewEphemeralCreateTestFramework()
+	assert.NoError(t, err)
+
+	dbq := ephemeralDB.db
+	defer dbq.CloseDatabase()
+
+	// test code as normal, for example:
+	var applicationStates []ApplicationState
+	err = dbq.UnsafeListAllApplicationStates(ctx, &applicationStates)
+	assert.NoError(t, err)
+
+	errClean := NewEphemeralCleanTestFramework(ephemeralDB.dbContainerID, ephemeralDB.dockerNetwork)
+	assert.NoError(t, errClean)
+}

--- a/backend-shared/config/db/postgres-integration.go
+++ b/backend-shared/config/db/postgres-integration.go
@@ -8,6 +8,8 @@ import (
 	"github.com/go-pg/pg/v10"
 )
 
+const DEFAULT_PORT = 5432
+
 func isEnvExist(key string) bool {
 	if _, ok := os.LookupEnv(key); ok {
 		return true
@@ -35,40 +37,6 @@ func connectToDatabaseWithPort(verbose bool, dbName string, port int) (*pg.DB, e
 	}
 	opts := &pg.Options{
 		Addr:     fmt.Sprintf("%s:%s", addr, fmt.Sprint(port)),
-		User:     "postgres",
-		Password: password,
-		Database: dbName,
-	}
-
-	db := pg.Connect(opts)
-
-	if err := checkConn(db); err != nil {
-		return nil, fmt.Errorf("%v, unable to connect to database: Host:'%s' User:'%s' Pass:'%s' DB:'%s' ", err, opts.Addr, opts.User, opts.Password, opts.Database)
-	}
-
-	if verbose {
-		db.AddQueryHook(pgdebug.DebugHook{
-			// Print all queries.
-			Verbose: true,
-		})
-	}
-
-	return db, nil
-}
-
-// connectToDatabase connects to Postgres
-func connectToDatabase(verbose bool, dbName string) (*pg.DB, error) {
-	addr := "localhost"
-	if isEnvExist("DB_ADDR") {
-		addr = os.Getenv("DB_ADDR")
-	}
-
-	password := "gitops"
-	if isEnvExist("DB_PASS") {
-		password = os.Getenv("DB_PASS")
-	}
-	opts := &pg.Options{
-		Addr:     fmt.Sprintf("%s:5432", addr),
 		User:     "postgres",
 		Password: password,
 		Database: dbName,

--- a/backend-shared/config/db/postgres-integration.go
+++ b/backend-shared/config/db/postgres-integration.go
@@ -22,8 +22,42 @@ func checkConn(db *pg.DB) error {
 	return err
 }
 
-// connectToDatabase connects to Postgres.
-func connectToDatabase(verbose bool) (*pg.DB, error) {
+// connectToDatabaseWithPort connects to Postgres with a defined port
+func connectToDatabaseWithPort(verbose bool, dbName string, port int) (*pg.DB, error) {
+	addr := "localhost"
+	if isEnvExist("DB_ADDR") {
+		addr = os.Getenv("DB_ADDR")
+	}
+
+	password := "gitops"
+	if isEnvExist("DB_PASS") {
+		password = os.Getenv("DB_PASS")
+	}
+	opts := &pg.Options{
+		Addr:     fmt.Sprintf("%s:%s", addr, fmt.Sprint(port)),
+		User:     "postgres",
+		Password: password,
+		Database: dbName,
+	}
+
+	db := pg.Connect(opts)
+
+	if err := checkConn(db); err != nil {
+		return nil, fmt.Errorf("%v, unable to connect to database: Host:'%s' User:'%s' Pass:'%s' DB:'%s' ", err, opts.Addr, opts.User, opts.Password, opts.Database)
+	}
+
+	if verbose {
+		db.AddQueryHook(pgdebug.DebugHook{
+			// Print all queries.
+			Verbose: true,
+		})
+	}
+
+	return db, nil
+}
+
+// connectToDatabase connects to Postgres
+func connectToDatabase(verbose bool, dbName string) (*pg.DB, error) {
 	addr := "localhost"
 	if isEnvExist("DB_ADDR") {
 		addr = os.Getenv("DB_ADDR")
@@ -37,7 +71,7 @@ func connectToDatabase(verbose bool) (*pg.DB, error) {
 		Addr:     fmt.Sprintf("%s:5432", addr),
 		User:     "postgres",
 		Password: password,
-		Database: "postgres",
+		Database: dbName,
 	}
 
 	db := pg.Connect(opts)

--- a/backend-shared/config/db/postgres-integration.go
+++ b/backend-shared/config/db/postgres-integration.go
@@ -36,7 +36,7 @@ func connectToDatabaseWithPort(verbose bool, dbName string, port int) (*pg.DB, e
 		password = os.Getenv("DB_PASS")
 	}
 	opts := &pg.Options{
-		Addr:     fmt.Sprintf("%s:%s", addr, fmt.Sprint(port)),
+		Addr:     fmt.Sprintf("%s:%v", addr, port),
 		User:     "postgres",
 		Password: password,
 		Database: dbName,

--- a/backend-shared/config/db/queries.go
+++ b/backend-shared/config/db/queries.go
@@ -204,7 +204,11 @@ type PostgreSQLDatabaseQueries struct {
 }
 
 func NewProductionPostgresDBQueries(verbose bool) (DatabaseQueries, error) {
-	db, err := connectToDatabase(verbose, "postgres")
+	return NewProductionPostgresDBQueriesWithport(verbose, DEFAULT_PORT)
+}
+
+func NewProductionPostgresDBQueriesWithport(verbose bool, port int) (DatabaseQueries, error) {
+	db, err := connectToDatabaseWithPort(verbose, "postgres", port)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +224,11 @@ func NewProductionPostgresDBQueries(verbose bool) (DatabaseQueries, error) {
 }
 
 func NewUnsafePostgresDBQueries(verbose bool, allowTestUuids bool) (AllDatabaseQueries, error) {
-	db, err := connectToDatabase(verbose, "postgres")
+	return NewUnsafePostgresDBQueriesWithPort(verbose, allowTestUuids, DEFAULT_PORT)
+}
+
+func NewUnsafePostgresDBQueriesWithPort(verbose bool, allowTestUuids bool, port int) (AllDatabaseQueries, error) {
+	db, err := connectToDatabaseWithPort(verbose, "postgres", port)
 	if err != nil {
 		return nil, err
 	}

--- a/backend-shared/config/db/queries.go
+++ b/backend-shared/config/db/queries.go
@@ -204,10 +204,10 @@ type PostgreSQLDatabaseQueries struct {
 }
 
 func NewProductionPostgresDBQueries(verbose bool) (DatabaseQueries, error) {
-	return NewProductionPostgresDBQueriesWithport(verbose, DEFAULT_PORT)
+	return NewProductionPostgresDBQueriesWithPort(verbose, DEFAULT_PORT)
 }
 
-func NewProductionPostgresDBQueriesWithport(verbose bool, port int) (DatabaseQueries, error) {
+func NewProductionPostgresDBQueriesWithPort(verbose bool, port int) (DatabaseQueries, error) {
 	db, err := connectToDatabaseWithPort(verbose, "postgres", port)
 	if err != nil {
 		return nil, err

--- a/backend-shared/config/db/queries.go
+++ b/backend-shared/config/db/queries.go
@@ -204,7 +204,7 @@ type PostgreSQLDatabaseQueries struct {
 }
 
 func NewProductionPostgresDBQueries(verbose bool) (DatabaseQueries, error) {
-	db, err := connectToDatabase(verbose)
+	db, err := connectToDatabase(verbose, "postgres")
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func NewProductionPostgresDBQueries(verbose bool) (DatabaseQueries, error) {
 }
 
 func NewUnsafePostgresDBQueries(verbose bool, allowTestUuids bool) (AllDatabaseQueries, error) {
-	db, err := connectToDatabase(verbose)
+	db, err := connectToDatabase(verbose, "postgres")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hi, :hugs:!

This is in regards with issue GITOPS-1634, this PR mainly involves two main methods (NewEphemeralCreateTestFramework, and, NewEphemeralCleanTestFramework) which are responsible for creating and cleaning a ephemeral, disposable Postgresql container which is being merely used for testing purpose.

The tests written against above method might look like this:

```
func TestEphemeralCode(t *testing.T) {
	ctx := context.Background()
	// Create ephemeral DB
	ephemeralDB, err := NewEphemeralCreateTestFramework()
	assert.NoError(t, err)

	dbq := ephemeralDB.db
	defer dbq.CloseDatabase()

	// test code as normal, for example:
	var applicationStates []ApplicationState
	err = dbq.UnsafeListAllApplicationStates(ctx, &applicationStates)
	assert.NoError(t, err)

	errClean := NewEphemeralCleanTestFramework(ephemeralDB.dbContainerID, ephemeralDB.dockerNetwork)
	assert.NoError(t, errClean)
}

```