### PR TITLE
add tekton ci from infra-deployments

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -1,23 +1,27 @@
+---
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: gitops-pull-request
+  name: gitops-service-cluster-agent
   annotations:
-    pipelinesascode.tekton.dev/on-event: "[pull_request]"
-    pipelinesascode.tekton.dev/on-target-branch: "[main]"
-    pipelinesascode.tekton.dev/max-keep-runs: "2"
+    pipelinesascode.tekton.dev/on-event: "push"
+    pipelinesascode.tekton.dev/on-target-branch: "main"
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:
     - name: git-url
-      value: "{{repo_url}}"
+      value: 'https://github.com/redhat-appstudio/managed-gitops'
     - name: revision
-      value: "{{revision}}"
+      value: "{{ revision }}"
     - name: output-image
-      value: 'quay.io/redhat-appstudio/pull-request-builds:mgiops-{{revision}}'
+      value: 'quay.io/redhat-appstudio/gitops-service:{{ revision }}'
+    - name: path-context
+      value: .
+    - name: dockerfile
+      value: Dockerfile
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio/build-templates-bundle:0866720a87aec4675074069cd16662d8e01237cf
-  serviceAccountName: pipeline
   workspaces:
     - name: workspace
       volumeClaimTemplate:


### PR DESCRIPTION
This PR moves the CI previously defined in the [infra-deployments](https://github.com/CathalOConnorRH/infra-deployments/blob/637e85d68679d81cff2c4f03a9354145a1f7936d/components/gitops/.tekton/trigger-template.yaml) repository to this repository