### PR TITLE
Refactor database access to use unchecked behaviour by default

### DIFF
--- a/backend-shared/config/db/apicrtodatabasemapping.go
+++ b/backend-shared/config/db/apicrtodatabasemapping.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteAPICRToDatabaseMapping(ctx context.Context, obj *APICRToDatabaseMapping) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteAPICRToDatabaseMapping(ctx context.Context, obj *APICRToDatabaseMapping) (int, error) {
 	if err := validateQueryParamsEntity(obj, dbq); err != nil {
 		return 0, err
 	}
@@ -103,7 +103,7 @@ func (dbq *PostgreSQLDatabaseQueries) GetDatabaseMappingForAPICR(ctx context.Con
 
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedListAPICRToDatabaseMappingByAPINamespaceAndName(ctx context.Context, apiCRResourceType string, crName string, crNamespace string, crWorkspaceUID string, dbRelationType string, apiCRToDBMappingParam *[]APICRToDatabaseMapping) error {
+func (dbq *PostgreSQLDatabaseQueries) ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx context.Context, apiCRResourceType string, crName string, crNamespace string, crWorkspaceUID string, dbRelationType string, apiCRToDBMappingParam *[]APICRToDatabaseMapping) error {
 
 	if err := validateQueryParamsEntity(apiCRToDBMappingParam, dbq); err != nil {
 		return err
@@ -132,7 +132,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedListAPICRToDatabaseMappingByAPINa
 		Context(ctx).
 		Select(); err != nil {
 
-		return fmt.Errorf("error on retrieving UncheckedListAPICRToDatabaseMappingByAPINamespaceAndName: %v", err)
+		return fmt.Errorf("error on retrieving ListAPICRToDatabaseMappingByAPINamespaceAndName: %v", err)
 	}
 
 	*apiCRToDBMappingParam = dbResults
@@ -147,7 +147,7 @@ func (dbMapping *APICRToDatabaseMapping) DisposeAppScoped(ctx context.Context, d
 	if err := isEmptyValues("APICRToDatabaseMappingDispose", "dbq", dbq); err != nil {
 		return err
 	}
-	_, err := dbq.UncheckedDeleteAPICRToDatabaseMapping(ctx, dbMapping)
+	_, err := dbq.DeleteAPICRToDatabaseMapping(ctx, dbMapping)
 
 	return err
 }

--- a/backend-shared/config/db/application.go
+++ b/backend-shared/config/db/application.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func (dbq *PostgreSQLDatabaseQueries) GetApplicationById(ctx context.Context, application *Application, ownerId string) error {
+func (dbq *PostgreSQLDatabaseQueries) CheckedGetApplicationById(ctx context.Context, application *Application, ownerId string) error {
 
 	if err := validateQueryParamsEntity(application, dbq); err != nil {
 		return err
@@ -148,7 +148,7 @@ func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllApplications(ctx context.Cont
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) DeleteApplicationById(ctx context.Context, id string, ownerId string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) CheckedDeleteApplicationById(ctx context.Context, id string, ownerId string) (int, error) {
 
 	if err := validateQueryParams(id, dbq); err != nil {
 		return 0, err
@@ -158,7 +158,7 @@ func (dbq *PostgreSQLDatabaseQueries) DeleteApplicationById(ctx context.Context,
 		Application_id: id,
 	}
 
-	if err := dbq.GetApplicationById(ctx, result, ownerId); err != nil {
+	if err := dbq.CheckedGetApplicationById(ctx, result, ownerId); err != nil {
 		if IsResultNotFoundError(err) {
 			return 0, nil
 		}

--- a/backend-shared/config/db/application.go
+++ b/backend-shared/config/db/application.go
@@ -55,7 +55,7 @@ func (dbq *PostgreSQLDatabaseQueries) CheckedGetApplicationById(ctx context.Cont
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedGetApplicationById(ctx context.Context, application *Application) error {
+func (dbq *PostgreSQLDatabaseQueries) GetApplicationById(ctx context.Context, application *Application) error {
 
 	if err := validateQueryParamsEntity(application, dbq); err != nil {
 		return err
@@ -88,7 +88,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedGetApplicationById(ctx context.Co
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) CreateApplication(ctx context.Context, obj *Application, ownerId string) error {
+func (dbq *PostgreSQLDatabaseQueries) CheckedCreateApplication(ctx context.Context, obj *Application, ownerId string) error {
 
 	if err := validateQueryParamsEntity(obj, dbq); err != nil {
 		return err
@@ -116,7 +116,7 @@ func (dbq *PostgreSQLDatabaseQueries) CreateApplication(ctx context.Context, obj
 
 	// Verify the user can access the managed environment
 	managedEnv := ManagedEnvironment{Managedenvironment_id: obj.Managed_environment_id}
-	if err := dbq.GetManagedEnvironmentById(ctx, &managedEnv, ownerId); err != nil {
+	if err := dbq.CheckedGetManagedEnvironmentById(ctx, &managedEnv, ownerId); err != nil {
 		return fmt.Errorf("on creating Application, unable to retrieve managed environment %s for user %s: %v", obj.Managed_environment_id, ownerId, err)
 	}
 
@@ -174,7 +174,7 @@ func (dbq *PostgreSQLDatabaseQueries) CheckedDeleteApplicationById(ctx context.C
 	return deleteResult.RowsAffected(), nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteApplicationById(ctx context.Context, id string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteApplicationById(ctx context.Context, id string) (int, error) {
 
 	if err := validateQueryParams(id, dbq); err != nil {
 		return 0, err
@@ -192,7 +192,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteApplicationById(ctx context
 	return deleteResult.RowsAffected(), nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedCreateApplication(ctx context.Context, obj *Application) error {
+func (dbq *PostgreSQLDatabaseQueries) CreateApplication(ctx context.Context, obj *Application) error {
 
 	if err := validateQueryParamsEntity(obj, dbq); err != nil {
 		return err
@@ -227,7 +227,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedCreateApplication(ctx context.Con
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedUpdateApplication(ctx context.Context, obj *Application) error {
+func (dbq *PostgreSQLDatabaseQueries) UpdateApplication(ctx context.Context, obj *Application) error {
 
 	if err := validateQueryParamsEntity(obj, dbq); err != nil {
 		return err

--- a/backend-shared/config/db/applicationstates.go
+++ b/backend-shared/config/db/applicationstates.go
@@ -18,7 +18,7 @@ func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllApplicationStates(ctx context
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteApplicationStateById(ctx context.Context, id string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteApplicationStateById(ctx context.Context, id string) (int, error) {
 
 	if err := validateQueryParams(id, dbq); err != nil {
 		return 0, err
@@ -36,7 +36,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteApplicationStateById(ctx co
 	return deleteResult.RowsAffected(), nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedCreateApplicationState(ctx context.Context, obj *ApplicationState) error {
+func (dbq *PostgreSQLDatabaseQueries) CreateApplicationState(ctx context.Context, obj *ApplicationState) error {
 
 	if err := validateQueryParamsEntity(obj, dbq); err != nil {
 		return err
@@ -61,7 +61,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedCreateApplicationState(ctx contex
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedUpdateApplicationState(ctx context.Context, obj *ApplicationState) error {
+func (dbq *PostgreSQLDatabaseQueries) UpdateApplicationState(ctx context.Context, obj *ApplicationState) error {
 
 	if err := validateQueryParamsEntity(obj, dbq); err != nil {
 		return err
@@ -87,7 +87,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedUpdateApplicationState(ctx contex
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedGetApplicationStateById(ctx context.Context, obj *ApplicationState) error {
+func (dbq *PostgreSQLDatabaseQueries) GetApplicationStateById(ctx context.Context, obj *ApplicationState) error {
 
 	if err := validateQueryParamsEntity(obj, dbq); err != nil {
 		return err

--- a/backend-shared/config/db/clustercredentials.go
+++ b/backend-shared/config/db/clustercredentials.go
@@ -81,7 +81,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedGetClusterCredentialsById(ctx con
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) GetClusterCredentialsById(ctx context.Context, clusterCredentials *ClusterCredentials, ownerId string) error {
+func (dbq *PostgreSQLDatabaseQueries) CheckedGetClusterCredentialsById(ctx context.Context, clusterCredentials *ClusterCredentials, ownerId string) error {
 
 	if err := validateQueryParamsEntity(clusterCredentials, dbq); err != nil {
 		return err
@@ -127,7 +127,7 @@ func (dbq *PostgreSQLDatabaseQueries) GetClusterCredentialsById(ctx context.Cont
 
 }
 
-func (dbq *PostgreSQLDatabaseQueries) ListClusterCredentialsByHost(ctx context.Context, hostName string, clusterCredentials *[]ClusterCredentials, ownerId string) error {
+func (dbq *PostgreSQLDatabaseQueries) CheckedListClusterCredentialsByHost(ctx context.Context, hostName string, clusterCredentials *[]ClusterCredentials, ownerId string) error {
 
 	if err := validateQueryParams(hostName, dbq); err != nil {
 		return err
@@ -225,7 +225,7 @@ func (dbq *PostgreSQLDatabaseQueries) isAccessibleByUser(ctx context.Context, cl
 		for _, engineCluster := range engineClustersUsingCredential {
 
 			var gitopsEngineInstances []GitopsEngineInstance
-			if err := dbq.ListAllGitopsEngineInstancesForGitopsEngineClusterIdAndOwnerId(ctx, engineCluster.Gitopsenginecluster_id, ownerId, &gitopsEngineInstances); err != nil {
+			if err := dbq.CheckedListAllGitopsEngineInstancesForGitopsEngineClusterIdAndOwnerId(ctx, engineCluster.Gitopsenginecluster_id, ownerId, &gitopsEngineInstances); err != nil {
 				return false, err
 			}
 

--- a/backend-shared/config/db/clustercredentials.go
+++ b/backend-shared/config/db/clustercredentials.go
@@ -54,7 +54,7 @@ func (dbq *PostgreSQLDatabaseQueries) CreateClusterCredentials(ctx context.Conte
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedGetClusterCredentialsById(ctx context.Context, clusterCreds *ClusterCredentials) error {
+func (dbq *PostgreSQLDatabaseQueries) GetClusterCredentialsById(ctx context.Context, clusterCreds *ClusterCredentials) error {
 
 	if err := validateUnsafeQueryParamsEntity(clusterCreds, dbq); err != nil {
 		return err
@@ -193,7 +193,7 @@ func (dbq *PostgreSQLDatabaseQueries) isAccessibleByUser(ctx context.Context, cl
 	// Determine if any of those manageEnvironments are accessible by the user
 	for _, managedEnvironment := range *managedEnvironments {
 		dbManagedEnv := ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
-		err := dbq.GetManagedEnvironmentById(ctx, &dbManagedEnv, ownerId)
+		err := dbq.CheckedGetManagedEnvironmentById(ctx, &dbManagedEnv, ownerId)
 		if err != nil {
 
 			if IsResultNotFoundError(err) {
@@ -241,7 +241,7 @@ func (dbq *PostgreSQLDatabaseQueries) isAccessibleByUser(ctx context.Context, cl
 
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteClusterCredentialsById(ctx context.Context, id string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteClusterCredentialsById(ctx context.Context, id string) (int, error) {
 
 	if dbq.dbConnection == nil {
 		return 0, fmt.Errorf("database connection is nil")

--- a/backend-shared/config/db/clusteruser.go
+++ b/backend-shared/config/db/clusteruser.go
@@ -18,7 +18,7 @@ func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllClusterUsers(ctx context.Cont
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteClusterUserById(ctx context.Context, id string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteClusterUserById(ctx context.Context, id string) (int, error) {
 
 	if err := validateQueryParams(id, dbq); err != nil {
 		return 0, err

--- a/backend-shared/config/db/deploymenttoapplicationmapping.go
+++ b/backend-shared/config/db/deploymenttoapplicationmapping.go
@@ -170,7 +170,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedGetDeploymentToApplicationMapping
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) GetDeploymentToApplicationMappingByDeplId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping, ownerId string) error {
+func (dbq *PostgreSQLDatabaseQueries) CheckedGetDeploymentToApplicationMappingByDeplId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping, ownerId string) error {
 
 	if err := validateQueryParamsEntity(deplToAppMappingParam, dbq); err != nil {
 		return err
@@ -206,7 +206,7 @@ func (dbq *PostgreSQLDatabaseQueries) GetDeploymentToApplicationMappingByDeplId(
 
 	// Check that the user has access to retrieve the referenced Application
 	deplApplication := Application{Application_id: dbResults[0].Application_id}
-	if err := dbq.GetApplicationById(ctx, &deplApplication, ownerId); err != nil {
+	if err := dbq.CheckedGetApplicationById(ctx, &deplApplication, ownerId); err != nil {
 
 		if IsResultNotFoundError(err) {
 			return NewResultNotFoundError(fmt.Sprintf("unable to retrieve deployment mapping for Application: %v", err))
@@ -220,7 +220,7 @@ func (dbq *PostgreSQLDatabaseQueries) GetDeploymentToApplicationMappingByDeplId(
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) DeleteDeploymentToApplicationMappingByDeplId(ctx context.Context, id string, ownerId string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) CheckedDeleteDeploymentToApplicationMappingByDeplId(ctx context.Context, id string, ownerId string) (int, error) {
 
 	if err := validateQueryParams(id, dbq); err != nil {
 		return 0, err
@@ -231,7 +231,7 @@ func (dbq *PostgreSQLDatabaseQueries) DeleteDeploymentToApplicationMappingByDepl
 	}
 
 	// Verify that the user can delete the mapping, by checking that they can access it.
-	if err := dbq.GetDeploymentToApplicationMappingByDeplId(ctx, entity, ownerId); err != nil {
+	if err := dbq.CheckedGetDeploymentToApplicationMappingByDeplId(ctx, entity, ownerId); err != nil {
 
 		if IsResultNotFoundError(err) {
 			return 0, nil

--- a/backend-shared/config/db/deploymenttoapplicationmapping.go
+++ b/backend-shared/config/db/deploymenttoapplicationmapping.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedListDeploymentToApplicationMappingByWorkspaceUID(ctx context.Context, workspaceUID string,
+func (dbq *PostgreSQLDatabaseQueries) ListDeploymentToApplicationMappingByWorkspaceUID(ctx context.Context, workspaceUID string,
 	deplToAppMappingParam *[]DeploymentToApplicationMapping) error {
 
 	if err := validateQueryParamsEntity(deplToAppMappingParam, dbq); err != nil {
@@ -29,7 +29,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedListDeploymentToApplicationMappin
 		Context(ctx).
 		Select(); err != nil {
 
-		return fmt.Errorf("error on retrieving UncheckedListDeploymentToApplicationMappingByWorkspaceUID: %v", err)
+		return fmt.Errorf("error on retrieving ListDeploymentToApplicationMappingByWorkspaceUID: %v", err)
 	}
 
 	*deplToAppMappingParam = dbResults
@@ -37,7 +37,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedListDeploymentToApplicationMappin
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedListDeploymentToApplicationMappingByNamespaceAndName(ctx context.Context, deploymentName string,
+func (dbq *PostgreSQLDatabaseQueries) ListDeploymentToApplicationMappingByNamespaceAndName(ctx context.Context, deploymentName string,
 	deploymentNamespace string, workspaceUID string, deplToAppMappingParam *[]DeploymentToApplicationMapping) error {
 
 	if err := validateQueryParamsEntity(deplToAppMappingParam, dbq); err != nil {
@@ -65,7 +65,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedListDeploymentToApplicationMappin
 		Context(ctx).
 		Select(); err != nil {
 
-		return fmt.Errorf("error on retrieving UncheckedListDeploymentToApplicationMappingByNamespaceAndName: %v", err)
+		return fmt.Errorf("error on retrieving ListDeploymentToApplicationMappingByNamespaceAndName: %v", err)
 	}
 
 	*deplToAppMappingParam = dbResults
@@ -73,7 +73,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedListDeploymentToApplicationMappin
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteDeploymentToApplicationMappingByNamespaceAndName(ctx context.Context, deploymentName string, deploymentNamespace string, workspaceUID string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteDeploymentToApplicationMappingByNamespaceAndName(ctx context.Context, deploymentName string, deploymentNamespace string, workspaceUID string) (int, error) {
 
 	if err := validateQueryParamsNoPK(dbq); err != nil {
 		return 0, err
@@ -100,7 +100,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteDeploymentToApplicationMapp
 	return deleteResult.RowsAffected(), nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedGetDeploymentToApplicationMappingByDeplId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping) error {
+func (dbq *PostgreSQLDatabaseQueries) GetDeploymentToApplicationMappingByDeplId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping) error {
 
 	if err := validateQueryParamsEntity(deplToAppMappingParam, dbq); err != nil {
 		return err
@@ -137,7 +137,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedGetDeploymentToApplicationMapping
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedGetDeploymentToApplicationMappingByApplicationId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping) error {
+func (dbq *PostgreSQLDatabaseQueries) GetDeploymentToApplicationMappingByApplicationId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping) error {
 
 	if err := validateQueryParamsEntity(deplToAppMappingParam, dbq); err != nil {
 		return err
@@ -154,11 +154,11 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedGetDeploymentToApplicationMapping
 		Context(ctx).
 		Select(); err != nil {
 
-		return fmt.Errorf("error on retrieving UncheckedGetDeploymentToApplicationMappingByApplicationId: %v", err)
+		return fmt.Errorf("error on retrieving GetDeploymentToApplicationMappingByApplicationId: %v", err)
 	}
 
 	if len(dbResults) > 1 {
-		return fmt.Errorf("multiple results returned from UncheckedGetDeploymentToApplicationMappingByApplicationId")
+		return fmt.Errorf("multiple results returned from GetDeploymentToApplicationMappingByApplicationId")
 	}
 
 	if len(dbResults) == 0 {
@@ -248,7 +248,7 @@ func (dbq *PostgreSQLDatabaseQueries) CheckedDeleteDeploymentToApplicationMappin
 	return deleteResult.RowsAffected(), nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteDeploymentToApplicationMappingByDeplId(ctx context.Context, id string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteDeploymentToApplicationMappingByDeplId(ctx context.Context, id string) (int, error) {
 
 	if err := validateQueryParams(id, dbq); err != nil {
 		return 0, err

--- a/backend-shared/config/db/gitopsenginecluster.go
+++ b/backend-shared/config/db/gitopsenginecluster.go
@@ -37,7 +37,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedGetGitopsEngineClusterById(ctx co
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) GetGitopsEngineClusterById(ctx context.Context, gitopsEngineCluster *GitopsEngineCluster, ownerId string) error {
+func (dbq *PostgreSQLDatabaseQueries) CheckedGetGitopsEngineClusterById(ctx context.Context, gitopsEngineCluster *GitopsEngineCluster, ownerId string) error {
 
 	if err := validateQueryParamsEntity(gitopsEngineCluster, dbq); err != nil {
 		return err
@@ -53,7 +53,7 @@ func (dbq *PostgreSQLDatabaseQueries) GetGitopsEngineClusterById(ctx context.Con
 
 	// Return engine instances that are owned by 'ownerid', and are running on cluster 'id'
 	var dbResultGitopsEngineInstances []GitopsEngineInstance
-	if err := dbq.ListAllGitopsEngineInstancesForGitopsEngineClusterIdAndOwnerId(ctx, gitopsEngineCluster.Gitopsenginecluster_id, ownerId, &dbResultGitopsEngineInstances); err != nil {
+	if err := dbq.CheckedListAllGitopsEngineInstancesForGitopsEngineClusterIdAndOwnerId(ctx, gitopsEngineCluster.Gitopsenginecluster_id, ownerId, &dbResultGitopsEngineInstances); err != nil {
 		return NewResultNotFoundError(
 			fmt.Sprintf("unable to list engine instances for engine cluster '%s' %v", gitopsEngineCluster.Gitopsenginecluster_id, err))
 	}
@@ -88,7 +88,7 @@ func (dbq *PostgreSQLDatabaseQueries) GetGitopsEngineClusterById(ctx context.Con
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) ListGitopsEngineClusterByCredentialId(ctx context.Context, credentialId string, engineClustersParam *[]GitopsEngineCluster, ownerId string) error {
+func (dbq *PostgreSQLDatabaseQueries) CheckedListGitopsEngineClusterByCredentialId(ctx context.Context, credentialId string, engineClustersParam *[]GitopsEngineCluster, ownerId string) error {
 
 	if err := validateQueryParams(credentialId, dbq); err != nil {
 		return err
@@ -120,7 +120,7 @@ func (dbq *PostgreSQLDatabaseQueries) ListGitopsEngineClusterByCredentialId(ctx 
 
 		// Return engine instances that are owned by 'ownerid', and are running on cluster 'id'
 		var dbEngineInstances []GitopsEngineInstance
-		if err := dbq.ListAllGitopsEngineInstancesForGitopsEngineClusterIdAndOwnerId(ctx, gitopsEngineCluster.Gitopsenginecluster_id, ownerId, &dbEngineInstances); err != nil {
+		if err := dbq.CheckedListAllGitopsEngineInstancesForGitopsEngineClusterIdAndOwnerId(ctx, gitopsEngineCluster.Gitopsenginecluster_id, ownerId, &dbEngineInstances); err != nil {
 			return fmt.Errorf("unable to list engine instance for '%s', owner '%s', error: %v", gitopsEngineCluster.Gitopsenginecluster_id, ownerId, err)
 		}
 

--- a/backend-shared/config/db/gitopsenginecluster.go
+++ b/backend-shared/config/db/gitopsenginecluster.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedGetGitopsEngineClusterById(ctx context.Context, gitopsEngineCluster *GitopsEngineCluster) error {
+func (dbq *PostgreSQLDatabaseQueries) GetGitopsEngineClusterById(ctx context.Context, gitopsEngineCluster *GitopsEngineCluster) error {
 
 	if err := validateQueryParamsEntity(gitopsEngineCluster, dbq); err != nil {
 		return err
@@ -186,7 +186,7 @@ func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllGitopsEngineClusters(ctx cont
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteGitopsEngineClusterById(ctx context.Context, id string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteGitopsEngineClusterById(ctx context.Context, id string) (int, error) {
 
 	if err := validateUnsafeQueryParams(id, dbq); err != nil {
 		return 0, err

--- a/backend-shared/config/db/gitopsengineinstance.go
+++ b/backend-shared/config/db/gitopsengineinstance.go
@@ -47,7 +47,7 @@ func (dbq *PostgreSQLDatabaseQueries) CheckedListAllGitopsEngineInstancesForGito
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedGetGitopsEngineInstanceById(ctx context.Context, engineInstanceParam *GitopsEngineInstance) error {
+func (dbq *PostgreSQLDatabaseQueries) GetGitopsEngineInstanceById(ctx context.Context, engineInstanceParam *GitopsEngineInstance) error {
 
 	if err := validateQueryParamsEntity(engineInstanceParam, dbq); err != nil {
 		return err
@@ -167,7 +167,7 @@ func (dbq *PostgreSQLDatabaseQueries) CheckedDeleteGitopsEngineInstanceById(ctx 
 
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteGitopsEngineInstanceById(ctx context.Context, id string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteGitopsEngineInstanceById(ctx context.Context, id string) (int, error) {
 
 	return dbq.internalDeleteGitopsEngineInstanceById(ctx, id, "", true)
 

--- a/backend-shared/config/db/gitopsengineinstance.go
+++ b/backend-shared/config/db/gitopsengineinstance.go
@@ -18,7 +18,7 @@ func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllGitopsEngineInstances(ctx con
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) ListAllGitopsEngineInstancesForGitopsEngineClusterIdAndOwnerId(ctx context.Context, engineClusterId string, ownerId string, gitopsEngineInstancesParam *[]GitopsEngineInstance) error {
+func (dbq *PostgreSQLDatabaseQueries) CheckedListAllGitopsEngineInstancesForGitopsEngineClusterIdAndOwnerId(ctx context.Context, engineClusterId string, ownerId string, gitopsEngineInstancesParam *[]GitopsEngineInstance) error {
 
 	if err := validateQueryParams(engineClusterId, dbq); err != nil {
 		return err
@@ -80,7 +80,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedGetGitopsEngineInstanceById(ctx c
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) GetGitopsEngineInstanceById(ctx context.Context, engineInstanceParam *GitopsEngineInstance, ownerId string) error {
+func (dbq *PostgreSQLDatabaseQueries) CheckedGetGitopsEngineInstanceById(ctx context.Context, engineInstanceParam *GitopsEngineInstance, ownerId string) error {
 
 	if err := validateQueryParamsEntity(engineInstanceParam, dbq); err != nil {
 		return err
@@ -161,7 +161,7 @@ func (dbq *PostgreSQLDatabaseQueries) CreateGitopsEngineInstance(ctx context.Con
 
 }
 
-func (dbq *PostgreSQLDatabaseQueries) DeleteGitopsEngineInstanceById(ctx context.Context, id string, ownerId string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) CheckedDeleteGitopsEngineInstanceById(ctx context.Context, id string, ownerId string) (int, error) {
 
 	return dbq.internalDeleteGitopsEngineInstanceById(ctx, id, ownerId, false)
 
@@ -188,7 +188,7 @@ func (dbq *PostgreSQLDatabaseQueries) internalDeleteGitopsEngineInstanceById(ctx
 		// If we are able to retrieve the engine instance with the ownerId, then it is reasonable to
 		// assume the a valid purpose for deleting the value on behalf of the user.
 		existingValue := GitopsEngineInstance{Gitopsengineinstance_id: id}
-		err := dbq.GetGitopsEngineInstanceById(ctx, &existingValue, ownerId)
+		err := dbq.CheckedGetGitopsEngineInstanceById(ctx, &existingValue, ownerId)
 		if err != nil || existingValue.Gitopsengineinstance_id != id {
 			return 0, fmt.Errorf("unable to locate gitops engine instance id, or access denied: '%s', %v", id, err)
 		}

--- a/backend-shared/config/db/injection_test.go
+++ b/backend-shared/config/db/injection_test.go
@@ -60,7 +60,7 @@ func TestGitopsEngineInstanceWrongInput(t *testing.T) {
 		retrieveGitopsEngineInstance := &GitopsEngineInstance{
 			Gitopsengineinstance_id: gitopsEngineInstance.Gitopsengineinstance_id,
 		}
-		err = dbq.UncheckedGetGitopsEngineInstanceById(ctx, retrieveGitopsEngineInstance)
+		err = dbq.GetGitopsEngineInstanceById(ctx, retrieveGitopsEngineInstance)
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -90,7 +90,7 @@ func TestClusterCredentialWrongInput(t *testing.T) {
 	retrievedClusterCredentials := &ClusterCredentials{
 		Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
 	}
-	err = dbq.UncheckedGetClusterCredentialsById(ctx, retrievedClusterCredentials)
+	err = dbq.GetClusterCredentialsById(ctx, retrievedClusterCredentials)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -132,7 +132,7 @@ func TestManagedEnviromentWrongInput(t *testing.T) {
 		retrieveManagedEnv := &ManagedEnvironment{
 			Managedenvironment_id: "test-managed-env-1",
 		}
-		err = dbq.UncheckedGetManagedEnvironmentById(ctx, retrieveManagedEnv)
+		err = dbq.GetManagedEnvironmentById(ctx, retrieveManagedEnv)
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -253,14 +253,14 @@ func TestApplicationWrongInput(t *testing.T) {
 		Managed_environment_id:  managedEnvironment.Managedenvironment_id,
 	}
 
-	err = dbq.CreateApplication(ctx, application, clusterAccess.Clusteraccess_user_id)
+	err = dbq.CheckedCreateApplication(ctx, application, clusterAccess.Clusteraccess_user_id)
 	if !assert.NoError(t, err) {
 		return
 	}
 
 	retrievedApplication := Application{Application_id: application.Application_id}
 
-	err = dbq.UncheckedGetApplicationById(ctx, &retrievedApplication)
+	err = dbq.GetApplicationById(ctx, &retrievedApplication)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/backend-shared/config/db/kubernetesresourcetodbresourcemapping.go
+++ b/backend-shared/config/db/kubernetesresourcetodbresourcemapping.go
@@ -16,7 +16,7 @@ const (
 	K8sToDBMapping_GitopsEngineInstance = "GitopsEngineInstance"
 )
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteKubernetesResourceToDBResourceMapping(ctx context.Context, obj *KubernetesToDBResourceMapping) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteKubernetesResourceToDBResourceMapping(ctx context.Context, obj *KubernetesToDBResourceMapping) (int, error) {
 
 	if err := validateQueryParamsEntity(obj, dbq); err != nil {
 		return 0, err

--- a/backend-shared/config/db/managedenvironment.go
+++ b/backend-shared/config/db/managedenvironment.go
@@ -78,7 +78,7 @@ func (dbq *PostgreSQLDatabaseQueries) ListManagedEnvironmentForClusterCredential
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedGetManagedEnvironmentById(ctx context.Context, managedEnvironment *ManagedEnvironment) error {
+func (dbq *PostgreSQLDatabaseQueries) GetManagedEnvironmentById(ctx context.Context, managedEnvironment *ManagedEnvironment) error {
 
 	if err := validateQueryParamsEntity(managedEnvironment, dbq); err != nil {
 		return err
@@ -111,7 +111,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedGetManagedEnvironmentById(ctx con
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) GetManagedEnvironmentById(ctx context.Context, managedEnvironment *ManagedEnvironment, ownerId string) error {
+func (dbq *PostgreSQLDatabaseQueries) CheckedGetManagedEnvironmentById(ctx context.Context, managedEnvironment *ManagedEnvironment, ownerId string) error {
 
 	if err := validateQueryParamsEntity(managedEnvironment, dbq); err != nil {
 		return err
@@ -161,7 +161,7 @@ func (dbq *PostgreSQLDatabaseQueries) CheckedDeleteManagedEnvironmentById(ctx co
 	}
 
 	existingValue := ManagedEnvironment{Managedenvironment_id: id}
-	err := dbq.GetManagedEnvironmentById(ctx, &existingValue, ownerId)
+	err := dbq.CheckedGetManagedEnvironmentById(ctx, &existingValue, ownerId)
 	if err != nil || existingValue.Managedenvironment_id != id {
 		return 0, fmt.Errorf("unable to locate managed environment id, or access denied: %s", id)
 	}
@@ -175,7 +175,7 @@ func (dbq *PostgreSQLDatabaseQueries) CheckedDeleteManagedEnvironmentById(ctx co
 }
 
 // This method does NOT check whether the user has access
-func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteManagedEnvironmentById(ctx context.Context, id string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteManagedEnvironmentById(ctx context.Context, id string) (int, error) {
 
 	if err := validateUnsafeQueryParams(id, dbq); err != nil {
 		return 0, err

--- a/backend-shared/config/db/managedenvironment.go
+++ b/backend-shared/config/db/managedenvironment.go
@@ -150,7 +150,7 @@ func (dbq *PostgreSQLDatabaseQueries) GetManagedEnvironmentById(ctx context.Cont
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) DeleteManagedEnvironmentById(ctx context.Context, id string, ownerId string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) CheckedDeleteManagedEnvironmentById(ctx context.Context, id string, ownerId string) (int, error) {
 
 	if err := validateQueryParams(id, dbq); err != nil {
 		return 0, err

--- a/backend-shared/config/db/operations.go
+++ b/backend-shared/config/db/operations.go
@@ -54,7 +54,7 @@ func (dbq *PostgreSQLDatabaseQueries) CreateOperation(ctx context.Context, obj *
 
 	// Verify the instance exists
 	gei := GitopsEngineInstance{Gitopsengineinstance_id: obj.Instance_id}
-	if err := dbq.UncheckedGetGitopsEngineInstanceById(ctx, &gei); err != nil {
+	if err := dbq.GetGitopsEngineInstanceById(ctx, &gei); err != nil {
 		return fmt.Errorf("unable to retrieve operation's gitops engine instance ID: '%v' %v", obj.Instance_id, err)
 	}
 
@@ -76,7 +76,7 @@ func (dbq *PostgreSQLDatabaseQueries) CreateOperation(ctx context.Context, obj *
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedUpdateOperation(ctx context.Context, obj *Operation) error {
+func (dbq *PostgreSQLDatabaseQueries) UpdateOperation(ctx context.Context, obj *Operation) error {
 
 	if err := validateQueryParamsEntity(obj, dbq); err != nil {
 		return err
@@ -105,7 +105,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedUpdateOperation(ctx context.Conte
 
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedGetOperationById(ctx context.Context, operation *Operation) error {
+func (dbq *PostgreSQLDatabaseQueries) GetOperationById(ctx context.Context, operation *Operation) error {
 
 	if err := validateQueryParamsEntity(operation, dbq); err != nil {
 		return err
@@ -178,7 +178,7 @@ func (dbq *PostgreSQLDatabaseQueries) CheckedGetOperationById(ctx context.Contex
 
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteOperationById(ctx context.Context, id string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteOperationById(ctx context.Context, id string) (int, error) {
 
 	if err := validateQueryParams(id, dbq); err != nil {
 		return 0, err

--- a/backend-shared/config/db/operations.go
+++ b/backend-shared/config/db/operations.go
@@ -139,7 +139,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedGetOperationById(ctx context.Cont
 
 }
 
-func (dbq *PostgreSQLDatabaseQueries) GetOperationById(ctx context.Context, operation *Operation, ownerId string) error {
+func (dbq *PostgreSQLDatabaseQueries) CheckedGetOperationById(ctx context.Context, operation *Operation, ownerId string) error {
 
 	if err := validateQueryParamsEntity(operation, dbq); err != nil {
 		return err
@@ -198,7 +198,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteOperationById(ctx context.C
 	return deleteResult.RowsAffected(), nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) DeleteOperationById(ctx context.Context, id string, ownerId string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) CheckedDeleteOperationById(ctx context.Context, id string, ownerId string) (int, error) {
 
 	if err := validateQueryParams(id, dbq); err != nil {
 		return 0, err

--- a/backend-shared/config/db/queries.go
+++ b/backend-shared/config/db/queries.go
@@ -81,7 +81,7 @@ type DatabaseQueries interface {
 	GetClusterUserByUsername(ctx context.Context, clusterUser *ClusterUser) error
 	CheckedGetGitopsEngineClusterById(ctx context.Context, gitopsEngineCluster *GitopsEngineCluster, ownerId string) error
 	CheckedGetGitopsEngineInstanceById(ctx context.Context, engineInstanceParam *GitopsEngineInstance, ownerId string) error
-	GetManagedEnvironmentById(ctx context.Context, managedEnvironment *ManagedEnvironment, ownerId string) error
+	CheckedGetManagedEnvironmentById(ctx context.Context, managedEnvironment *ManagedEnvironment, ownerId string) error
 	CheckedGetOperationById(ctx context.Context, operation *Operation, ownerId string) error
 	CheckedGetDeploymentToApplicationMappingByDeplId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping, ownerId string) error
 	GetClusterAccessByPrimaryKey(ctx context.Context, obj *ClusterAccess) error
@@ -91,22 +91,22 @@ type DatabaseQueries interface {
 	// I'm still figuring out the difference between unchecked and unsafe: For now, they are very similar.
 	// - In the best case, both are useful and can co-exist.
 	// - In the worst case, the idea of unsafe is fundamentally flawed due to cycles in the table model. - jgwest
-	UncheckedGetGitopsEngineInstanceById(ctx context.Context, engineInstanceParam *GitopsEngineInstance) error
-	UncheckedGetGitopsEngineClusterById(ctx context.Context, gitopsEngineCluster *GitopsEngineCluster) error
-	UncheckedGetManagedEnvironmentById(ctx context.Context, managedEnvironment *ManagedEnvironment) error
+	GetGitopsEngineInstanceById(ctx context.Context, engineInstanceParam *GitopsEngineInstance) error
+	GetGitopsEngineClusterById(ctx context.Context, gitopsEngineCluster *GitopsEngineCluster) error
+	GetManagedEnvironmentById(ctx context.Context, managedEnvironment *ManagedEnvironment) error
 
-	UncheckedDeleteKubernetesResourceToDBResourceMapping(ctx context.Context, obj *KubernetesToDBResourceMapping) (int, error)
-	UncheckedDeleteClusterCredentialsById(ctx context.Context, id string) (int, error)
-	UncheckedDeleteClusterUserById(ctx context.Context, id string) (int, error)
-	UncheckedDeleteGitopsEngineClusterById(ctx context.Context, id string) (int, error)
+	DeleteKubernetesResourceToDBResourceMapping(ctx context.Context, obj *KubernetesToDBResourceMapping) (int, error)
+	DeleteClusterCredentialsById(ctx context.Context, id string) (int, error)
+	DeleteClusterUserById(ctx context.Context, id string) (int, error)
+	DeleteGitopsEngineClusterById(ctx context.Context, id string) (int, error)
 
-	UncheckedGetClusterCredentialsById(ctx context.Context, clusterCreds *ClusterCredentials) error
+	GetClusterCredentialsById(ctx context.Context, clusterCreds *ClusterCredentials) error
 
-	UncheckedGetDeploymentToApplicationMappingByApplicationId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping) error
+	GetDeploymentToApplicationMappingByApplicationId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping) error
 
-	UncheckedDeleteGitopsEngineInstanceById(ctx context.Context, id string) (int, error)
+	DeleteGitopsEngineInstanceById(ctx context.Context, id string) (int, error)
 
-	UncheckedDeleteManagedEnvironmentById(ctx context.Context, id string) (int, error)
+	DeleteManagedEnvironmentById(ctx context.Context, id string) (int, error)
 
 	// List functions return zero or more results. If no results are found (and no errors occurred), an empty slice is set in the result parameter.
 	CheckedListAllGitopsEngineInstancesForGitopsEngineClusterIdAndOwnerId(ctx context.Context, engineClusterId string, ownerId string, gitopsEngineInstancesParam *[]GitopsEngineInstance) error
@@ -140,42 +140,43 @@ type DatabaseQueries interface {
 type ApplicationScopedQueries interface {
 	CloseableQueries
 
-	UncheckedUpdateOperation(ctx context.Context, obj *Operation) error
+	UpdateOperation(ctx context.Context, obj *Operation) error
 
 	CreateOperation(ctx context.Context, obj *Operation, ownerId string) error
-	UncheckedGetOperationById(ctx context.Context, operation *Operation) error
+	GetOperationById(ctx context.Context, operation *Operation) error
 	ListOperationsByResourceIdAndTypeAndOwnerId(ctx context.Context, resourceID string, resourceType string, operations *[]Operation, ownerId string) error
 	CheckedDeleteOperationById(ctx context.Context, id string, ownerId string) (int, error)
-	UncheckedDeleteOperationById(ctx context.Context, id string) (int, error)
+	DeleteOperationById(ctx context.Context, id string) (int, error)
 
-	UncheckedCreateSyncOperation(ctx context.Context, obj *SyncOperation) error
-	UncheckedGetSyncOperationById(ctx context.Context, syncOperation *SyncOperation) error
-	UncheckedDeleteSyncOperationById(ctx context.Context, id string) (int, error)
+	CreateSyncOperation(ctx context.Context, obj *SyncOperation) error
+	GetSyncOperationById(ctx context.Context, syncOperation *SyncOperation) error
+	DeleteSyncOperationById(ctx context.Context, id string) (int, error)
 
-	CreateApplication(ctx context.Context, obj *Application, ownerId string) error
-	UncheckedGetApplicationById(ctx context.Context, application *Application) error
-	UncheckedUpdateApplication(ctx context.Context, obj *Application) error
-	UncheckedDeleteApplicationById(ctx context.Context, id string) (int, error)
+	CreateApplication(ctx context.Context, obj *Application) error
+	CheckedCreateApplication(ctx context.Context, obj *Application, ownerId string) error
+	GetApplicationById(ctx context.Context, application *Application) error
+	UpdateApplication(ctx context.Context, obj *Application) error
+	DeleteApplicationById(ctx context.Context, id string) (int, error)
 	CheckedDeleteApplicationById(ctx context.Context, id string, ownerId string) (int, error)
 
 	CreateAPICRToDatabaseMapping(ctx context.Context, obj *APICRToDatabaseMapping) error
-	UncheckedListAPICRToDatabaseMappingByAPINamespaceAndName(ctx context.Context, apiCRResourceType string, crName string, crNamespace string, crWorkspaceUID string, dbRelationType string, apiCRToDBMappingParam *[]APICRToDatabaseMapping) error
+	ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx context.Context, apiCRResourceType string, crName string, crNamespace string, crWorkspaceUID string, dbRelationType string, apiCRToDBMappingParam *[]APICRToDatabaseMapping) error
 	GetDatabaseMappingForAPICR(ctx context.Context, obj *APICRToDatabaseMapping) error
-	UncheckedDeleteAPICRToDatabaseMapping(ctx context.Context, obj *APICRToDatabaseMapping) (int, error)
+	DeleteAPICRToDatabaseMapping(ctx context.Context, obj *APICRToDatabaseMapping) (int, error)
 
 	CreateDeploymentToApplicationMapping(ctx context.Context, obj *DeploymentToApplicationMapping) error
-	UncheckedGetDeploymentToApplicationMappingByDeplId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping) error
-	UncheckedListDeploymentToApplicationMappingByNamespaceAndName(ctx context.Context, deploymentName string, deploymentNamespace string, workspaceUID string, deplToAppMappingParam *[]DeploymentToApplicationMapping) error
-	UncheckedListDeploymentToApplicationMappingByWorkspaceUID(ctx context.Context, workspaceUID string, deplToAppMappingParam *[]DeploymentToApplicationMapping) error
-	UncheckedDeleteDeploymentToApplicationMappingByDeplId(ctx context.Context, id string) (int, error)
-	UncheckedDeleteDeploymentToApplicationMappingByNamespaceAndName(ctx context.Context, deploymentName string, deploymentNamespace string, workspaceUID string) (int, error)
+	GetDeploymentToApplicationMappingByDeplId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping) error
+	ListDeploymentToApplicationMappingByNamespaceAndName(ctx context.Context, deploymentName string, deploymentNamespace string, workspaceUID string, deplToAppMappingParam *[]DeploymentToApplicationMapping) error
+	ListDeploymentToApplicationMappingByWorkspaceUID(ctx context.Context, workspaceUID string, deplToAppMappingParam *[]DeploymentToApplicationMapping) error
+	DeleteDeploymentToApplicationMappingByDeplId(ctx context.Context, id string) (int, error)
+	DeleteDeploymentToApplicationMappingByNamespaceAndName(ctx context.Context, deploymentName string, deploymentNamespace string, workspaceUID string) (int, error)
 
 	UpdateSyncOperationRemoveApplicationField(ctx context.Context, applicationId string) (int, error)
 
-	UncheckedGetApplicationStateById(ctx context.Context, obj *ApplicationState) error
-	UncheckedCreateApplicationState(ctx context.Context, obj *ApplicationState) error
-	UncheckedUpdateApplicationState(ctx context.Context, obj *ApplicationState) error
-	UncheckedDeleteApplicationStateById(ctx context.Context, id string) (int, error)
+	GetApplicationStateById(ctx context.Context, obj *ApplicationState) error
+	CreateApplicationState(ctx context.Context, obj *ApplicationState) error
+	UpdateApplicationState(ctx context.Context, obj *ApplicationState) error
+	DeleteApplicationStateById(ctx context.Context, id string) (int, error)
 }
 
 type CloseableQueries interface {

--- a/backend-shared/config/db/syncoperation.go
+++ b/backend-shared/config/db/syncoperation.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedGetSyncOperationById(ctx context.Context, syncOperation *SyncOperation) error {
+func (dbq *PostgreSQLDatabaseQueries) GetSyncOperationById(ctx context.Context, syncOperation *SyncOperation) error {
 
 	if err := validateQueryParamsEntity(syncOperation, dbq); err != nil {
 		return err
@@ -22,15 +22,15 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedGetSyncOperationById(ctx context.
 		Context(ctx).
 		Select(); err != nil {
 
-		return fmt.Errorf("error on retrieving UncheckedGetSyncOperationById: %v", err)
+		return fmt.Errorf("error on retrieving GetSyncOperationById: %v", err)
 	}
 
 	if len(dbResults) >= 2 {
-		return fmt.Errorf("multiple results returned from UncheckedGetSyncOperationById")
+		return fmt.Errorf("multiple results returned from GetSyncOperationById")
 	}
 
 	if len(dbResults) == 0 {
-		return NewResultNotFoundError("no results found for UncheckedGetSyncOperationById")
+		return NewResultNotFoundError("no results found for GetSyncOperationById")
 	}
 
 	*syncOperation = dbResults[0]
@@ -38,7 +38,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedGetSyncOperationById(ctx context.
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedCreateSyncOperation(ctx context.Context, obj *SyncOperation) error {
+func (dbq *PostgreSQLDatabaseQueries) CreateSyncOperation(ctx context.Context, obj *SyncOperation) error {
 
 	if err := validateQueryParamsEntity(obj, dbq); err != nil {
 		return err
@@ -76,7 +76,7 @@ func (dbq *PostgreSQLDatabaseQueries) UncheckedCreateSyncOperation(ctx context.C
 
 }
 
-func (dbq *PostgreSQLDatabaseQueries) UncheckedDeleteSyncOperationById(ctx context.Context, id string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteSyncOperationById(ctx context.Context, id string) (int, error) {
 
 	if err := validateQueryParams(id, dbq); err != nil {
 		return 0, err
@@ -131,6 +131,6 @@ func (obj *SyncOperation) DisposeAppScoped(ctx context.Context, dbq ApplicationS
 		return fmt.Errorf("missing database interface in syncoperation dispose")
 	}
 
-	_, err := dbq.UncheckedDeleteSyncOperationById(ctx, obj.SyncOperation_id)
+	_, err := dbq.DeleteSyncOperationById(ctx, obj.SyncOperation_id)
 	return err
 }

--- a/backend-shared/config/db/types_test.go
+++ b/backend-shared/config/db/types_test.go
@@ -41,7 +41,7 @@ func testSetup(t *testing.T) {
 	for _, operation := range operations {
 
 		if strings.HasPrefix(operation.Operation_id, "test-") {
-			rowsAffected, err := dbq.DeleteOperationById(ctx, operation.Operation_id, operation.Operation_owner_user_id)
+			rowsAffected, err := dbq.CheckedDeleteOperationById(ctx, operation.Operation_id, operation.Operation_owner_user_id)
 			assert.Equal(t, rowsAffected, 1)
 			assert.NoError(t, err)
 		}
@@ -239,7 +239,7 @@ func TestCreateApplication(t *testing.T) {
 		return
 	}
 
-	rowsAffected, err := dbq.DeleteApplicationById(ctx, application.Application_id, clusterAccess.Clusteraccess_user_id)
+	rowsAffected, err := dbq.CheckedDeleteApplicationById(ctx, application.Application_id, clusterAccess.Clusteraccess_user_id)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -270,7 +270,7 @@ func TestDeploymentToApplicationMapping(t *testing.T) {
 	defer dbq.CloseDatabase()
 
 	mapping := DeploymentToApplicationMapping{}
-	err = dbq.GetDeploymentToApplicationMappingByDeplId(ctx, &mapping, "")
+	err = dbq.CheckedGetDeploymentToApplicationMappingByDeplId(ctx, &mapping, "")
 	fmt.Println(err, mapping)
 
 }
@@ -293,7 +293,7 @@ func TestGitopsEngineInstanceAndCluster(t *testing.T) {
 	}
 
 	retrievedGitopsEngineCluster := &GitopsEngineCluster{Gitopsenginecluster_id: gitopsEngineCluster.Gitopsenginecluster_id}
-	if err = dbq.GetGitopsEngineClusterById(ctx, retrievedGitopsEngineCluster, testClusterUser.Clusteruser_id); !assert.NoError(t, err) {
+	if err = dbq.CheckedGetGitopsEngineClusterById(ctx, retrievedGitopsEngineCluster, testClusterUser.Clusteruser_id); !assert.NoError(t, err) {
 		return
 	}
 	if !assert.Equal(t, &gitopsEngineCluster, &retrievedGitopsEngineCluster) {
@@ -310,7 +310,7 @@ func TestGitopsEngineInstanceAndCluster(t *testing.T) {
 
 	// get should return not found, after the delete
 	gitopsEngineInstance = &GitopsEngineInstance{Gitopsengineinstance_id: gitopsEngineCluster.Gitopsenginecluster_id}
-	if err = dbq.GetGitopsEngineInstanceById(ctx, gitopsEngineInstance, testClusterUser.Clusteruser_id); !assert.Error(t, err) {
+	if err = dbq.CheckedGetGitopsEngineInstanceById(ctx, gitopsEngineInstance, testClusterUser.Clusteruser_id); !assert.Error(t, err) {
 		return
 	}
 	assert.True(t, IsResultNotFoundError(err))
@@ -320,7 +320,7 @@ func TestGitopsEngineInstanceAndCluster(t *testing.T) {
 	assert.NoError(t, err)
 
 	retrievedGitopsEngineCluster = &GitopsEngineCluster{Gitopsenginecluster_id: gitopsEngineCluster.Gitopsenginecluster_id}
-	err = dbq.GetGitopsEngineClusterById(ctx, retrievedGitopsEngineCluster, testClusterUser.Clusteruser_id)
+	err = dbq.CheckedGetGitopsEngineClusterById(ctx, retrievedGitopsEngineCluster, testClusterUser.Clusteruser_id)
 	assert.Error(t, err)
 	assert.True(t, IsResultNotFoundError(err))
 }
@@ -397,20 +397,20 @@ func TestOperation(t *testing.T) {
 	assert.NoError(t, err)
 
 	result := Operation{Operation_id: operation.Operation_id}
-	err = dbq.GetOperationById(ctx, &result, operation.Operation_owner_user_id)
+	err = dbq.CheckedGetOperationById(ctx, &result, operation.Operation_owner_user_id)
 	assert.NoError(t, err)
 	assert.Equal(t, result.Operation_id, operation.Operation_id)
 
 	result = Operation{Operation_id: operation.Operation_id}
-	err = dbq.GetOperationById(ctx, &result, "another-user")
+	err = dbq.CheckedGetOperationById(ctx, &result, "another-user")
 	if !assert.Error(t, err) {
 		return
 	}
 	assert.True(t, IsResultNotFoundError(err))
-	rowsAffected, _ := dbq.DeleteOperationById(ctx, operation.Operation_id, "another-user")
+	rowsAffected, _ := dbq.CheckedDeleteOperationById(ctx, operation.Operation_id, "another-user")
 	assert.Equal(t, rowsAffected, 0)
 
-	rowsAffected, err = dbq.DeleteOperationById(ctx, operation.Operation_id, operation.Operation_owner_user_id)
+	rowsAffected, err = dbq.CheckedDeleteOperationById(ctx, operation.Operation_id, operation.Operation_owner_user_id)
 	assert.Equal(t, rowsAffected, 1)
 	assert.NoError(t, err)
 }
@@ -545,7 +545,7 @@ func TestClusterCredentials(t *testing.T) {
 	retrievedClusterCredentials = &ClusterCredentials{
 		Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
 	}
-	err = dbq.GetClusterCredentialsById(ctx, retrievedClusterCredentials, testClusterUser.Clusteruser_id)
+	err = dbq.CheckedGetClusterCredentialsById(ctx, retrievedClusterCredentials, testClusterUser.Clusteruser_id)
 	if !assert.NoError(t, err) ||
 		!assert.NotNil(t, retrievedClusterCredentials) {
 		return

--- a/backend-shared/config/db/types_test.go
+++ b/backend-shared/config/db/types_test.go
@@ -27,7 +27,7 @@ func testSetup(t *testing.T) {
 	assert.NoError(t, err)
 	for _, applicationState := range applicationStates {
 		if strings.HasPrefix(applicationState.Applicationstate_application_id, "test-") {
-			rowsAffected, err := dbq.UncheckedDeleteApplicationStateById(ctx, applicationState.Applicationstate_application_id)
+			rowsAffected, err := dbq.DeleteApplicationStateById(ctx, applicationState.Applicationstate_application_id)
 			assert.NoError(t, err)
 			if err == nil {
 				assert.Equal(t, rowsAffected, 1)
@@ -52,7 +52,7 @@ func testSetup(t *testing.T) {
 	assert.NoError(t, err)
 	for _, application := range applications {
 		if strings.HasPrefix(application.Application_id, "test-") {
-			rowsAffected, err := dbq.UncheckedDeleteApplicationById(ctx, application.Application_id)
+			rowsAffected, err := dbq.DeleteApplicationById(ctx, application.Application_id)
 			assert.Equal(t, rowsAffected, 1)
 			assert.NoError(t, err)
 		}
@@ -79,7 +79,7 @@ func testSetup(t *testing.T) {
 	for _, gitopsEngineInstance := range engineInstances {
 		if strings.HasPrefix(gitopsEngineInstance.Gitopsengineinstance_id, "test-") {
 
-			rowsAffected, err := dbq.UncheckedDeleteGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id)
+			rowsAffected, err := dbq.DeleteGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id)
 
 			if !assert.NoError(t, err) {
 				return
@@ -95,7 +95,7 @@ func testSetup(t *testing.T) {
 	assert.NoError(t, err)
 	for _, engineCluster := range engineClusters {
 		if strings.HasPrefix(engineCluster.Gitopsenginecluster_id, "test-") {
-			rowsAffected, err := dbq.UncheckedDeleteGitopsEngineClusterById(ctx, engineCluster.Gitopsenginecluster_id)
+			rowsAffected, err := dbq.DeleteGitopsEngineClusterById(ctx, engineCluster.Gitopsenginecluster_id)
 			assert.NoError(t, err)
 			if err == nil {
 				assert.Equal(t, rowsAffected, 1)
@@ -108,7 +108,7 @@ func testSetup(t *testing.T) {
 	assert.NoError(t, err)
 	for _, managedEnvironment := range managedEnvironments {
 		if strings.HasPrefix(managedEnvironment.Managedenvironment_id, "test-") {
-			rowsAffected, err := dbq.UncheckedDeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
+			rowsAffected, err := dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
 			assert.Equal(t, rowsAffected, 1)
 			assert.NoError(t, err)
 		}
@@ -119,7 +119,7 @@ func testSetup(t *testing.T) {
 	assert.NoError(t, err)
 	for _, clusterCredential := range clusterCredentials {
 		if strings.HasPrefix(clusterCredential.Clustercredentials_cred_id, "test-") {
-			rowsAffected, err := dbq.UncheckedDeleteClusterCredentialsById(ctx, clusterCredential.Clustercredentials_cred_id)
+			rowsAffected, err := dbq.DeleteClusterCredentialsById(ctx, clusterCredential.Clustercredentials_cred_id)
 			assert.NoError(t, err)
 			if err == nil {
 				assert.Equal(t, rowsAffected, 1)
@@ -134,7 +134,7 @@ func testSetup(t *testing.T) {
 
 	for _, user := range clusterUsers {
 		if strings.HasPrefix(user.Clusteruser_id, "test-") {
-			rowsAffected, err := dbq.UncheckedDeleteClusterUserById(ctx, (user.Clusteruser_id))
+			rowsAffected, err := dbq.DeleteClusterUserById(ctx, (user.Clusteruser_id))
 			assert.Equal(t, rowsAffected, 1)
 			assert.NoError(t, err)
 		}
@@ -224,14 +224,14 @@ func TestCreateApplication(t *testing.T) {
 		Managed_environment_id:  managedEnvironment.Managedenvironment_id,
 	}
 
-	err = dbq.CreateApplication(ctx, application, clusterAccess.Clusteraccess_user_id)
+	err = dbq.CheckedCreateApplication(ctx, application, clusterAccess.Clusteraccess_user_id)
 	if !assert.NoError(t, err) {
 		return
 	}
 
 	retrievedApplication := Application{Application_id: application.Application_id}
 
-	err = dbq.UncheckedGetApplicationById(ctx, &retrievedApplication)
+	err = dbq.GetApplicationById(ctx, &retrievedApplication)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -248,7 +248,7 @@ func TestCreateApplication(t *testing.T) {
 	}
 
 	retrievedApplication = Application{Application_id: application.Application_id}
-	err = dbq.UncheckedGetApplicationById(ctx, &retrievedApplication)
+	err = dbq.GetApplicationById(ctx, &retrievedApplication)
 	if !assert.Error(t, err) {
 		return
 	}
@@ -304,7 +304,7 @@ func TestGitopsEngineInstanceAndCluster(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, rowsAffected, 1)
 
-	rowsAffected, err = dbq.UncheckedDeleteGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id)
+	rowsAffected, err = dbq.DeleteGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id)
 	assert.NoError(t, err)
 	assert.Equal(t, rowsAffected, 1)
 
@@ -315,7 +315,7 @@ func TestGitopsEngineInstanceAndCluster(t *testing.T) {
 	}
 	assert.True(t, IsResultNotFoundError(err))
 
-	rowsAffected, err = dbq.UncheckedDeleteGitopsEngineClusterById(ctx, gitopsEngineCluster.Gitopsenginecluster_id)
+	rowsAffected, err = dbq.DeleteGitopsEngineClusterById(ctx, gitopsEngineCluster.Gitopsenginecluster_id)
 	assert.Equal(t, rowsAffected, 1)
 	assert.NoError(t, err)
 
@@ -342,14 +342,14 @@ func TestManagedEnvironment(t *testing.T) {
 	}
 
 	result := ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
-	err = dbq.GetManagedEnvironmentById(ctx, &result, testClusterUser.Clusteruser_id)
+	err = dbq.CheckedGetManagedEnvironmentById(ctx, &result, testClusterUser.Clusteruser_id)
 	if !assert.NoError(t, err) {
 		return
 	}
 	assert.Equal(t, managedEnvironment.Name, result.Name)
 
 	result = ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
-	err = dbq.GetManagedEnvironmentById(ctx, &result, "another-user")
+	err = dbq.CheckedGetManagedEnvironmentById(ctx, &result, "another-user")
 	assert.NotNil(t, err)
 	// deleting from another user should fail
 	assert.True(t, IsResultNotFoundError(err))
@@ -358,12 +358,12 @@ func TestManagedEnvironment(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, rowsAffected, 1)
 
-	rowsAffected, err = dbq.UncheckedDeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
+	rowsAffected, err = dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
 	assert.NoError(t, err)
 	assert.Equal(t, rowsAffected, 1)
 
 	result = ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
-	err = dbq.GetManagedEnvironmentById(ctx, &result, testClusterUser.Clusteruser_id)
+	err = dbq.CheckedGetManagedEnvironmentById(ctx, &result, testClusterUser.Clusteruser_id)
 	assert.NotNil(t, err)
 	assert.True(t, IsResultNotFoundError(err))
 
@@ -439,7 +439,7 @@ func TestClusterUser(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, clusterUser.User_name, retrievedClusterUser.User_name)
 
-	rowsAffected, err := dbq.UncheckedDeleteClusterUserById(ctx, clusterUser.Clusteruser_id)
+	rowsAffected, err := dbq.DeleteClusterUserById(ctx, clusterUser.Clusteruser_id)
 	assert.Equal(t, rowsAffected, 1)
 	assert.NoError(t, err)
 
@@ -533,7 +533,7 @@ func TestClusterCredentials(t *testing.T) {
 	retrievedClusterCredentials := &ClusterCredentials{
 		Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
 	}
-	err = dbq.UncheckedGetClusterCredentialsById(ctx, retrievedClusterCredentials)
+	err = dbq.GetClusterCredentialsById(ctx, retrievedClusterCredentials)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -559,19 +559,19 @@ func TestClusterCredentials(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, rowsAffected, 1)
 
-	rowsAffected, err = dbq.UncheckedDeleteGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id)
+	rowsAffected, err = dbq.DeleteGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id)
 	assert.NoError(t, err)
 	assert.Equal(t, rowsAffected, 1)
 
-	rowsAffected, err = dbq.UncheckedDeleteGitopsEngineClusterById(ctx, gitopsEngineCluster.Gitopsenginecluster_id)
+	rowsAffected, err = dbq.DeleteGitopsEngineClusterById(ctx, gitopsEngineCluster.Gitopsenginecluster_id)
 	assert.NoError(t, err)
 	assert.Equal(t, rowsAffected, 1)
 
-	rowsAffected, err = dbq.UncheckedDeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
+	rowsAffected, err = dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
 	assert.NoError(t, err)
 	assert.Equal(t, rowsAffected, 1)
 
-	rowsAffected, err = dbq.UncheckedDeleteClusterCredentialsById(ctx, clusterCredentials.Clustercredentials_cred_id)
+	rowsAffected, err = dbq.DeleteClusterCredentialsById(ctx, clusterCredentials.Clustercredentials_cred_id)
 	// add delete options for other tables table as well!
 	assert.NoError(t, err)
 	assert.Equal(t, rowsAffected, 1)
@@ -579,7 +579,7 @@ func TestClusterCredentials(t *testing.T) {
 	retrievedClusterCredentials = &ClusterCredentials{
 		Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
 	}
-	err = dbq.UncheckedGetClusterCredentialsById(ctx, retrievedClusterCredentials)
+	err = dbq.GetClusterCredentialsById(ctx, retrievedClusterCredentials)
 	if !assert.Error(t, err) {
 		return
 	}

--- a/backend-shared/util/utils.go
+++ b/backend-shared/util/utils.go
@@ -35,7 +35,7 @@ func GetGitOpsEngineSingleInstanceNamespace() string {
 	return DefaultGitOpsEngineSingleInstanceNamespace
 }
 
-func UncheckedGetOrCreateManagedEnvironmentByNamespaceUID(ctx context.Context, workspaceNamespace v1.Namespace,
+func GetOrCreateManagedEnvironmentByNamespaceUID(ctx context.Context, workspaceNamespace v1.Namespace,
 	dbq db.DatabaseQueries, log logr.Logger) (*db.ManagedEnvironment, error) {
 
 	workspaceNamespaceUID := string(workspaceNamespace.UID)
@@ -55,7 +55,7 @@ func UncheckedGetOrCreateManagedEnvironmentByNamespaceUID(ctx context.Context, w
 
 		// Retrieve the managed environment database entry for this resource
 		managedEnvironment := db.ManagedEnvironment{Managedenvironment_id: string(dbResourceMapping.DBRelationKey)}
-		err = dbq.UncheckedGetManagedEnvironmentById(ctx, &managedEnvironment)
+		err = dbq.GetManagedEnvironmentById(ctx, &managedEnvironment)
 
 		if err == nil {
 			// Success: mapping exists, and so does the environment it points to
@@ -71,7 +71,7 @@ func UncheckedGetOrCreateManagedEnvironmentByNamespaceUID(ctx context.Context, w
 		// mapping pointed to.
 
 		// Since the managed environment doesn't exist, delete the mapping; it will be recreated below.
-		if _, err := dbq.UncheckedDeleteKubernetesResourceToDBResourceMapping(ctx, dbResourceMapping); err != nil {
+		if _, err := dbq.DeleteKubernetesResourceToDBResourceMapping(ctx, dbResourceMapping); err != nil {
 			return nil, fmt.Errorf("unable to delete K8s resource to DB mapping: %v", dbResourceMapping)
 		}
 
@@ -117,14 +117,14 @@ func UncheckedGetOrCreateManagedEnvironmentByNamespaceUID(ctx context.Context, w
 	return &managedEnvironment, nil
 }
 
-// UncheckedGetOrCreateGitopsEngineInstanceByInstanceNamespaceUID gets (or creates it if it doesn't exist) a GitOpsEngineInstance database entry that
+// GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID gets (or creates it if it doesn't exist) a GitOpsEngineInstance database entry that
 // corresponds to an GitOps engine instance running on the cluster.
-func UncheckedGetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.Context,
+func GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.Context,
 	gitopsEngineNamespace v1.Namespace, kubesystemNamespaceUID string,
 	dbq db.DatabaseQueries, log logr.Logger) (*db.GitopsEngineInstance, *db.GitopsEngineCluster, error) {
 
 	// First create the GitOpsEngine cluster if needed; this will be used to create the instance.
-	gitopsEngineCluster, err := UncheckedGetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx, kubesystemNamespaceUID, dbq, log)
+	gitopsEngineCluster, err := GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx, kubesystemNamespaceUID, dbq, log)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create GitOpsEngineCluster for '%v', error: '%v'", kubesystemNamespaceUID, err)
 	}
@@ -157,7 +157,7 @@ func UncheckedGetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.
 			Gitopsengineinstance_id: dbResourceMapping.DBRelationKey,
 		}
 
-		if err := dbq.UncheckedGetGitopsEngineInstanceById(ctx, gitopsEngineInstance); err != nil {
+		if err := dbq.GetGitopsEngineInstanceById(ctx, gitopsEngineInstance); err != nil {
 			if !db.IsResultNotFoundError(err) {
 				return nil, nil, err
 			}
@@ -166,7 +166,7 @@ func UncheckedGetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.
 
 			// We have found a mapping without the corresponding mapped entity, so delete the mapping.
 			// (We will recreate the mapping below)
-			if _, err := dbq.UncheckedDeleteKubernetesResourceToDBResourceMapping(ctx, dbResourceMapping); err != nil {
+			if _, err := dbq.DeleteKubernetesResourceToDBResourceMapping(ctx, dbResourceMapping); err != nil {
 				return nil, nil, err
 			}
 
@@ -229,7 +229,7 @@ func UncheckedGetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.
 		return gitopsEngineInstance, gitopsEngineCluster, nil
 
 	} else {
-		return nil, nil, fmt.Errorf("unexpected state in UncheckedGetOrCreateGitopsEngineInstanceByInstanceNamespaceUID")
+		return nil, nil, fmt.Errorf("unexpected state in GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID")
 	}
 
 }
@@ -265,7 +265,7 @@ func GetGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context, kubesys
 			Gitopsenginecluster_id: dbResourceMapping.DBRelationKey,
 		}
 
-		if err := dbq.UncheckedGetGitopsEngineClusterById(ctx, gitopsEngineCluster); err != nil {
+		if err := dbq.GetGitopsEngineClusterById(ctx, gitopsEngineCluster); err != nil {
 			if !db.IsResultNotFoundError(err) {
 				return nil, err
 			}
@@ -279,11 +279,11 @@ func GetGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context, kubesys
 
 }
 
-// UncheckedGetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID gets (or creates it if it doesn't exist) a GitOpsEngineCluster
+// GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID gets (or creates it if it doesn't exist) a GitOpsEngineCluster
 // database entry that corresponds to an GitOps engine cluster.
 //
 // In order to determine which cluster we are on, we use the UID of the 'kube-system' namespace.
-func UncheckedGetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context, kubesystemNamespaceUID string, dbq db.DatabaseQueries, log logr.Logger) (*db.GitopsEngineCluster, error) {
+func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context, kubesystemNamespaceUID string, dbq db.DatabaseQueries, log logr.Logger) (*db.GitopsEngineCluster, error) {
 
 	var gitopsEngineCluster *db.GitopsEngineCluster
 
@@ -313,7 +313,7 @@ func UncheckedGetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context
 			Gitopsenginecluster_id: dbResourceMapping.DBRelationKey,
 		}
 
-		if err := dbq.UncheckedGetGitopsEngineClusterById(ctx, gitopsEngineCluster); err != nil {
+		if err := dbq.GetGitopsEngineClusterById(ctx, gitopsEngineCluster); err != nil {
 			if !db.IsResultNotFoundError(err) {
 				return nil, err
 			}
@@ -322,7 +322,7 @@ func UncheckedGetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context
 
 			// We have found a mapping without the corresponding mapped entity, so delete the mapping.
 			// (We will recreate the mapping below)
-			if _, err := dbq.UncheckedDeleteKubernetesResourceToDBResourceMapping(ctx, dbResourceMapping); err != nil {
+			if _, err := dbq.DeleteKubernetesResourceToDBResourceMapping(ctx, dbResourceMapping); err != nil {
 				return nil, err
 			}
 
@@ -393,11 +393,11 @@ func UncheckedGetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context
 
 }
 
-func UncheckedGetOrCreateDeploymentToApplicationMapping(ctx context.Context, createDeplToAppMapping *db.DeploymentToApplicationMapping, dbq db.ApplicationScopedQueries, log logr.Logger) error {
+func GetOrCreateDeploymentToApplicationMapping(ctx context.Context, createDeplToAppMapping *db.DeploymentToApplicationMapping, dbq db.ApplicationScopedQueries, log logr.Logger) error {
 
-	if err := dbq.UncheckedGetDeploymentToApplicationMappingByDeplId(ctx, createDeplToAppMapping); err != nil {
+	if err := dbq.GetDeploymentToApplicationMappingByDeplId(ctx, createDeplToAppMapping); err != nil {
 		if !db.IsResultNotFoundError(err) {
-			logErr := fmt.Errorf("unable to get obj in UncheckedGetOrDeploymentToApplicationMapping: %v", err)
+			logErr := fmt.Errorf("unable to get obj in GetOrDeploymentToApplicationMapping: %v", err)
 			log.Error(logErr, "unable to get deplToApp mapping", "createDeplToAppMapping", createDeplToAppMapping)
 			return logErr
 		}
@@ -408,7 +408,7 @@ func UncheckedGetOrCreateDeploymentToApplicationMapping(ctx context.Context, cre
 	}
 
 	// Ensure that there isn't an old depltoappmapping hanging around with matching name/namespace, before we create a new one.
-	if _, err := dbq.UncheckedDeleteDeploymentToApplicationMappingByNamespaceAndName(ctx,
+	if _, err := dbq.DeleteDeploymentToApplicationMappingByNamespaceAndName(ctx,
 		createDeplToAppMapping.DeploymentName,
 		createDeplToAppMapping.DeploymentNamespace,
 		createDeplToAppMapping.WorkspaceUID); err != nil {

--- a/backend-shared/util/utils_test.go
+++ b/backend-shared/util/utils_test.go
@@ -32,7 +32,7 @@ func TestUncheckedGetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(t *testi
 
 	// kubesystemNamespaceUID := "fake-uid"
 
-	// engineInstance, engineCluster, err := UncheckedGetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(context.Background(), gitopsEngineNamespace,
+	// engineInstance, engineCluster, err := GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(context.Background(), gitopsEngineNamespace,
 	// 	kubesystemNamespaceUID, dbq, logr.FromContext(context.Background()))
 
 	// t.Logf("%v", engineInstance)

--- a/backend/eventloop/application_event_runner.go
+++ b/backend/eventloop/application_event_runner.go
@@ -487,7 +487,7 @@ func (a *applicationEventLoopRunner_Action) cleanupOldSyncDBEntry(ctx context.Co
 
 			log := log.WithValues("operationId", operationId)
 
-			rowsDeleted, err := dbQueries.DeleteOperationById(ctx, operationId, clusterUser.Clusteruser_id)
+			rowsDeleted, err := dbQueries.CheckedDeleteOperationById(ctx, operationId, clusterUser.Clusteruser_id)
 			if err != nil {
 				log.Error(err, "unable to delete old operation")
 				return err

--- a/backend/eventloop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_runner_test.go
@@ -119,7 +119,7 @@ func TestApplicationEventLoopRunner_handleDeploymentModified(t *testing.T) {
 	{
 		var appMappings []db.DeploymentToApplicationMapping
 
-		err = dbQueries.UncheckedListDeploymentToApplicationMappingByNamespaceAndName(context.Background(), gitopsDepl.Name, gitopsDepl.Namespace, workspaceID, &appMappings)
+		err = dbQueries.ListDeploymentToApplicationMappingByNamespaceAndName(context.Background(), gitopsDepl.Name, gitopsDepl.Namespace, workspaceID, &appMappings)
 		assert.Nil(t, err)
 
 		if !assert.True(t, len(appMappings) == 1) {
@@ -160,7 +160,7 @@ func TestApplicationEventLoopRunner_handleDeploymentModified(t *testing.T) {
 	managedEnvironment := db.ManagedEnvironment{
 		Managedenvironment_id: application.Managed_environment_id,
 	}
-	err = dbQueries.GetManagedEnvironmentById(ctx, &managedEnvironment, clusterUser.Clusteruser_id)
+	err = dbQueries.CheckedGetManagedEnvironmentById(ctx, &managedEnvironment, clusterUser.Clusteruser_id)
 	assert.Nil(t, err)
 
 	// Delete the GitOpsDepl and verify that the corresponding DB entries are removed -------------
@@ -174,13 +174,13 @@ func TestApplicationEventLoopRunner_handleDeploymentModified(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Application should no longer exist
-	err = dbQueries.UncheckedGetApplicationById(ctx, &application)
+	err = dbQueries.GetApplicationById(ctx, &application)
 	assert.NotNil(t, err)
 	assert.True(t, db.IsResultNotFoundError(err))
 
 	// DeploymentToApplicationMapping should be removed, too
 	var appMappings []db.DeploymentToApplicationMapping
-	err = dbQueries.UncheckedListDeploymentToApplicationMappingByNamespaceAndName(context.Background(), gitopsDepl.Name, gitopsDepl.Namespace, workspaceID, &appMappings)
+	err = dbQueries.ListDeploymentToApplicationMappingByNamespaceAndName(context.Background(), gitopsDepl.Name, gitopsDepl.Namespace, workspaceID, &appMappings)
 	assert.Nil(t, err)
 	assert.True(t, len(appMappings) == 0)
 

--- a/backend/eventloop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_runner_test.go
@@ -142,7 +142,7 @@ func TestApplicationEventLoopRunner_handleDeploymentModified(t *testing.T) {
 		Application_id: deplToAppMapping.Application_id,
 	}
 
-	if err := dbQueries.GetApplicationById(context.Background(), &application, clusterUser.Clusteruser_id); err != nil {
+	if err := dbQueries.CheckedGetApplicationById(context.Background(), &application, clusterUser.Clusteruser_id); err != nil {
 		assert.Nil(t, err)
 		return
 	}
@@ -151,7 +151,7 @@ func TestApplicationEventLoopRunner_handleDeploymentModified(t *testing.T) {
 		Gitopsengineinstance_id: application.Engine_instance_inst_id,
 	}
 
-	err = dbQueries.GetGitopsEngineInstanceById(context.Background(), &gitopsEngineInstance, clusterUser.Clusteruser_id)
+	err = dbQueries.CheckedGetGitopsEngineInstanceById(context.Background(), &gitopsEngineInstance, clusterUser.Clusteruser_id)
 	if !assert.Nil(t, err) {
 		return
 	}
@@ -185,7 +185,7 @@ func TestApplicationEventLoopRunner_handleDeploymentModified(t *testing.T) {
 	assert.True(t, len(appMappings) == 0)
 
 	// GitopsEngine instance should still be reachable
-	err = dbQueries.GetGitopsEngineInstanceById(context.Background(), &gitopsEngineInstance, clusterUser.Clusteruser_id)
+	err = dbQueries.CheckedGetGitopsEngineInstanceById(context.Background(), &gitopsEngineInstance, clusterUser.Clusteruser_id)
 	if !assert.Nil(t, err) {
 		return
 	}

--- a/backend/eventloop/preprocess_event_loop.go
+++ b/backend/eventloop/preprocess_event_loop.go
@@ -187,7 +187,7 @@ func (task *processEventTask) processEvent(ctx context.Context, newEvent eventLo
 
 			// 1) Go from GitOpsDeploymentSyncRun CR -> Sync Operation DB table, by searching
 			// for the CR's namespace/name/workspace ID tuple.
-			if err := dbQueries.UncheckedListAPICRToDatabaseMappingByAPINamespaceAndName(ctx,
+			if err := dbQueries.ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx,
 				db.APICRToDatabaseMapping_ResourceType_GitOpsDeploymentSyncRun,
 				newEvent.request.Name, newEvent.request.Namespace, newEvent.workspaceID,
 				db.APICRToDatabaseMapping_DBRelationType_SyncOperation, &items); err != nil {
@@ -207,7 +207,7 @@ func (task *processEventTask) processEvent(ctx context.Context, newEvent eventLo
 				syncOperation := &db.SyncOperation{
 					SyncOperation_id: items[0].DBRelationKey,
 				}
-				if err := dbQueries.UncheckedGetSyncOperationById(ctx, syncOperation); err != nil {
+				if err := dbQueries.GetSyncOperationById(ctx, syncOperation); err != nil {
 
 					if !db.IsResultNotFoundError(err) {
 						log.Error(err, "unable to retrieve sync operation for gitopsdeplsyncrun")
@@ -231,7 +231,7 @@ func (task *processEventTask) processEvent(ctx context.Context, newEvent eventLo
 				}
 
 				// 4) Finally, we have found the DeploymentToApplicationMapping, which contains the gitops cr uid
-				if err := dbQueries.UncheckedGetDeploymentToApplicationMappingByApplicationId(ctx, &dtam); err != nil {
+				if err := dbQueries.GetDeploymentToApplicationMappingByApplicationId(ctx, &dtam); err != nil {
 
 					if !db.IsResultNotFoundError(err) {
 						log.Error(err, "unable to retrieve dtam for application id: "+dtam.Application_id)
@@ -265,7 +265,7 @@ func (task *processEventTask) processEvent(ctx context.Context, newEvent eventLo
 
 			// Look for a corresponding DeploymentoApplicationMapping for the GitOpsDeployment CR in the namespace
 			var items []db.DeploymentToApplicationMapping
-			if err := dbQueries.UncheckedListDeploymentToApplicationMappingByNamespaceAndName(ctx, newEvent.request.Name, newEvent.request.Namespace,
+			if err := dbQueries.ListDeploymentToApplicationMappingByNamespaceAndName(ctx, newEvent.request.Name, newEvent.request.Namespace,
 				newEvent.workspaceID, &items); err != nil {
 				log.Error(err, "unable to retrieve gitopsdeployment by namespacename in processEvent")
 				return true
@@ -428,7 +428,7 @@ func getGitOpsDeplIdFromDatabaseUsingNameAndNamespace(ctx context.Context, newEv
 
 		var items []db.DeploymentToApplicationMapping
 
-		if err := dbQueries.UncheckedListDeploymentToApplicationMappingByNamespaceAndName(ctx, newEvent.request.Name, newEvent.request.Namespace, newEvent.workspaceID, &items); err != nil {
+		if err := dbQueries.ListDeploymentToApplicationMappingByNamespaceAndName(ctx, newEvent.request.Name, newEvent.request.Namespace, newEvent.workspaceID, &items); err != nil {
 			log.Error(err, "unable to list depltoappmapping in getGitOpsDeplFromDatabaseUsingNameAndNamespace")
 			return "", err
 		}
@@ -448,7 +448,7 @@ func getGitOpsDeplIdFromDatabaseUsingNameAndNamespace(ctx context.Context, newEv
 
 		// 1) Go from GitOpsDeploymentSyncRun CR -> Sync Operation DB table, by searching
 		// by the SyncRun CR's namespace/name/workspace ID tuple.
-		if err := dbQueries.UncheckedListAPICRToDatabaseMappingByAPINamespaceAndName(ctx,
+		if err := dbQueries.ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx,
 			db.APICRToDatabaseMapping_ResourceType_GitOpsDeploymentSyncRun,
 			newEvent.request.Name, newEvent.request.Namespace, newEvent.workspaceID,
 			db.APICRToDatabaseMapping_DBRelationType_SyncOperation, &items); err != nil {
@@ -467,7 +467,7 @@ func getGitOpsDeplIdFromDatabaseUsingNameAndNamespace(ctx context.Context, newEv
 			syncOperation := &db.SyncOperation{
 				SyncOperation_id: items[0].DBRelationKey,
 			}
-			if err := dbQueries.UncheckedGetSyncOperationById(ctx, syncOperation); err != nil {
+			if err := dbQueries.GetSyncOperationById(ctx, syncOperation); err != nil {
 
 				if db.IsResultNotFoundError(err) {
 					log.V(sharedutil.LogLevel_Warn).Info("syncoperation id from apicr to db mapping didn't exist", "operationID", syncOperation.SyncOperation_id)
@@ -489,7 +489,7 @@ func getGitOpsDeplIdFromDatabaseUsingNameAndNamespace(ctx context.Context, newEv
 			dtam := db.DeploymentToApplicationMapping{
 				Application_id: syncOperation.Application_id,
 			}
-			if err := dbQueries.UncheckedGetDeploymentToApplicationMappingByApplicationId(ctx, &dtam); err != nil {
+			if err := dbQueries.GetDeploymentToApplicationMappingByApplicationId(ctx, &dtam); err != nil {
 
 				if db.IsResultNotFoundError(err) {
 					log.V(sharedutil.LogLevel_Warn).Info("dtam not found when using application id from sync operation", "application_id", dtam.Application_id)
@@ -565,7 +565,7 @@ func getGitOpsDeplIdFromSyncRunCR(ctx context.Context, gitopsSyncRunUID string, 
 	syncOperation := &db.SyncOperation{
 		SyncOperation_id: cr.DBRelationKey,
 	}
-	if err := dbQueries.UncheckedGetSyncOperationById(ctx, syncOperation); err != nil {
+	if err := dbQueries.GetSyncOperationById(ctx, syncOperation); err != nil {
 
 		if db.IsResultNotFoundError(err) {
 			return "", nil
@@ -584,7 +584,7 @@ func getGitOpsDeplIdFromSyncRunCR(ctx context.Context, gitopsSyncRunUID string, 
 	dtam := db.DeploymentToApplicationMapping{
 		Application_id: syncOperation.Application_id,
 	}
-	if err := dbQueries.UncheckedGetDeploymentToApplicationMappingByApplicationId(ctx, &dtam); err != nil {
+	if err := dbQueries.GetDeploymentToApplicationMappingByApplicationId(ctx, &dtam); err != nil {
 
 		if db.IsResultNotFoundError(err) {
 			return "", nil

--- a/backend/eventloop/sharedresourceloop.go
+++ b/backend/eventloop/sharedresourceloop.go
@@ -270,7 +270,7 @@ func internalProcessMessage_GetGitopsEngineInstanceById(ctx context.Context, id 
 		Gitopsengineinstance_id: id,
 	}
 
-	err := dbq.UncheckedGetGitopsEngineInstanceById(ctx, &gitopsEngineInstance)
+	err := dbq.GetGitopsEngineInstanceById(ctx, &gitopsEngineInstance)
 
 	return &gitopsEngineInstance, err
 }
@@ -308,7 +308,7 @@ func internalProcessMessage_GetOrCreateSharedResources(ctx context.Context, work
 		return nil, nil, nil, nil, fmt.Errorf("unable to retrieve cluster user in processMessage, '%s': %v", string(workspaceNamespace.UID), err)
 	}
 
-	managedEnv, err := sharedutil.UncheckedGetOrCreateManagedEnvironmentByNamespaceUID(ctx, workspaceNamespace, dbQueries, log)
+	managedEnv, err := sharedutil.GetOrCreateManagedEnvironmentByNamespaceUID(ctx, workspaceNamespace, dbQueries, log)
 	if err != nil {
 		log.Error(err, "unable to get or created managed env on deployment modified event")
 		return nil, nil, nil, nil, err
@@ -358,7 +358,7 @@ func internalUncheckedDetermineGitOpsEngineInstanceForNewApplication(ctx context
 		return nil, fmt.Errorf("unable to retrieve kube-system namespace in determineGitOpsEngineInstanceForNewApplication")
 	}
 
-	gitopsEngineInstance, _, err := sharedutil.UncheckedGetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx, *namespace, string(kubeSystemNamespace.UID), dbq, log)
+	gitopsEngineInstance, _, err := sharedutil.GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx, *namespace, string(kubeSystemNamespace.UID), dbq, log)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get or create engine instance for new application: %v", err)
 	}

--- a/backend/main.go
+++ b/backend/main.go
@@ -194,7 +194,7 @@ func createPrimaryGitOpsEngineInstance(k8sclient client.Client, log logr.Logger)
 		},
 	}
 
-	gitopsEngineInstance, _, err := sharedutil.UncheckedGetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx, *namespace, kubeSystemNamespace.Name, dbQueries, log)
+	gitopsEngineInstance, _, err := sharedutil.GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx, *namespace, kubeSystemNamespace.Name, dbQueries, log)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func createPrimaryGitOpsEngineInstance(k8sclient client.Client, log logr.Logger)
 		},
 	}
 
-	managedEnv, err := sharedutil.UncheckedGetOrCreateManagedEnvironmentByNamespaceUID(ctx, *gitopsLocalWorkspaceNamespace, dbQueries, log)
+	managedEnv, err := sharedutil.GetOrCreateManagedEnvironmentByNamespaceUID(ctx, *gitopsLocalWorkspaceNamespace, dbQueries, log)
 	if err != nil {
 		return err
 	}

--- a/cluster-agent/controllers/argoproj.io/application_controller.go
+++ b/cluster-agent/controllers/argoproj.io/application_controller.go
@@ -77,7 +77,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	} else {
 		applicationDB.Application_id = databaseID
 	}
-	if err := databaseQueries.UncheckedGetApplicationById(ctx, applicationDB); err != nil {
+	if err := databaseQueries.GetApplicationById(ctx, applicationDB); err != nil {
 		if db.IsResultNotFoundError(err) {
 
 			log.V(sharedutil.LogLevel_Warn).Info("Application CR '" + req.NamespacedName.String() + "' missing corresponding database entry: " + applicationDB.Application_id)
@@ -105,7 +105,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	applicationState := &db.ApplicationState{
 		Applicationstate_application_id: applicationDB.Application_id,
 	}
-	if err := databaseQueries.UncheckedGetApplicationStateById(ctx, applicationState); err != nil {
+	if err := databaseQueries.GetApplicationStateById(ctx, applicationState); err != nil {
 		if db.IsResultNotFoundError(err) {
 
 			// 3a) ApplicationState doesn't exist: so create it
@@ -114,7 +114,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			applicationState.Sync_Status = string(app.Status.Sync.Status)
 			sanitizeHealthAndStatus(applicationState)
 
-			if err := databaseQueries.UncheckedCreateApplicationState(ctx, applicationState); err != nil {
+			if err := databaseQueries.CreateApplicationState(ctx, applicationState); err != nil {
 				log.Error(err, "unexpected error on writing new application state")
 				return ctrl.Result{}, err
 			}
@@ -133,7 +133,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	applicationState.Sync_Status = string(app.Status.Sync.Status)
 	sanitizeHealthAndStatus(applicationState)
 
-	if err := databaseQueries.UncheckedUpdateApplicationState(ctx, applicationState); err != nil {
+	if err := databaseQueries.UpdateApplicationState(ctx, applicationState); err != nil {
 		log.Error(err, "unexpected error on updating existing application state")
 		return ctrl.Result{}, err
 	}

--- a/cluster-agent/controllers/managed-gitops/eventloop/eventloop.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/eventloop.go
@@ -121,7 +121,7 @@ func (task *processEventTask) PerformTask(taskContext context.Context) (bool, er
 			dbOperation.Human_readable_state = err.Error()
 		}
 
-		if err := dbQueries.UncheckedUpdateOperation(taskContext, dbOperation); err != nil {
+		if err := dbQueries.UpdateOperation(taskContext, dbOperation); err != nil {
 			task.log.Error(err, "unable to update operation state", "operation", dbOperation.Operation_id)
 			return true, err
 		}
@@ -160,7 +160,7 @@ func (task *processEventTask) internalPerformTask(taskContext context.Context, d
 	dbOperation := db.Operation{
 		Operation_id: operationCR.Spec.OperationID,
 	}
-	if err := dbQueries.UncheckedGetOperationById(taskContext, &dbOperation); err != nil {
+	if err := dbQueries.GetOperationById(taskContext, &dbOperation); err != nil {
 
 		if db.IsResultNotFoundError(err) {
 			// no corresponding db operation, so no work to do
@@ -182,7 +182,7 @@ func (task *processEventTask) internalPerformTask(taskContext context.Context, d
 	dbGitopsEngineInstance := &db.GitopsEngineInstance{
 		Gitopsengineinstance_id: dbOperation.Instance_id,
 	}
-	if err := dbQueries.UncheckedGetGitopsEngineInstanceById(taskContext, dbGitopsEngineInstance); err != nil {
+	if err := dbQueries.GetGitopsEngineInstanceById(taskContext, dbGitopsEngineInstance); err != nil {
 
 		if db.IsResultNotFoundError(err) {
 			// log as warning
@@ -269,7 +269,7 @@ func processOperation_Application(ctx context.Context, dbOperation db.Operation,
 		Application_id: dbOperation.Resource_id,
 	}
 
-	if err := dbQueries.UncheckedGetApplicationById(ctx, dbApplication); err != nil {
+	if err := dbQueries.GetApplicationById(ctx, dbApplication); err != nil {
 
 		if db.IsResultNotFoundError(err) {
 			// The application db entry no longer exists, so delete the corresponding application CR


### PR DESCRIPTION
This PR:
- Refactors the `Unchecked*` functions, removing the `Unchecked` prefix. Thus calling the 'unchecked' method should now be the default way of accessing the database.
- Refactors the previously unprefixed functions, adding the `Checked` prefix. 
- Updates the comment at the top of queries.go to reflect the philosophy change around these queries.

## Why?

At the moment, we have a concept of checked/unchecked database methods in `queries.go`:
- *Checked*: Before a database query is performed, we check if the user has permission to issue this request.
- *Unchecked*: We do not perform the above check.

While this idea of 'check the database before it is used' works in principle, in practice I expect it to have a heavy performance impact, especially relative to the benefits it provides. We can probably better handle these same checks at a higher level, and with less impact.

This idea of checked/unchecked queries also increase the cognitive load of creating new database tables, and writing new code that interacts with the database.

My hope is that, in the future, we can re-examine our use of these, and incrementally integrate them into our codebase.

But for now, we should prefer unchecked functions, when writing new code, and I have marked the 'checked' functions as experimental only.