### PR TITLE
Add unit tests for sharedresourceloop

### DIFF
--- a/appstudio-controller/go.sum
+++ b/appstudio-controller/go.sum
@@ -618,6 +618,7 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
@@ -884,6 +885,7 @@ github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvw
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
+github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -897,7 +899,6 @@ github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDs
 github.com/onsi/gomega v1.10.4/go.mod h1:g/HbgYopi++010VEqkFgJHKC09uJiW9UkXvMUuKHUCQ=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/onsi/gomega v1.14.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
-github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=

--- a/backend-shared/config/db/util/utils.go
+++ b/backend-shared/config/db/util/utils.go
@@ -33,8 +33,9 @@ func GetGitOpsEngineSingleInstanceNamespace() string {
 	return DefaultGitOpsEngineSingleInstanceNamespace
 }
 
+// The bool return value is 'true' if ManagedEnvironment is created; 'false' if it already exists in DB or in case of failure.
 func GetOrCreateManagedEnvironmentByNamespaceUID(ctx context.Context, workspaceNamespace v1.Namespace,
-	dbq db.DatabaseQueries, log logr.Logger) (*db.ManagedEnvironment, error) {
+	dbq db.DatabaseQueries, log logr.Logger) (*db.ManagedEnvironment, bool, error) {
 
 	workspaceNamespaceUID := string(workspaceNamespace.UID)
 
@@ -57,12 +58,12 @@ func GetOrCreateManagedEnvironmentByNamespaceUID(ctx context.Context, workspaceN
 
 		if err == nil {
 			// Success: mapping exists, and so does the environment it points to
-			return &managedEnvironment, nil
+			return &managedEnvironment, false, nil
 		}
 
 		if !db.IsResultNotFoundError(err) {
 			// Failure: A generic error occurred.
-			return nil, fmt.Errorf("unable to retrieve resource mapping: %v", err)
+			return nil, false, fmt.Errorf("unable to retrieve resource mapping: %v", err)
 		}
 
 		// At this point, we found the mapping, but didn't find the ManagedEnvironment that the
@@ -70,11 +71,11 @@ func GetOrCreateManagedEnvironmentByNamespaceUID(ctx context.Context, workspaceN
 
 		// Since the managed environment doesn't exist, delete the mapping; it will be recreated below.
 		if _, err := dbq.DeleteKubernetesResourceToDBResourceMapping(ctx, dbResourceMapping); err != nil {
-			return nil, fmt.Errorf("unable to delete K8s resource to DB mapping: %v", dbResourceMapping)
+			return nil, false, fmt.Errorf("unable to delete K8s resource to DB mapping: %v", dbResourceMapping)
 		}
 
 	} else if !db.IsResultNotFoundError(err) {
-		return nil, fmt.Errorf("unable to retrieve resource mapping: %v", err)
+		return nil, false, fmt.Errorf("unable to retrieve resource mapping: %v", err)
 	}
 
 	// At this point in the function, both the managed environment and mapping necessarily don't exist
@@ -90,7 +91,7 @@ func GetOrCreateManagedEnvironmentByNamespaceUID(ctx context.Context, workspaceN
 		Serviceaccount_ns:           "serviceaccount_ns",
 	}
 	if err := dbq.CreateClusterCredentials(ctx, &clusterCreds); err != nil {
-		return nil, fmt.Errorf("unable to create cluster creds for managed env: %v", err)
+		return nil, false, fmt.Errorf("unable to create cluster creds for managed env: %v", err)
 	}
 
 	managedEnvironment := db.ManagedEnvironment{
@@ -98,7 +99,7 @@ func GetOrCreateManagedEnvironmentByNamespaceUID(ctx context.Context, workspaceN
 		Clustercredentials_id: clusterCreds.Clustercredentials_cred_id,
 	}
 	if err := dbq.CreateManagedEnvironment(ctx, &managedEnvironment); err != nil {
-		return nil, fmt.Errorf("unable to create managed env: %v", err)
+		return nil, false, fmt.Errorf("unable to create managed env: %v", err)
 	}
 
 	dbResourceMapping = &db.KubernetesToDBResourceMapping{
@@ -109,22 +110,23 @@ func GetOrCreateManagedEnvironmentByNamespaceUID(ctx context.Context, workspaceN
 	}
 
 	if err := dbq.CreateKubernetesResourceToDBResourceMapping(ctx, dbResourceMapping); err != nil {
-		return nil, fmt.Errorf("unable to create KubernetesResourceToDBResourceMapping: %v", err)
+		return nil, false, fmt.Errorf("unable to create KubernetesResourceToDBResourceMapping: %v", err)
 	}
 
-	return &managedEnvironment, nil
+	return &managedEnvironment, true, nil
 }
 
 // GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID gets (or creates it if it doesn't exist) a GitOpsEngineInstance database entry that
 // corresponds to an GitOps engine instance running on the cluster.
+// The bool return value is 'true' if GitopsEngineInstance is created; 'false' if it already exists in DB or in case of failure.
 func GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.Context,
 	gitopsEngineNamespace v1.Namespace, kubesystemNamespaceUID string,
-	dbq db.DatabaseQueries, log logr.Logger) (*db.GitopsEngineInstance, *db.GitopsEngineCluster, error) {
+	dbq db.DatabaseQueries, log logr.Logger) (*db.GitopsEngineInstance, bool, *db.GitopsEngineCluster, error) {
 
 	// First create the GitOpsEngine cluster if needed; this will be used to create the instance.
 	gitopsEngineCluster, err := GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx, kubesystemNamespaceUID, dbq, log)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to create GitOpsEngineCluster for '%v', error: '%v'", kubesystemNamespaceUID, err)
+		return nil, false, nil, fmt.Errorf("unable to create GitOpsEngineCluster for '%v', error: '%v'", kubesystemNamespaceUID, err)
 	}
 
 	var gitopsEngineInstance *db.GitopsEngineInstance
@@ -144,7 +146,7 @@ func GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.Context,
 	if err := dbq.GetDBResourceMappingForKubernetesResource(ctx, dbResourceMapping); err != nil {
 
 		if !db.IsResultNotFoundError(err) {
-			return nil, nil, fmt.Errorf("unable to get DBResourceMapping for getOrCreateGitopsEngineInstanceByInstanceNamespaceUID: %v", err)
+			return nil, false, nil, fmt.Errorf("unable to get DBResourceMapping for getOrCreateGitopsEngineInstanceByInstanceNamespaceUID: %v", err)
 		}
 
 		dbResourceMapping = nil
@@ -157,7 +159,7 @@ func GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.Context,
 
 		if err := dbq.GetGitopsEngineInstanceById(ctx, gitopsEngineInstance); err != nil {
 			if !db.IsResultNotFoundError(err) {
-				return nil, nil, err
+				return nil, false, nil, err
 			}
 
 			log.V(util.LogLevel_Warn).Error(nil, "GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID found a resource mapping, but no engine instance.")
@@ -165,7 +167,7 @@ func GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.Context,
 			// We have found a mapping without the corresponding mapped entity, so delete the mapping.
 			// (We will recreate the mapping below)
 			if _, err := dbq.DeleteKubernetesResourceToDBResourceMapping(ctx, dbResourceMapping); err != nil {
-				return nil, nil, err
+				return nil, false, nil, err
 			}
 
 			gitopsEngineInstance = nil
@@ -173,12 +175,12 @@ func GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.Context,
 		} else {
 
 			if gitopsEngineInstance.EngineCluster_id != gitopsEngineCluster.Gitopsenginecluster_id {
-				return nil, nil, fmt.Errorf("able to locate engine instance, and engine cluster, but they mismatched: instance id: %v, cluster id: %v",
+				return nil, false, nil, fmt.Errorf("able to locate engine instance, and engine cluster, but they mismatched: instance id: %v, cluster id: %v",
 					gitopsEngineInstance.Gitopsengineinstance_id, gitopsEngineCluster.Gitopsenginecluster_id)
 			}
 
 			// Success: both existed.
-			return gitopsEngineInstance, gitopsEngineCluster, nil
+			return gitopsEngineInstance, false, gitopsEngineCluster, nil
 		}
 	}
 
@@ -192,42 +194,42 @@ func GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.Context,
 		}
 
 		if err := dbq.CreateGitopsEngineInstance(ctx, gitopsEngineInstance); err != nil {
-			return nil, nil, fmt.Errorf("unable to create engine instance, when neither existed: %v", err)
+			return nil, false, nil, fmt.Errorf("unable to create engine instance, when neither existed: %v", err)
 		}
 
 		expectedDBResourceMapping.DBRelationKey = gitopsEngineInstance.Gitopsengineinstance_id
 		if err := dbq.CreateKubernetesResourceToDBResourceMapping(ctx, &expectedDBResourceMapping); err != nil {
-			return nil, nil, fmt.Errorf("unable to create mapping when neither existed: %v", err)
+			return nil, false, nil, fmt.Errorf("unable to create mapping when neither existed: %v", err)
 		}
 
-		return gitopsEngineInstance, gitopsEngineCluster, nil
+		return gitopsEngineInstance, true, gitopsEngineCluster, nil
 
 	} else if dbResourceMapping != nil && gitopsEngineInstance == nil {
 		// Scenario B) this shouldn't happen: the above logic should ensure that dbResourceMapping is always nil, if gitopsEngineInstance is nil
-		return nil, nil, fmt.Errorf("SEVERE: the dbResourceMapping existed, but the gitops engine instance did not")
+		return nil, false, nil, fmt.Errorf("SEVERE: the dbResourceMapping existed, but the gitops engine instance did not")
 
 	} else if dbResourceMapping == nil && gitopsEngineInstance != nil {
 		// Scenario C) this will happen if the instance exists, but there is no mapping for it
 
 		expectedDBResourceMapping.DBRelationKey = gitopsEngineInstance.Gitopsengineinstance_id
 		if err := dbq.CreateKubernetesResourceToDBResourceMapping(ctx, &expectedDBResourceMapping); err != nil {
-			return nil, nil, fmt.Errorf("unable to create mapping when dbResourceMapping didn't exist: %v", err)
+			return nil, false, nil, fmt.Errorf("unable to create mapping when dbResourceMapping didn't exist: %v", err)
 		}
 
-		return gitopsEngineInstance, gitopsEngineCluster, nil
+		return gitopsEngineInstance, false, gitopsEngineCluster, nil
 
 	} else if dbResourceMapping != nil && gitopsEngineInstance != nil {
 		// Scenario D) both exist, so just return the cluster
 
 		if gitopsEngineInstance.EngineCluster_id != gitopsEngineCluster.Gitopsenginecluster_id {
-			return nil, nil, fmt.Errorf("able to locate engine instance, and engine cluster, but they mismatched: instance id: %v, cluster id: %v",
+			return nil, false, nil, fmt.Errorf("able to locate engine instance, and engine cluster, but they mismatched: instance id: %v, cluster id: %v",
 				gitopsEngineInstance.Gitopsengineinstance_id, gitopsEngineCluster.Gitopsenginecluster_id)
 		}
 
-		return gitopsEngineInstance, gitopsEngineCluster, nil
+		return gitopsEngineInstance, false, gitopsEngineCluster, nil
 
 	} else {
-		return nil, nil, fmt.Errorf("unexpected state in GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID")
+		return nil, false, nil, fmt.Errorf("unexpected state in GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID")
 	}
 
 }

--- a/backend/condition/conditions_suite_test.go
+++ b/backend/condition/conditions_suite_test.go
@@ -3,7 +3,7 @@ package condition
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/backend/condition/conditions_test.go
+++ b/backend/condition/conditions_test.go
@@ -1,7 +1,7 @@
 package condition
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend/apis/managed-gitops/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/backend/controllers/managed-gitops/suite_test.go
+++ b/backend/controllers/managed-gitops/suite_test.go
@@ -20,12 +20,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -42,10 +41,7 @@ var testEnv *envtest.Environment
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
-
-	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
-		[]Reporter{printer.NewlineReporter{}})
+	RunSpecs(t, "Controller Suite")
 }
 
 var _ = BeforeSuite(func() {
@@ -73,7 +69,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-}, 60)
+})
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/backend/eventloop/application_event_loop/application_event_loop_test.go
+++ b/backend/eventloop/application_event_loop/application_event_loop_test.go
@@ -1,7 +1,7 @@
 package application_event_loop
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/managed-gitops/backend/apis/managed-gitops/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/eventlooptypes"

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -37,7 +37,7 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleDeploym
 		return false, nil, nil, fmt.Errorf("unable to retrieve namespace '%s': %v", deplNamespace, err)
 	}
 
-	clusterUser, err := a.sharedResourceEventLoop.GetOrCreateClusterUserByNamespaceUID(ctx, workspaceClient, gitopsDeplNamespace)
+	clusterUser, _, err := a.sharedResourceEventLoop.GetOrCreateClusterUserByNamespaceUID(ctx, workspaceClient, gitopsDeplNamespace)
 	if err != nil {
 		return false, nil, nil, fmt.Errorf("unable to retrieve cluster user in handleDeploymentModified, '%s': %v", string(gitopsDeplNamespace.UID), err)
 	}
@@ -151,7 +151,7 @@ func (a applicationEventLoopRunner_Action) handleNewGitOpsDeplEvent(ctx context.
 		return false, nil, nil, fmt.Errorf("unable to retrieve namespace for managed env, '%s': %v", gitopsDeployment.ObjectMeta.Namespace, err)
 	}
 
-	_, managedEnv, engineInstance, _, err := a.sharedResourceEventLoop.GetOrCreateSharedResources(ctx, a.workspaceClient, gitopsDeplNamespace)
+	_, _, managedEnv, _, engineInstance, _, _, _, _, err := a.sharedResourceEventLoop.GetOrCreateSharedResources(ctx, a.workspaceClient, gitopsDeplNamespace)
 
 	if err != nil {
 		a.log.Error(err, "unable to get or create required db entries on deployment modified event")

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
@@ -27,7 +27,7 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleSyncRun
 		return false, fmt.Errorf("unable to retrieve namespace '%s': %v", a.eventResourceNamespace, err)
 	}
 
-	clusterUser, err := a.sharedResourceEventLoop.GetOrCreateClusterUserByNamespaceUID(ctx, a.workspaceClient, namespace)
+	clusterUser, _, err := a.sharedResourceEventLoop.GetOrCreateClusterUserByNamespaceUID(ctx, a.workspaceClient, namespace)
 	if err != nil {
 		return false, fmt.Errorf("unable to retrieve cluster user in handleDeploymentModified, '%s': %v", string(namespace.UID), err)
 	}

--- a/backend/eventloop/application_event_loop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_test.go
@@ -10,7 +10,7 @@ import (
 	condition "github.com/redhat-appstudio/managed-gitops/backend/condition/mocks"
 	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/shared_resource_loop"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	db "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"

--- a/backend/eventloop/application_event_loop/application_eventloop_suite_test.go
+++ b/backend/eventloop/application_event_loop/application_eventloop_suite_test.go
@@ -3,7 +3,7 @@ package application_event_loop_test
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/backend/eventloop/controller_event_loop_test.go
+++ b/backend/eventloop/controller_event_loop_test.go
@@ -1,7 +1,7 @@
 package eventloop
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/managed-gitops/backend/apis/managed-gitops/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/eventlooptypes"

--- a/backend/eventloop/event_loop_suite_test.go
+++ b/backend/eventloop/event_loop_suite_test.go
@@ -3,7 +3,7 @@ package eventloop
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/backend/eventloop/preprocess_event_loop_test.go
+++ b/backend/eventloop/preprocess_event_loop_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"

--- a/backend/eventloop/shared_resource_loop/shared_resource_loop_suite_test.go
+++ b/backend/eventloop/shared_resource_loop/shared_resource_loop_suite_test.go
@@ -1,0 +1,13 @@
+package shared_resource_loop_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSharedResourceLoop(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SharedResourceLoop Suite")
+}

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -41,8 +41,9 @@ type SharedResourceEventLoop struct {
 	inputChannel chan sharedResourceLoopMessage
 }
 
+// The bool return value is 'true' if ClusterUser is created; 'false' if it already exists in DB or in case of failure.
 func (srEventLoop *SharedResourceEventLoop) GetOrCreateClusterUserByNamespaceUID(ctx context.Context, workspaceClient client.Client,
-	workspaceNamespace corev1.Namespace) (*db.ClusterUser, error) {
+	workspaceNamespace corev1.Namespace) (*db.ClusterUser, bool, error) {
 
 	responseChannel := make(chan interface{})
 
@@ -60,15 +61,15 @@ func (srEventLoop *SharedResourceEventLoop) GetOrCreateClusterUserByNamespaceUID
 	select {
 	case rawResponse = <-responseChannel:
 	case <-ctx.Done():
-		return nil, fmt.Errorf("context cancelled in getOrCreateClusterUserByNamespaceUID")
+		return nil, false, fmt.Errorf("context cancelled in getOrCreateClusterUserByNamespaceUID")
 	}
 
 	response, ok := rawResponse.(sharedResourceLoopMessage_getOrCreateClusterUserByNamespaceUIDResponse)
 	if !ok {
-		return nil, fmt.Errorf("SEVERE: unexpected response type")
+		return nil, false, fmt.Errorf("SEVERE: unexpected response type")
 	}
 
-	return response.clusterUser, response.err
+	return response.clusterUser, response.isNewUser, response.err
 
 }
 
@@ -107,9 +108,10 @@ func (srEventLoop *SharedResourceEventLoop) GetGitopsEngineInstanceById(ctx cont
 
 // Ensure the user's workspace is configured, ensure a GitOpsEngineInstance exists that will target it, and ensure
 // a cluster access exists the give the user permission to target them from the engine.
+// The bool return value is 'true' if it's respective resource is created; 'false' if it already exists in DB or in case of failure.
 func (srEventLoop *SharedResourceEventLoop) GetOrCreateSharedResources(ctx context.Context,
-	workspaceClient client.Client, workspaceNamespace corev1.Namespace) (*db.ClusterUser,
-	*db.ManagedEnvironment, *db.GitopsEngineInstance, *db.ClusterAccess, error) {
+	workspaceClient client.Client, workspaceNamespace corev1.Namespace) (*db.ClusterUser, bool,
+	*db.ManagedEnvironment, bool, *db.GitopsEngineInstance, bool, *db.ClusterAccess, bool, *db.GitopsEngineCluster, error) {
 
 	responseChannel := make(chan interface{})
 
@@ -127,16 +129,24 @@ func (srEventLoop *SharedResourceEventLoop) GetOrCreateSharedResources(ctx conte
 	select {
 	case rawResponse = <-responseChannel:
 	case <-ctx.Done():
-		return nil, nil, nil, nil, fmt.Errorf("context cancelled in getOrCreateSharedResources")
+		return nil, false, nil, false, nil, false, nil, false, nil, fmt.Errorf("context cancelled in getOrCreateSharedResources")
 	}
 
 	response, ok := rawResponse.(sharedResourceLoopMessage_getOrCreateSharedResourcesResponse)
 	if !ok {
-		return nil, nil, nil, nil, fmt.Errorf("SEVERE: unexpected response type")
+		return nil, false, nil, false, nil, false, nil, false, nil, fmt.Errorf("SEVERE: unexpected response type")
 	}
 
-	return response.clusterUser, response.managedEnv, response.gitopsEngineInstance, response.clusterAccess, nil
-
+	return response.clusterUser,
+		response.isNewUser,
+		response.managedEnv,
+		response.isNewManagedEnv,
+		response.gitopsEngineInstance,
+		response.isNewInstance,
+		response.clusterAccess,
+		response.isNewClusterAccess,
+		response.gitopsEngineCluster,
+		nil
 }
 
 func NewSharedResourceLoop() *SharedResourceEventLoop {
@@ -177,9 +187,14 @@ type sharedResourceLoopMessage_getGitopsEngineInstanceByIdResponse struct {
 type sharedResourceLoopMessage_getOrCreateSharedResourcesResponse struct {
 	err                  error
 	clusterUser          *db.ClusterUser
+	isNewUser            bool
 	managedEnv           *db.ManagedEnvironment
+	isNewManagedEnv      bool
 	gitopsEngineInstance *db.GitopsEngineInstance
+	isNewInstance        bool
 	clusterAccess        *db.ClusterAccess
+	isNewClusterAccess   bool
+	gitopsEngineCluster  *db.GitopsEngineCluster
 }
 
 type sharedResourceLoopMessage_getOrCreateClusterUserByNamespaceUIDRequest struct {
@@ -189,6 +204,7 @@ type sharedResourceLoopMessage_getOrCreateClusterUserByNamespaceUIDRequest struc
 type sharedResourceLoopMessage_getOrCreateClusterUserByNamespaceUIDResponse struct {
 	err         error
 	clusterUser *db.ClusterUser
+	isNewUser   bool
 }
 
 func internalSharedResourceEventLoop(inputChan chan sharedResourceLoopMessage) {
@@ -218,14 +234,28 @@ func processSharedResourceMessage(ctx context.Context, msg sharedResourceLoopMes
 	log.V(sharedutil.LogLevel_Debug).Info("sharedResourceEventLoop received message: "+string(msg.messageType), "workspace", msg.workspaceNamespace.UID)
 
 	if msg.messageType == sharedResourceLoopMessage_getOrCreateSharedResources {
-		clusterUser, managedEnv, gitopsEngineInstance, clusterAccess, err := internalProcessMessage_GetOrCreateSharedResources(ctx, msg.workspaceClient, msg.workspaceNamespace, dbQueries, log)
+		clusterUser,
+			isNewUser,
+			managedEnv,
+			isNewManagedEnv,
+			gitopsEngineInstance,
+			isNewInstance,
+			clusterAccess,
+			isNewClusterAccess,
+			gitopsEngineCluster,
+			err := internalProcessMessage_GetOrCreateSharedResources(ctx, msg.workspaceClient, msg.workspaceNamespace, dbQueries, log)
 
 		response := sharedResourceLoopMessage_getOrCreateSharedResourcesResponse{
 			err:                  err,
 			clusterUser:          clusterUser,
+			isNewUser:            isNewUser,
 			managedEnv:           managedEnv,
+			isNewManagedEnv:      isNewManagedEnv,
 			gitopsEngineInstance: gitopsEngineInstance,
+			isNewInstance:        isNewInstance,
 			clusterAccess:        clusterAccess,
+			isNewClusterAccess:   isNewClusterAccess,
+			gitopsEngineCluster:  gitopsEngineCluster,
 		}
 
 		// Reply on a separate goroutine so cancelled callers don't block the event loop
@@ -235,11 +265,12 @@ func processSharedResourceMessage(ctx context.Context, msg sharedResourceLoopMes
 
 	} else if msg.messageType == sharedResourceLoopMessage_getOrCreateClusterUserByNamespaceUID {
 
-		clusterUser, err := internalProcessMessage_GetOrCreateClusterUserByNamespaceUID(ctx, msg.workspaceNamespace, dbQueries)
+		clusterUser, isNewUser, err := internalProcessMessage_GetOrCreateClusterUserByNamespaceUID(ctx, msg.workspaceNamespace, dbQueries)
 
 		response := sharedResourceLoopMessage_getOrCreateClusterUserByNamespaceUIDResponse{
 			err:         err,
 			clusterUser: clusterUser,
+			isNewUser:   isNewUser,
 		}
 
 		// Reply on a separate goroutine so cancelled callers don't block the event loop
@@ -283,13 +314,13 @@ func internalProcessMessage_GetGitopsEngineInstanceById(ctx context.Context, id 
 	}
 
 	err := dbq.GetGitopsEngineInstanceById(ctx, &gitopsEngineInstance)
-
 	return &gitopsEngineInstance, err
 }
 
+// The bool return value is 'true' if ClusterUser is created; 'false' if it already exists in DB or in case of failure.
 func internalProcessMessage_GetOrCreateClusterUserByNamespaceUID(ctx context.Context, workspaceNamespace corev1.Namespace,
-	dbq db.DatabaseQueries) (*db.ClusterUser, error) {
-
+	dbq db.DatabaseQueries) (*db.ClusterUser, bool, error) {
+	isNewUser := false
 	// TODO: GITOPSRVCE-19 - KCP support: for now, we assume that the namespace UID that the request occurred in is the user id.
 	clusterUser := db.ClusterUser{User_name: string(workspaceNamespace.UID)}
 
@@ -297,40 +328,42 @@ func internalProcessMessage_GetOrCreateClusterUserByNamespaceUID(ctx context.Con
 	err := dbq.GetClusterUserByUsername(ctx, &clusterUser)
 	if err != nil {
 		if db.IsResultNotFoundError(err) {
+			isNewUser = true
 
 			if err := dbq.CreateClusterUser(ctx, &clusterUser); err != nil {
-				return nil, err
+				return nil, false, err
 			}
 
 		} else {
-			return nil, err
+			return nil, false, err
 		}
 	}
 
-	return &clusterUser, nil
+	return &clusterUser, isNewUser, nil
 }
 
 // Ensure the user's workspace is configured, ensure a GitOpsEngineInstance exists that will target it, and ensure
 // a cluster access exists the give the user permission to target them from the engine.
+// The bool return value is 'true' if respective resource is created; 'false' if it already exists in DB or in case of failure.
 func internalProcessMessage_GetOrCreateSharedResources(ctx context.Context, workspaceClient client.Client,
 	workspaceNamespace corev1.Namespace, dbQueries db.DatabaseQueries,
-	log logr.Logger) (*db.ClusterUser, *db.ManagedEnvironment, *db.GitopsEngineInstance, *db.ClusterAccess, error) {
+	log logr.Logger) (*db.ClusterUser, bool, *db.ManagedEnvironment, bool, *db.GitopsEngineInstance, bool, *db.ClusterAccess, bool, *db.GitopsEngineCluster, error) {
 
-	clusterUser, err := internalGetOrCreateClusterUserByNamespaceUID(ctx, string(workspaceNamespace.UID), dbQueries)
+	clusterUser, isNewUser, err := internalGetOrCreateClusterUserByNamespaceUID(ctx, string(workspaceNamespace.UID), dbQueries)
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("unable to retrieve cluster user in processMessage, '%s': %v", string(workspaceNamespace.UID), err)
+		return nil, false, nil, false, nil, false, nil, false, nil, fmt.Errorf("unable to retrieve cluster user in processMessage, '%s': %v", string(workspaceNamespace.UID), err)
 	}
 
-	managedEnv, err := dbutil.GetOrCreateManagedEnvironmentByNamespaceUID(ctx, workspaceNamespace, dbQueries, log)
+	managedEnv, isNewManagedEnv, err := dbutil.GetOrCreateManagedEnvironmentByNamespaceUID(ctx, workspaceNamespace, dbQueries, log)
 	if err != nil {
 		log.Error(err, "unable to get or created managed env on deployment modified event")
-		return nil, nil, nil, nil, err
+		return nil, false, nil, false, nil, false, nil, false, nil, err
 	}
 
-	engineInstance, err := internalDetermineGitOpsEngineInstanceForNewApplication(ctx, *clusterUser, *managedEnv, workspaceClient, dbQueries, log)
+	engineInstance, isNewInstance, gitopsEngineCluster, err := internalDetermineGitOpsEngineInstanceForNewApplication(ctx, *clusterUser, *managedEnv, workspaceClient, dbQueries, log)
 	if err != nil {
 		log.Error(err, "unable to determine gitops engine instance")
-		return nil, nil, nil, nil, err
+		return nil, false, nil, false, nil, false, nil, false, nil, err
 	}
 
 	// Create the cluster access object, to allow us to interact with the GitOpsEngine and ManagedEnvironment on the user's behalf
@@ -340,13 +373,22 @@ func internalProcessMessage_GetOrCreateSharedResources(ctx context.Context, work
 		Clusteraccess_gitops_engine_instance_id: engineInstance.Gitopsengineinstance_id,
 	}
 
-	if err := internalGetOrCreateClusterAccess(ctx, &ca, dbQueries); err != nil {
+	err, isNewClusterAccess := internalGetOrCreateClusterAccess(ctx, &ca, dbQueries)
+	if err != nil {
 		log.Error(err, "unable to create cluster access")
-		return nil, nil, nil, nil, err
+		return nil, false, nil, false, nil, false, nil, false, nil, err
 	}
 
-	return clusterUser, managedEnv, engineInstance, &ca, nil
-
+	return clusterUser,
+		isNewUser,
+		managedEnv,
+		isNewManagedEnv,
+		engineInstance,
+		isNewInstance,
+		&ca,
+		isNewClusterAccess,
+		gitopsEngineCluster,
+		nil
 }
 
 // Whenever a new Argo CD Application needs to be created, we need to find an Argo CD instance
@@ -355,25 +397,25 @@ func internalProcessMessage_GetOrCreateSharedResources(ctx context.Context, work
 // there are no Argo CD instances that are overloaded (have too many users).
 //
 // However, at the moment we are using a single shared Argo CD instnace, so we will
-// just return that.
+// just return that, also the bool return value is 'true' if GitOpsEngineInstance is created; 'false' if it already exists in DB or in case of failure.
 //
 // This logic would be improved by https://issues.redhat.com/browse/GITOPSRVCE-73 (and others)
 func internalDetermineGitOpsEngineInstanceForNewApplication(ctx context.Context, user db.ClusterUser, managedEnv db.ManagedEnvironment,
-	k8sClient client.Client, dbq db.DatabaseQueries, log logr.Logger) (*db.GitopsEngineInstance, error) {
+	k8sClient client.Client, dbq db.DatabaseQueries, log logr.Logger) (*db.GitopsEngineInstance, bool, *db.GitopsEngineCluster, error) {
 
 	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: dbutil.GetGitOpsEngineSingleInstanceNamespace(), Namespace: dbutil.GetGitOpsEngineSingleInstanceNamespace()}}
 	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
-		return nil, fmt.Errorf("unable to retrieve gitopsengine namespace in determineGitOpsEngineInstanceForNewApplication")
+		return nil, false, nil, fmt.Errorf("unable to retrieve gitopsengine namespace in determineGitOpsEngineInstanceForNewApplication")
 	}
 
 	kubeSystemNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Namespace: "kube-system"}}
 	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(kubeSystemNamespace), kubeSystemNamespace); err != nil {
-		return nil, fmt.Errorf("unable to retrieve kube-system namespace in determineGitOpsEngineInstanceForNewApplication")
+		return nil, false, nil, fmt.Errorf("unable to retrieve kube-system namespace in determineGitOpsEngineInstanceForNewApplication")
 	}
 
-	gitopsEngineInstance, _, err := dbutil.GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx, *namespace, string(kubeSystemNamespace.UID), dbq, log)
+	gitopsEngineInstance, isNewInstance, gitopsEngineCluster, err := dbutil.GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx, *namespace, string(kubeSystemNamespace.UID), dbq, log)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get or create engine instance for new application: %v", err)
+		return nil, false, nil, fmt.Errorf("unable to get or create engine instance for new application: %v", err)
 	}
 
 	// When we support multiple Argo CD instance, the algorithm would be:
@@ -388,44 +430,47 @@ func internalDetermineGitOpsEngineInstanceForNewApplication(ctx context.Context,
 	// In a way that ensures that applications are balanced between instances.
 	// Preliminary thoughts: https://docs.google.com/document/d/15E8d5frNuTFEdCHMlNSk0LQr6DI7BtiypxIC2AnW-OQ/edit#
 
-	return gitopsEngineInstance, nil
+	return gitopsEngineInstance, isNewInstance, gitopsEngineCluster, nil
 }
 
-func internalGetOrCreateClusterAccess(ctx context.Context, ca *db.ClusterAccess, dbq db.DatabaseQueries) error {
+// The bool return value is 'true' if ClusterAccess is created; 'false' if it already exists in DB or in case of failure.
+func internalGetOrCreateClusterAccess(ctx context.Context, ca *db.ClusterAccess, dbq db.DatabaseQueries) (error, bool) {
 
 	if err := dbq.GetClusterAccessByPrimaryKey(ctx, ca); err != nil {
 
 		if !db.IsResultNotFoundError(err) {
-			return err
+			return err, false
 		}
 	} else {
-		return nil
+		return nil, false
 	}
 
 	if err := dbq.CreateClusterAccess(ctx, ca); err != nil {
-		return err
+		return err, false
 	}
 
-	return nil
+	return nil, true
 }
 
-func internalGetOrCreateClusterUserByNamespaceUID(ctx context.Context, namespaceUID string, dbq db.DatabaseQueries) (*db.ClusterUser, error) {
-
+// The bool return value is 'true' if ClusterUser is created; 'false' if it already exists in DB or in case of failure.
+func internalGetOrCreateClusterUserByNamespaceUID(ctx context.Context, namespaceUID string, dbq db.DatabaseQueries) (*db.ClusterUser, bool, error) {
+	isNewUser := false
 	// TODO: GITOPSRVCE-19 - KCP support: for now, we assume that the namespace UID that the request occurred in is the user id.
 	clusterUser := db.ClusterUser{User_name: namespaceUID}
 
 	err := dbq.GetClusterUserByUsername(ctx, &clusterUser)
 	if err != nil {
 		if db.IsResultNotFoundError(err) {
+			isNewUser = true
 
 			if err := dbq.CreateClusterUser(ctx, &clusterUser); err != nil {
-				return nil, err
+				return nil, false, err
 			}
 
 		} else {
-			return nil, err
+			return nil, false, err
 		}
 	}
 
-	return &clusterUser, nil
+	return &clusterUser, isNewUser, nil
 }

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
@@ -1,0 +1,283 @@
+package shared_resource_loop
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
+	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/eventlooptypes"
+
+	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
+	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend/apis/managed-gitops/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Used to list down resources for deletion which are created while running tests.
+type testResources struct {
+	clusterAccess           *db.ClusterAccess
+	Clusteruser_id          string
+	Managedenvironment_id   string
+	Gitopsengineinstance_id string
+	EngineCluster_id        string
+	Clustercredentials_id   []string
+}
+
+var _ = Describe("SharedResourceEventLoop Test", func() {
+
+	// This will be used by AfterEach to clean resources
+	var resourcesToBeDeleted testResources
+
+	var ctx context.Context
+	var k8sClient *sharedutil.ProxyClient
+	var workspace *v1.Namespace
+
+	Context("Shared Resource Event Loop test", func() {
+
+		// Create a fake k8s client before each test
+		BeforeEach(func() {
+			ctx = context.Background()
+			scheme,
+				argocdNamespace,
+				kubesystemNamespace,
+				workspaceTemp, err := eventlooptypes.GenericTestSetup()
+
+			Expect(err).To(BeNil())
+
+			workspace = workspaceTemp
+
+			gitopsDepl := &managedgitopsv1alpha1.GitOpsDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-gitops-depl",
+					Namespace: workspace.Name,
+					UID:       uuid.NewUUID(),
+				},
+			}
+
+			k8sClientOuter := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(gitopsDepl, workspace, argocdNamespace, kubesystemNamespace).
+				Build()
+
+			k8sClient = &sharedutil.ProxyClient{
+				InnerClient: k8sClientOuter,
+			}
+
+			// After each test delete the resources created by it.
+			DeferCleanup(func() {
+				dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+				Expect(err).To(BeNil())
+
+				defer dbq.CloseDatabase()
+
+				// Delete clusterAccess
+				if resourcesToBeDeleted.clusterAccess != nil {
+					rowsAffected, err := dbq.DeleteClusterAccessById(ctx,
+						resourcesToBeDeleted.clusterAccess.Clusteraccess_user_id,
+						resourcesToBeDeleted.clusterAccess.Clusteraccess_managed_environment_id,
+						resourcesToBeDeleted.clusterAccess.Clusteraccess_gitops_engine_instance_id)
+
+					Expect(rowsAffected).To(Equal(1))
+					Expect(err).To(BeNil())
+				}
+
+				// Delete clusterUser
+				if resourcesToBeDeleted.Clusteruser_id != "" {
+					rowsAffected, err := dbq.DeleteClusterUserById(ctx, resourcesToBeDeleted.Clusteruser_id)
+					Expect(rowsAffected).To(Equal(1))
+					Expect(err).To(BeNil())
+				}
+
+				// Delete managedEnv
+				if resourcesToBeDeleted.Managedenvironment_id != "" {
+					rowsAffected, err := dbq.DeleteManagedEnvironmentById(ctx, resourcesToBeDeleted.Managedenvironment_id)
+					Expect(rowsAffected).To(Equal(1))
+					Expect(err).To(BeNil())
+				}
+
+				// Delete engineInstance
+				if resourcesToBeDeleted.Gitopsengineinstance_id != "" {
+					rowsAffected, err := dbq.DeleteGitopsEngineInstanceById(ctx, resourcesToBeDeleted.Gitopsengineinstance_id)
+					Expect(rowsAffected).To(Equal(1))
+					Expect(err).To(BeNil())
+				}
+
+				// Delete engineCluster
+				if resourcesToBeDeleted.EngineCluster_id != "" {
+					rowsAffected, err := dbq.DeleteGitopsEngineClusterById(ctx, resourcesToBeDeleted.EngineCluster_id)
+					Expect(rowsAffected).To(Equal(1))
+					Expect(err).To(BeNil())
+				}
+
+				// Delete clusterCredentials
+				if len(resourcesToBeDeleted.Clustercredentials_id) != 0 {
+					for _, clustercredentials_id := range resourcesToBeDeleted.Clustercredentials_id {
+						rowsAffected, err := dbq.DeleteClusterCredentialsById(ctx, clustercredentials_id)
+						Expect(rowsAffected).To(Equal(1))
+						Expect(err).To(BeNil())
+					}
+				}
+
+			})
+		})
+
+		It("Should create or fetch a user by Namespace id.", func() {
+			sharedResourceEventLoop := &SharedResourceEventLoop{inputChannel: make(chan sharedResourceLoopMessage)}
+
+			go internalSharedResourceEventLoop(sharedResourceEventLoop.inputChannel)
+
+			// At first assuming there are no existing users, hence creating new.
+			usrOld,
+				isNewUser,
+				err := sharedResourceEventLoop.GetOrCreateClusterUserByNamespaceUID(ctx, k8sClient, *workspace)
+
+			Expect(err).To(BeNil())
+			Expect(usrOld).NotTo(BeNil())
+			Expect(isNewUser).To(BeTrue())
+
+			// User is created in previous call, then same user should be returned instead of creating new.
+			usrNew,
+				isNewUser,
+				err := sharedResourceEventLoop.GetOrCreateClusterUserByNamespaceUID(ctx, k8sClient, *workspace)
+
+			Expect(err).To(BeNil())
+			Expect(usrNew).NotTo(BeNil())
+			Expect(isNewUser).To(BeFalse())
+			Expect(usrOld).To(Equal(usrNew))
+
+			// To be used by AfterEach to clean up the resources created by test
+			resourcesToBeDeleted = testResources{Clusteruser_id: usrNew.Clusteruser_id}
+		})
+
+		It("Should create or fetch resources.", func() {
+			sharedResourceEventLoop := &SharedResourceEventLoop{inputChannel: make(chan sharedResourceLoopMessage)}
+
+			go internalSharedResourceEventLoop(sharedResourceEventLoop.inputChannel)
+
+			// At first assuming there are no existing resources, hence creating new.
+			clusterUserOld,
+				isNewUser,
+				managedEnvOld,
+				isNewManagedEnv,
+				gitopsEngineInstanceOld,
+				isNewInstance,
+				clusterAccessOld,
+				isNewClusterAccess,
+				gitopsEngineClusterOld,
+				err := sharedResourceEventLoop.GetOrCreateSharedResources(ctx, k8sClient, *workspace)
+
+			Expect(err).To(BeNil())
+			Expect(clusterUserOld).NotTo(BeNil())
+			Expect(managedEnvOld).NotTo(BeNil())
+			Expect(gitopsEngineInstanceOld).NotTo(BeNil())
+			Expect(clusterAccessOld).NotTo(BeNil())
+
+			Expect(isNewUser).To(BeTrue())
+			Expect(isNewManagedEnv).To(BeTrue())
+			Expect(isNewInstance).To(BeTrue())
+			Expect(isNewClusterAccess).To(BeTrue())
+
+			// Resources are created in previous call, then same resources should be returned instead of creating new.
+			clusterUserNew,
+				isNewUser,
+				managedEnvNew,
+				isNewManagedEnv,
+				gitopsEngineInstanceNew,
+				isNewInstance,
+				clusterAccessNew,
+				isNewClusterAccess,
+				_, err := sharedResourceEventLoop.GetOrCreateSharedResources(ctx, k8sClient, *workspace)
+
+			Expect(err).To(BeNil())
+			Expect(clusterUserNew).NotTo(BeNil())
+			Expect(managedEnvNew).NotTo(BeNil())
+			Expect(gitopsEngineInstanceNew).NotTo(BeNil())
+			Expect(clusterAccessNew).NotTo(BeNil())
+
+			Expect(isNewUser).To(BeFalse())
+			Expect(isNewManagedEnv).To(BeFalse())
+			Expect(isNewInstance).To(BeFalse())
+			Expect(isNewClusterAccess).To(BeFalse())
+
+			Expect(clusterUserOld).To(Equal(clusterUserNew))
+			Expect(managedEnvOld).To(Equal(managedEnvNew))
+			Expect(gitopsEngineInstanceOld).To(Equal(gitopsEngineInstanceNew))
+			Expect(clusterAccessOld).To(Equal(clusterAccessNew))
+
+			// To be used by AfterEach to clean up the resources created by test
+			resourcesToBeDeleted = testResources{
+				Clusteruser_id:          clusterUserOld.Clusteruser_id,
+				Managedenvironment_id:   managedEnvOld.Managedenvironment_id,
+				Gitopsengineinstance_id: gitopsEngineInstanceOld.Gitopsengineinstance_id,
+				clusterAccess:           clusterAccessOld,
+				EngineCluster_id:        gitopsEngineInstanceOld.EngineCluster_id,
+				Clustercredentials_id: []string{
+					gitopsEngineClusterOld.Clustercredentials_id,
+					managedEnvOld.Clustercredentials_id,
+				},
+			}
+		})
+
+		It("Should fetch a engine instance by ID.", func() {
+			sharedResourceEventLoop := &SharedResourceEventLoop{inputChannel: make(chan sharedResourceLoopMessage)}
+
+			go internalSharedResourceEventLoop(sharedResourceEventLoop.inputChannel)
+
+			// Negative test, engineInstance is not present, it should return error
+			engineInstanceOld, err := sharedResourceEventLoop.GetGitopsEngineInstanceById(ctx, "", k8sClient, *workspace)
+			Expect(err).NotTo(BeNil())
+			Expect(engineInstanceOld.EngineCluster_id).To(BeEmpty())
+
+			// Create new engine instance which will be used by "GetGitopsEngineInstanceById" fucntion
+			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+			Expect(err).To(BeNil())
+
+			defer dbq.CloseDatabase()
+
+			clusterCredentials := db.ClusterCredentials{
+				Clustercredentials_cred_id: string(uuid.NewUUID()),
+			}
+
+			gitopsEngineCluster := db.GitopsEngineCluster{
+				Gitopsenginecluster_id: string(uuid.NewUUID()),
+				Clustercredentials_id:  clusterCredentials.Clustercredentials_cred_id,
+			}
+
+			gitopsEngineInstance := db.GitopsEngineInstance{
+				Gitopsengineinstance_id: string(uuid.NewUUID()),
+				Namespace_name:          workspace.Namespace,
+				Namespace_uid:           string(workspace.UID),
+				EngineCluster_id:        gitopsEngineCluster.Gitopsenginecluster_id,
+			}
+
+			err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)
+			Expect(err).To(BeNil())
+
+			err = dbq.CreateGitopsEngineCluster(ctx, &gitopsEngineCluster)
+			Expect(err).To(BeNil())
+
+			err = dbq.CreateGitopsEngineInstance(ctx, &gitopsEngineInstance)
+			Expect(err).To(BeNil())
+
+			// Fetch the same engineInstance by ID
+			engineInstanceNew, err := sharedResourceEventLoop.GetGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id, k8sClient, *workspace)
+
+			Expect(err).To(BeNil())
+			Expect(engineInstanceNew.EngineCluster_id).NotTo(BeNil())
+
+			// To be used by AfterEach to clean up the resources created by test
+			resourcesToBeDeleted = testResources{
+				Gitopsengineinstance_id: gitopsEngineInstance.Gitopsengineinstance_id,
+				EngineCluster_id:        gitopsEngineInstance.EngineCluster_id,
+				Clustercredentials_id: []string{
+					clusterCredentials.Clustercredentials_cred_id,
+				},
+			}
+		})
+	})
+})

--- a/backend/eventloop/workspace_event_loop_test.go
+++ b/backend/eventloop/workspace_event_loop_test.go
@@ -1,7 +1,7 @@
 package eventloop
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend/apis/managed-gitops/v1alpha1"

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/go-logr/logr v0.4.0
 	github.com/golang/mock v1.4.1
 	github.com/google/go-github v17.0.0+incompatible
-	github.com/onsi/ginkgo v1.16.4
-	github.com/onsi/gomega v1.15.0
+	github.com/onsi/ginkgo/v2 v2.1.3
+	github.com/onsi/gomega v1.17.0
 	github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
@@ -52,7 +52,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
@@ -78,7 +77,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiextensions-apiserver v0.21.2 // indirect
 	k8s.io/component-base v0.21.2 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -202,6 +202,7 @@ github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OI
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -246,6 +247,7 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -328,14 +330,16 @@ github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
+github.com/onsi/ginkgo/v2 v2.1.3 h1:e/3Cwtogj0HA+25nMP1jCMDIf8RtRYbGwGGuBIFztkc=
+github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
-github.com/onsi/gomega v1.15.0 h1:WjP/FQ/sk43MRmnEcT+MlDw2TFvkrXlprrPST/IudjU=
-github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
+github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
+github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/backend/main.go
+++ b/backend/main.go
@@ -195,7 +195,7 @@ func createPrimaryGitOpsEngineInstance(k8sclient client.Client, log logr.Logger)
 		},
 	}
 
-	gitopsEngineInstance, _, err := dbutil.GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx, *namespace, kubeSystemNamespace.Name, dbQueries, log)
+	gitopsEngineInstance, _, _, err := dbutil.GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx, *namespace, kubeSystemNamespace.Name, dbQueries, log)
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ func createPrimaryGitOpsEngineInstance(k8sclient client.Client, log logr.Logger)
 		},
 	}
 
-	managedEnv, err := dbutil.GetOrCreateManagedEnvironmentByNamespaceUID(ctx, *gitopsLocalWorkspaceNamespace, dbQueries, log)
+	managedEnv, _, err := dbutil.GetOrCreateManagedEnvironmentByNamespaceUID(ctx, *gitopsLocalWorkspaceNamespace, dbQueries, log)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description
This PR is to add Unit test cases for sharedresourceloop.

## Type of changes 
1. Added unit test cases for following functions

- GetOrCreateClusterUserByNamespaceUID
- GetOrCreateSharedResources
- . GetGitopsEngineInstanceById

2. Updated signature of functions to return flags to identify whether resources were newly created or fetched from existing entry.
3. Used a cleanup function delete resources created by tests.

#### Changes done after review 
1. Upgraded Ginkgo to V2.0 in `backend` (Can be done for other components in separate PR.) for using `DeferCleanup` to clean up resources after each test.
2. Changed Ginkgo import statements in `backend`.
3. Replaced `RunSpecsWithDefaultAndCustomReporters` with `RunSpecs` in `backend/controllers/managed-gitops/suite_test.go`, as it's been deprecated in Ginkgo V2.

## Jira ticket 
https://issues.redhat.com/browse/GITOPSRVCE-109