### PR TITLE
Refactor event loop tests and switch to Ginkgo

### DIFF
--- a/backend/eventloop/application_event_loop/application_event_loop_test.go
+++ b/backend/eventloop/application_event_loop/application_event_loop_test.go
@@ -1,0 +1,64 @@
+package application_event_loop
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-appstudio/managed-gitops/backend/apis/managed-gitops/v1alpha1"
+	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/eventlooptypes"
+	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/shared_resource_loop"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("ApplicationEventLoop Test", func() {
+
+	Context("Application Event Loop test", func() {
+
+		It("should forward messages received on the input channel, to the runner", func() {
+
+			mockApplicationEventLoopRunnerFactory := mockApplicationEventLoopRunnerFactory{
+				mockChannel: make(chan *eventlooptypes.EventLoopEvent),
+			}
+
+			inputChan := startApplicationEventQueueLoopWithFactory("", "", nil, &mockApplicationEventLoopRunnerFactory)
+
+			inputChan <- eventlooptypes.EventLoopMessage{
+				MessageType: eventlooptypes.ApplicationEventLoopMessageType_Event,
+				Event: &eventlooptypes.EventLoopEvent{
+					EventType:               eventlooptypes.DeploymentModified,
+					Request:                 reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "", Name: ""}},
+					Client:                  nil,
+					ReqResource:             v1alpha1.GitOpsDeploymentTypeName,
+					AssociatedGitopsDeplUID: "",
+					WorkspaceID:             "",
+				},
+				ShutdownSignalled: false,
+			}
+
+			outputEvent := <-mockApplicationEventLoopRunnerFactory.mockChannel
+			Expect(outputEvent).NotTo(BeNil())
+			Expect(outputEvent.EventType).To(Equal(outputEvent.EventType))
+			Expect(outputEvent.Request).To(Equal(outputEvent.Request))
+			Expect(outputEvent.ReqResource).To(Equal(outputEvent.ReqResource))
+			Expect(outputEvent.AssociatedGitopsDeplUID).To(Equal(outputEvent.AssociatedGitopsDeplUID))
+			Expect(outputEvent.WorkspaceID).To(Equal(outputEvent.WorkspaceID))
+
+		})
+	})
+
+})
+
+// mockApplicationEventLoopRunnerFactory which returns a pre-provided channel, rather than starting a new goroutine.
+type mockApplicationEventLoopRunnerFactory struct {
+	mockChannel chan *eventlooptypes.EventLoopEvent
+}
+
+var _ applicationEventRunnerFactory = &mockApplicationEventLoopRunnerFactory{}
+
+func (fact *mockApplicationEventLoopRunnerFactory) createNewApplicationEventLoopRunner(informWorkCompleteChan chan eventlooptypes.EventLoopMessage,
+	sharedResourceEventLoop *shared_resource_loop.SharedResourceEventLoop,
+	gitopsDeplUID string, workspaceID string, debugContext string) chan *eventlooptypes.EventLoopEvent {
+
+	return fact.mockChannel
+
+}

--- a/backend/eventloop/application_event_loop/application_event_runner.go
+++ b/backend/eventloop/application_event_loop/application_event_runner.go
@@ -62,7 +62,7 @@ import (
 // For more information on how events are distributed between goroutines by event loop, see:
 // https://miro.com/app/board/o9J_lgiqJAs=/?moveToWidget=3458764514216218600&cot=14
 
-func newApplicationEventLoopRunner(informWorkCompleteChan chan eventlooptypes.EventLoopMessage,
+func startNewApplicationEventLoopRunner(informWorkCompleteChan chan eventlooptypes.EventLoopMessage,
 	sharedResourceEventLoop *shared_resource_loop.SharedResourceEventLoop,
 	gitopsDeplUID string, workspaceID string, debugContext string) chan *eventlooptypes.EventLoopEvent {
 

--- a/backend/eventloop/application_event_loop/application_event_runner.go
+++ b/backend/eventloop/application_event_loop/application_event_runner.go
@@ -144,7 +144,7 @@ func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent
 					signalledShutdown, _, _, err = action.applicationEventRunner_handleDeploymentModified(ctx, scopedDBQueries)
 
 					// Get the GitOpsDeployment object from k8s, so we can update it if necessary
-					gitopsDepl, clientError := getMatchingGitOpsDeployment(newEvent.Request.Name, newEvent.Request.Namespace, newEvent.Client)
+					gitopsDepl, clientError := getMatchingGitOpsDeployment(ctx, newEvent.Request.Name, newEvent.Request.Namespace, newEvent.Client)
 					if clientError != nil {
 						return fmt.Errorf("couldn't fetch the GitOpsDeployment instance: %v", clientError)
 					}

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -105,6 +105,8 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleDeploym
 	log.V(sharedutil.LogLevel_Debug).Info("workspacerEventLoopRunner_handleDeploymentModified processing event",
 		"gitopsDeploymentExists", gitopsDeploymentCRExists, "deplToAppMapExists", deplToAppMapExistsInDB)
 
+	// Next, the work that we need below depends on how the CR differs from the DB entry
+
 	if !gitopsDeploymentCRExists && !deplToAppMapExistsInDB {
 		// if neither exists, our work is done
 		return false, nil, nil, nil

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -598,7 +598,7 @@ func newGitOpsDeploymentAdapter(gitopsDeployment *managedgitopsv1alpha1.GitOpsDe
 }
 
 // getMatchingGitOpsDeployment returns an updated instance of GitOpsDeployment obj from Kubernetes
-func getMatchingGitOpsDeployment(name, namespace string, client client.Client) (*managedgitopsv1alpha1.GitOpsDeployment, error) {
+func getMatchingGitOpsDeployment(ctx context.Context, name, namespace string, client client.Client) (*managedgitopsv1alpha1.GitOpsDeployment, error) {
 	gitopsDepl := &managedgitopsv1alpha1.GitOpsDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -606,8 +606,7 @@ func getMatchingGitOpsDeployment(name, namespace string, client client.Client) (
 		},
 	}
 
-	// TODO: This function should take a context
-	err := client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, gitopsDepl)
+	err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, gitopsDepl)
 
 	if err != nil {
 		return &managedgitopsv1alpha1.GitOpsDeployment{}, err

--- a/backend/eventloop/application_event_loop/application_eventloop_suite_test.go
+++ b/backend/eventloop/application_event_loop/application_eventloop_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestEventloop_application_event_runner(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "EventLoop Suite")
+	RunSpecs(t, "Application Event Loop Suite")
 }

--- a/backend/eventloop/controller_event_loop_test.go
+++ b/backend/eventloop/controller_event_loop_test.go
@@ -1,0 +1,55 @@
+package eventloop
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-appstudio/managed-gitops/backend/apis/managed-gitops/v1alpha1"
+	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/eventlooptypes"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("Controller Event Loop Test", func() {
+
+	Context("Controller event loop responds to channel events", func() {
+
+		It("Should pass events received on input channel to mock workspace event loop router", func() {
+
+			mockOutputChannelFactory := &mockWorkspaceEventLoopFactory{
+				mockChannel: make(chan eventlooptypes.EventLoopMessage),
+			}
+
+			loop := newControllerEventLoopWithFactory(mockOutputChannelFactory)
+
+			loop.eventLoopInputChannel <- eventlooptypes.EventLoopEvent{
+				EventType: eventlooptypes.DeploymentModified,
+				Request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: "",
+						Name:      "",
+					},
+				},
+				Client:                  nil,
+				ReqResource:             v1alpha1.GitOpsDeploymentTypeName,
+				AssociatedGitopsDeplUID: "",
+				WorkspaceID:             "",
+			}
+
+			resp := <-mockOutputChannelFactory.mockChannel
+			Expect(resp).NotTo(BeNil())
+
+		})
+	})
+})
+
+// mockWorkspaceEventLoopFactory is a mock of workspaceEventLoopRouterFactory
+type mockWorkspaceEventLoopFactory struct {
+	mockChannel chan eventlooptypes.EventLoopMessage
+}
+
+var _ workspaceEventLoopRouterFactory = &mockWorkspaceEventLoopFactory{}
+
+func (cetf *mockWorkspaceEventLoopFactory) startWorkspaceEventLoopRouter(workspaceID string) chan eventlooptypes.EventLoopMessage {
+	// Rather than starting a new workspace event loop, instead just return a pre-provided channel
+	return cetf.mockChannel
+}

--- a/backend/eventloop/event_loop_suite_test.go
+++ b/backend/eventloop/event_loop_suite_test.go
@@ -1,0 +1,13 @@
+package eventloop
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEventLoop(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Event Loop Tests")
+}

--- a/backend/eventloop/eventlooptypes/types_test_util.go
+++ b/backend/eventloop/eventlooptypes/types_test_util.go
@@ -15,7 +15,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-func GenericTestSetup(t *testing.T) (*runtime.Scheme, *v1.Namespace, *v1.Namespace, *v1.Namespace) {
+func GenericTestSetupForTestingT(t *testing.T) (*runtime.Scheme, *v1.Namespace, *v1.Namespace, *v1.Namespace) {
+
+	scheme, argocdNamespace, kubesystemNamespace, workspace, err := GenericTestSetup()
+	assert.NoError(t, err)
+
+	return scheme, argocdNamespace, kubesystemNamespace, workspace
+
+}
+
+func GenericTestSetup() (*runtime.Scheme, *v1.Namespace, *v1.Namespace, *v1.Namespace, error) {
 	scheme := runtime.NewScheme()
 
 	opts := zap.Options{
@@ -24,11 +33,18 @@ func GenericTestSetup(t *testing.T) (*runtime.Scheme, *v1.Namespace, *v1.Namespa
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	err := managedgitopsv1alpha1.AddToScheme(scheme)
-	assert.Nil(t, err)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
 	err = operation.AddToScheme(scheme)
-	assert.Nil(t, err)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
 	err = v1.AddToScheme(scheme)
-	assert.Nil(t, err)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
 
 	argocdNamespace := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -57,6 +73,6 @@ func GenericTestSetup(t *testing.T) (*runtime.Scheme, *v1.Namespace, *v1.Namespa
 		Spec: v1.NamespaceSpec{},
 	}
 
-	return scheme, argocdNamespace, kubesystemNamespace, workspace
+	return scheme, argocdNamespace, kubesystemNamespace, workspace, nil
 
 }

--- a/backend/eventloop/preprocess_event_loop.go
+++ b/backend/eventloop/preprocess_event_loop.go
@@ -395,7 +395,6 @@ func emitEventForExistingResource(gitopsDeplUID string, newEvent eventlooptypes.
 
 	// If it matches value from client, use provided id
 	if gitopsDeplUID == string(resource.GetUID()) {
-		// TODO: This logic seems wrong. (only works for gitopsdepl)
 		newEvent.AssociatedGitopsDeplUID = gitopsDeplUID
 		emitEvent(newEvent, nextStep, "existing resource, but value matches cr", log)
 		return

--- a/backend/eventloop/preprocess_event_loop_test.go
+++ b/backend/eventloop/preprocess_event_loop_test.go
@@ -3,12 +3,13 @@ package eventloop
 import (
 	"context"
 	"fmt"
-	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend/apis/managed-gitops/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/eventlooptypes"
-	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -16,76 +17,90 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func TestPreprocessEventLoop(t *testing.T) {
+var _ = Describe("Preprocess Event Loop Test", func() {
 
-	ctx := context.Background()
+	Context("Preprocess event loop responds to channel events", func() {
 
-	scheme, argocdNamespace, kubesystemNamespace, workspace := eventlooptypes.GenericTestSetup(t)
+		It("Should pass events received on input channel to application event loop", func() {
 
-	gitopsDepl := &managedgitopsv1alpha1.GitOpsDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-gitops-depl",
-			Namespace: workspace.Name,
-			UID:       uuid.NewUUID(),
-		},
-	}
+			ctx := context.Background()
 
-	informer := sharedutil.ListEventReceiver{}
+			scheme, argocdNamespace, kubesystemNamespace, workspace, err := eventlooptypes.GenericTestSetup()
+			Expect(err).To(BeNil())
 
-	k8sClientOuter := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gitopsDepl, workspace, argocdNamespace, kubesystemNamespace).Build()
-	k8sClient := &sharedutil.ProxyClient{
-		InnerClient: k8sClientOuter,
-		Informer:    &informer,
-	}
+			gitopsDepl := &managedgitopsv1alpha1.GitOpsDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-gitops-depl",
+					Namespace: workspace.Name,
+					UID:       uuid.NewUUID(),
+				},
+			}
 
-	fakeEventLoopChannel := make(chan eventlooptypes.EventLoopEvent)
-	fakeEventLoop := controllerEventLoop{
-		eventLoopInputChannel: fakeEventLoopChannel,
-	}
+			informer := sharedutil.ListEventReceiver{}
 
-	channel := make(chan eventlooptypes.EventLoopEvent)
+			k8sClientOuter := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gitopsDepl, workspace, argocdNamespace, kubesystemNamespace).Build()
+			k8sClient := &sharedutil.ProxyClient{
+				InnerClient: k8sClientOuter,
+				Informer:    &informer,
+			}
 
-	go preprocessEventLoopRouter(channel, &fakeEventLoop)
+			fakeEventLoopChannel := make(chan eventlooptypes.EventLoopEvent)
+			fakeEventLoop := controllerEventLoop{
+				eventLoopInputChannel: fakeEventLoopChannel,
+			}
 
-	event := eventlooptypes.EventLoopEvent{
-		EventType: eventlooptypes.DeploymentModified,
-		Request: reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: gitopsDepl.Namespace,
-				Name:      gitopsDepl.Name,
-			},
-		},
-		ReqResource: managedgitopsv1alpha1.GitOpsDeploymentTypeName,
-		Client:      k8sClient,
-		WorkspaceID: eventlooptypes.GetWorkspaceIDFromNamespaceID(*workspace),
-	}
+			channel := make(chan eventlooptypes.EventLoopEvent)
 
-	fmt.Println("sent event")
-	channel <- event
+			go preprocessEventLoopRouter(channel, &fakeEventLoop)
 
-	fmt.Println("waiting for response")
-	fmt.Printf("response: %v\n", <-fakeEventLoop.eventLoopInputChannel)
+			event := eventlooptypes.EventLoopEvent{
+				EventType: eventlooptypes.DeploymentModified,
+				Request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: gitopsDepl.Namespace,
+						Name:      gitopsDepl.Name,
+					},
+				},
+				ReqResource: managedgitopsv1alpha1.GitOpsDeploymentTypeName,
+				Client:      k8sClient,
+				WorkspaceID: eventlooptypes.GetWorkspaceIDFromNamespaceID(*workspace),
+			}
 
-	if err := k8sClient.Delete(ctx, gitopsDepl); err != nil {
-		assert.Nil(t, err)
-	}
+			fmt.Println("Sending event", event)
+			channel <- event
 
-	event = eventlooptypes.EventLoopEvent{
-		EventType: eventlooptypes.DeploymentModified,
-		Request: reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: gitopsDepl.Namespace,
-				Name:      gitopsDepl.Name,
-			},
-		},
-		ReqResource: managedgitopsv1alpha1.GitOpsDeploymentTypeName,
-		Client:      k8sClient,
-		WorkspaceID: eventlooptypes.GetWorkspaceIDFromNamespaceID(*workspace),
-	}
+			fmt.Println("Waiting for response")
+			response := <-fakeEventLoop.eventLoopInputChannel
+			Expect(response.Request).Should(Equal(event.Request))
+			Expect(response.EventType).Should(Equal(event.EventType))
+			Expect(response.WorkspaceID).Should(Equal(event.WorkspaceID))
+			fmt.Println("Received response", response)
 
-	fmt.Println("sent event")
-	channel <- event
-	fmt.Println("waiting for response")
-	fmt.Printf("response: %v\n", <-fakeEventLoop.eventLoopInputChannel)
+			err = k8sClient.Delete(ctx, gitopsDepl)
+			Expect(err).To(BeNil())
 
-}
+			event = eventlooptypes.EventLoopEvent{
+				EventType: eventlooptypes.DeploymentModified,
+				Request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: gitopsDepl.Namespace,
+						Name:      gitopsDepl.Name,
+					},
+				},
+				ReqResource: managedgitopsv1alpha1.GitOpsDeploymentTypeName,
+				Client:      k8sClient,
+				WorkspaceID: eventlooptypes.GetWorkspaceIDFromNamespaceID(*workspace),
+			}
+
+			fmt.Println("Sending event", event)
+			channel <- event
+			fmt.Println("Received response")
+			response = <-fakeEventLoop.eventLoopInputChannel
+			Expect(response.Request).Should(Equal(event.Request))
+			Expect(response.EventType).Should(Equal(event.EventType))
+			Expect(response.WorkspaceID).Should(Equal(event.WorkspaceID))
+			fmt.Printf("response: %v\n", response)
+
+		})
+	})
+})

--- a/backend/eventloop/workspace_event_loop_test.go
+++ b/backend/eventloop/workspace_event_loop_test.go
@@ -1,0 +1,91 @@
+package eventloop
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend/apis/managed-gitops/v1alpha1"
+	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/eventlooptypes"
+	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/shared_resource_loop"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("Workspace Event Loop Test", func() {
+
+	Context("Workspace event loop responds to channel events", func() {
+
+		It("Should pass events received on input channel to application event loop", func() {
+			scheme, argocdNamespace, kubesystemNamespace, apiNamespace, err := eventlooptypes.GenericTestSetup()
+			Expect(err).To(BeNil())
+
+			tAELF := &testApplicationEventLoopFactory{
+				outputChannel: make(chan eventlooptypes.EventLoopMessage),
+			}
+
+			// Start the workspace event loop with our custom test factory, so that we can capture output
+			inputChannel := make(chan eventlooptypes.EventLoopMessage)
+			internalStartWorkspaceEventLoopRouter(inputChannel, string(apiNamespace.UID), tAELF)
+
+			gitopsDepl := &managedgitopsv1alpha1.GitOpsDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-gitops-depl",
+					Namespace: apiNamespace.Name,
+					UID:       uuid.NewUUID(),
+				},
+				Spec: managedgitopsv1alpha1.GitOpsDeploymentSpec{
+					Source: managedgitopsv1alpha1.ApplicationSource{},
+					Type:   managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated,
+				},
+			}
+
+			k8sClientOuter := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gitopsDepl, apiNamespace, argocdNamespace, kubesystemNamespace).Build()
+
+			// Simulate a GitOpsDeployment modified event
+			msg := eventlooptypes.EventLoopMessage{
+				MessageType: eventlooptypes.ApplicationEventLoopMessageType_Event,
+				Event: &eventlooptypes.EventLoopEvent{
+					EventType: eventlooptypes.DeploymentModified,
+					Request: reconcile.Request{
+						NamespacedName: types.NamespacedName{
+							Namespace: apiNamespace.Name,
+							Name:      apiNamespace.Name,
+						},
+					},
+					Client:                  k8sClientOuter,
+					ReqResource:             managedgitopsv1alpha1.GitOpsDeploymentTypeName,
+					AssociatedGitopsDeplUID: string(gitopsDepl.UID),
+					WorkspaceID:             string(apiNamespace.UID),
+				},
+			}
+
+			// Sending an event to the workspace event loop should cause an event to be sent on the output channel
+			inputChannel <- msg
+			result := <-tAELF.outputChannel
+
+			Expect(result).NotTo(BeNil())
+			Expect(result.Event).To(Equal(msg.Event))
+			Expect(result.MessageType).To(Equal(msg.MessageType))
+
+		})
+
+	})
+})
+
+// testApplicationEventLoopFactory is a mock applicationEventQueueLoopFactory, used for unit tests above.
+type testApplicationEventLoopFactory struct {
+	outputChannel chan eventlooptypes.EventLoopMessage
+}
+
+var _ applicationEventQueueLoopFactory = &testApplicationEventLoopFactory{}
+
+// Instead of starting a new application event queue loop (like the default implementation of applictionEventQueueLoopFactory)
+// we instead just return a previously provided channel.
+func (ta *testApplicationEventLoopFactory) startApplicationEventQueueLoop(gitopsDeplID string, workspaceID string,
+	sharedResourceEventLoop *shared_resource_loop.SharedResourceEventLoop) chan eventlooptypes.EventLoopMessage {
+
+	return ta.outputChannel
+}


### PR DESCRIPTION
This PR:
- Refactors the event loop tests, adding mocking so that each event loop layer can be testing independently from the others
- Switches existing event loop test to Ginkgo test API
- Adds very simple tests that use those mocks, will create stories to add less simple tests.