### PR TITLE
Update database schema for manual sync

### DIFF
--- a/backend-shared/config/db/syncoperation.go
+++ b/backend-shared/config/db/syncoperation.go
@@ -5,6 +5,11 @@ import (
 	"fmt"
 )
 
+const (
+	SyncOperation_DesiredState_Running    = "Running"
+	SyncOperation_DesiredState_Terminated = "Terminated"
+)
+
 func (dbq *PostgreSQLDatabaseQueries) GetSyncOperationById(ctx context.Context, syncOperation *SyncOperation) error {
 
 	if err := validateQueryParamsEntity(syncOperation, dbq); err != nil {
@@ -59,7 +64,8 @@ func (dbq *PostgreSQLDatabaseQueries) CreateSyncOperation(ctx context.Context, o
 	if err := isEmptyValues("CreateSyncOperation",
 		"Application_id", obj.Application_id,
 		"DeploymentNameField", obj.DeploymentNameField,
-		"Revision", obj.Revision); err != nil {
+		"Revision", obj.Revision,
+		"DesiredState", obj.DesiredState); err != nil {
 		return err
 	}
 

--- a/backend-shared/config/db/types.go
+++ b/backend-shared/config/db/types.go
@@ -344,6 +344,8 @@ type SyncOperation struct {
 	DeploymentNameField string `pg:"deployment_name"`
 
 	Revision string `pg:"revision"`
+
+	DesiredState string `pg:"desired_state"`
 }
 
 // TODO: GITOPS-1678 - DEBT - Add comment.

--- a/backend/eventloop/application_event_runner.go
+++ b/backend/eventloop/application_event_runner.go
@@ -429,8 +429,7 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleSyncRun
 		// TODO: GITOPS-1466 - STUB - need to implement support for sync operation in cluster agent
 		log.Info("STUB: need to implement sync on cluster side")
 
-		dbQueries.DeleteSyncOperationById(ctx, syncOperation.SyncOperation_id)
-		if err != nil {
+		if _, err := dbQueries.DeleteSyncOperationById(ctx, syncOperation.SyncOperation_id); err != nil {
 			log.Error(err, "could not delete sync operation, when resource was deleted", "namespace", dbutil.GetGitOpsEngineSingleInstanceNamespace())
 			return false, err
 		}

--- a/backend/eventloop/preprocess_event_loop.go
+++ b/backend/eventloop/preprocess_event_loop.go
@@ -68,10 +68,8 @@ func preprocessEventLoopRouter(input chan eventLoopEvent, nextStep *controllerEv
 
 	dbQueries, err := db.NewProductionPostgresDBQueries(false)
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err, "SEVERE: preProcessEventLoopRouter exiting before startup")
 		return
-		// TODO: GITOPS-1678 - DEBT - shouldn't return here
-		// It returns here in case of wrong credentials (authentication failure with database)
 	}
 
 	for {

--- a/backend/eventloop/sharedresourceloop.go
+++ b/backend/eventloop/sharedresourceloop.go
@@ -185,8 +185,7 @@ func internalSharedResourceEventLoop(inputChan chan sharedResourceLoopMessage) {
 	log := log.FromContext(ctx)
 	dbQueries, err := db.NewProductionPostgresDBQueries(false)
 	if err != nil {
-		fmt.Println(err)
-		// TODO: GITOPS-1678 - DEBT - Log me, and probably handle better
+		log.Error(err, "SEVERE: internalSharedResourceEventLoop exiting before startup")
 		return
 	}
 

--- a/db-schema.sql
+++ b/db-schema.sql
@@ -388,6 +388,10 @@ CREATE TABLE SyncOperation (
 	-- The 'revisionID'  field of the GitOpsDeploymentSyncRun CR
 	revision VARCHAR(256) NOT NULL,
 
+	-- Whether we want the SyncOperation to continue running, or to be terminated.
+	-- values: Running, Terminated
+	desired_state VARCHAR(16) NOT NULL,	
+
 	seq_id serial
 
 );

--- a/docs/manifests.md
+++ b/docs/manifests.md
@@ -37,7 +37,7 @@ manifests directory
 └── routes.yaml # Currently not used
 ```
 
-These are automatically deployed when the `make deploy-cluster-agent-rbac` and `deploy-backend-rbac` targets are tiggered as dependency of their respective targets.
+These are automatically deployed when the `make deploy-cluster-agent-rbac` and `deploy-backend-rbac` targets are triggered as dependency of their respective targets.
 
 ## CRDs
 

--- a/docs/run.md
+++ b/docs/run.md
@@ -2,7 +2,7 @@
 
 ## Current status
 
-Given you have [installed](./install.md) Gitops Managed Service into your Kubernetes cluster, you can start using it by applying a CR.
+Given you have [installed](./install.md) GitOps Managed Service into your Kubernetes cluster, you can start using it by applying a CR.
 This can be either a `GitOpsDeployment` or a `GitOpsDeploymentSyncRun` to trigger the `backend` operator.
 
 Here's a sample:
@@ -26,7 +26,7 @@ In the current development phase, this is the expected output:
 kubectl -n gitops logs managed-gitops-backend-service-77c9648b5b-hgkt4 -c manager -f
 ```
 
-```json
+```
 2022-01-31T11:23:22.945Z	DEBUG	preprocess event loop router received event:	{"workspaceID": "815fa61b-0c05-437e-9f72-401e7cefecfd", "name": "gitopsdeployment-sample", "namespace": "default", "event": "[DeploymentModified] default/gitopsdeployment-sample/GitOpsDeployment, for workspace '815fa61b-0c05-437e-9f72-401e7cefecfd', gitopsdepluid: ''"}
 2022-01-31T11:23:22.952Z	DEBUG	Emitting event to workspace event loop	{"workspaceID": "815fa61b-0c05-437e-9f72-401e7cefecfd", "name": "gitopsdeployment-sample", "namespace": "default", "event": "[DeploymentModified] default/gitopsdeployment-sample/GitOpsDeployment, for workspace '815fa61b-0c05-437e-9f72-401e7cefecfd', gitopsdepluid: '9a4a6a74-900b-4101-b9a2-4bdf6d72060a'"}
 2022-01-31T11:23:22.953Z	DEBUG	eventLoop received event	{"event": "[DeploymentModified] default/gitopsdeployment-sample/GitOpsDeployment, for workspace '815fa61b-0c05-437e-9f72-401e7cefecfd', gitopsdepluid: '9a4a6a74-900b-4101-b9a2-4bdf6d72060a'", "workspace": "815fa61b-0c05-437e-9f72-401e7cefecfd"}
@@ -58,7 +58,7 @@ kubectl -n gitops logs managed-gitops-clusteragent-service-85d4db6968-gl98l -c m
 
 It crashes:
 
-```json
+```
 2022-01-31T11:23:55.057Z	INFO	controller-runtime.manager.controller.operation	Operation event seen in reconciler: argocd/operation-8b25bf97-a9d7-4508-94cf-560b319a46c2	{"reconciler group": "managed-gitops.redhat.com", "reconciler kind": "Operation", "name": "operation-8b25bf97-a9d7-4508-94cf-560b319a46c2", "namespace": "argocd"}
 SELECT "op"."operation_id", "op"."seq_id", "op"."instance_id", "op"."resource_id", "op"."operation_owner_user_id", "op"."resource_type", "op"."created_on", "op"."last_state_update", "op"."state", "op"."human_readable_state" FROM "operation" AS "op" WHERE (operation_id = '8b25bf97-a9d7-4508-94cf-560b319a46c2')
 2022-01-31T11:23:55.072Z	INFO	controller-runtime.manager.controller.operation	Operation event seen in reconciler: argocd/operation-8b25bf97-a9d7-4508-94cf-560b319a46c2	{"reconciler group": "managed-gitops.redhat.com", "reconciler kind": "Operation", "name": "operation-8b25bf97-a9d7-4508-94cf-560b319a46c2", "namespace": "argocd"}
@@ -89,7 +89,7 @@ spec:
 
 The cluster-agent should wake up, detect the change, attempt to connect to the database (which should succeed), and throw a database error indicating that there was no Operation table entry with the given id.
 
-```json
+```
 2022-01-31T11:25:13.951Z	INFO	controller-runtime.manager.controller.operation	Operation event seen in reconciler: default/operation-sample	{"reconciler group": "managed-gitops.redhat.com", "reconciler kind": "Operation", "name": "operation-sample", "namespace": "default"}
 SELECT "op"."operation_id", "op"."seq_id", "op"."instance_id", "op"."resource_id", "op"."operation_owner_user_id", "op"."resource_type", "op"."created_on", "op"."last_state_update", "op"."state", "op"."human_readable_state" FROM "operation" AS "op" WHERE (operation_id = 'fake-uuid!!!!')
 

--- a/manifests/database-init/job.yaml
+++ b/manifests/database-init/job.yaml
@@ -1,13 +1,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  # generateName: apply-gitops-service-db-schema-
   name: apply-gitops-service-db-schema
   namespace: gitops
-  annotations:
-    argocd.argoproj.io/hook: Sync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+#  annotations:
+#    argocd.argoproj.io/hook: PreSync
+#    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
-  ttlSecondsAfterFinished: 600
+  ttlSecondsAfterFinished: 3600
+
   template:
     spec:
       volumes:

--- a/manifests/staging-package/generate-staging-package.sh
+++ b/manifests/staging-package/generate-staging-package.sh
@@ -25,8 +25,8 @@ cp -R $ROOTPATH/manifests/cluster-agent-rbac/*.yaml $TARGET_DIR
 cp -R $ROOTPATH/manifests/postgresql-staging/postgresql-staging.yaml $TARGET_DIR
 
 # NOTE: ensure you update the COMMON_IMAGE with the image to deploy to the staging cluster
-ARGO_CD_NAMESPACE=gitops-service-argocd COMMON_IMAGE="quay.io/jgwest-redhat/gitops-service:latest" envsubst < $ROOTPATH/manifests/managed-gitops-backend-deployment.yaml > $TARGET_DIR/managed-gitops-backend-deployment.yaml
-ARGO_CD_NAMESPACE=gitops-service-argocd COMMON_IMAGE="quay.io/jgwest-redhat/gitops-service:latest" envsubst < $ROOTPATH/manifests/managed-gitops-clusteragent-deployment.yaml > $TARGET_DIR/managed-gitops-clusteragent-deployment.yaml
+ARGO_CD_NAMESPACE=gitops-service-argocd COMMON_IMAGE="quay.io/redhat-appstudio/gitops-service:239fd296f557024f0382c06d1a736183849808a1" envsubst < $ROOTPATH/manifests/managed-gitops-backend-deployment.yaml > $TARGET_DIR/managed-gitops-backend-deployment.yaml
+ARGO_CD_NAMESPACE=gitops-service-argocd COMMON_IMAGE="quay.io/redhat-appstudio/gitops-service:239fd296f557024f0382c06d1a736183849808a1" envsubst < $ROOTPATH/manifests/managed-gitops-clusteragent-deployment.yaml > $TARGET_DIR/managed-gitops-clusteragent-deployment.yaml
 
 cp -R $ROOTPATH/backend/config/crd/bases/managed-gitops.redhat.com_gitopsdeployments.yaml $TARGET_DIR
 cp -R $ROOTPATH/backend/config/crd/bases/managed-gitops.redhat.com_gitopsdeploymentsyncruns.yaml $TARGET_DIR


### PR DESCRIPTION
This PR:
- Adds `desired_state` to SyncOperation
- Add logic to handle deletion of a GitOpsDeploymentSyncRun CR; deletion of this API CR should cancel any sync operations that are running in Argo CD (but this sync cancellation logic will be in a separate PR).

This is a small chunk of a larger piece of work that I am still working on as part of manual sync. Because manual sync was depriotized in favour of automated sync, for this sprint, I am pushing this small piece as a PR so it doesn't get lost/out-of-sync with the rest of the codebase.
