### PR TITLE
ci: Bump github actions v2 to v3

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/.github/workflows/schema-sync.yml
+++ b/.github/workflows/schema-sync.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: "1.17.6"
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run script file
       run: |
          $GITHUB_WORKSPACE/backend-shared/hack/run-db-schema-sync-check.sh

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "1.17.6"
       - name: "Run make fmt and then 'git diff' to see if anything changed: to fix this check, run make fmt and then commit the changes."
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "1.17.6"
       - name: "Install gosec"
@@ -84,9 +84,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "1.17.6"
 
@@ -135,9 +135,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "1.17.6"
       - name: "Start PostgreSQL"


### PR DESCRIPTION
#### Description:
No related JIRA story for this. It's a CI maintenance PR.

The PR updates the version (major ver change) of two GitHub Action to are using.

* Bumps [actions/setup-go](https://github.com/actions/setup-go) from 2 to 3.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/actions/setup-go/releases">actions/setup-go's releases</a>.</em></p>
<blockquote>
<h2>v3.0.0</h2>
<h2>What's Changed</h2>
<ul>
<li>Update default runtime to node16 (<a href="https://github-redirect.dependabot.com/actions/setup-go/pull/192">actions/setup-go#192</a>)</li>
<li>Update <code>package-lock.json</code> file version to 2 (<a href="https://github-redirect.dependabot.com/actions/setup-go/pull/193">actions/setup-go#193</a>) and <code>@types/node</code> to 16.11.25 (<a href="https://github-redirect.dependabot.com/actions/setup-go/pull/194">actions/setup-go#194</a>)</li>
<li>Remove the <code>stable</code> input and fix SemVer notation (<a href="https://github-redirect.dependabot.com/actions/setup-go/pull/195">actions/setup-go#195</a>)</li>
</ul>
<h3>Breaking Changes</h3>
<p>With the update to Node 16, all scripts will now be run with Node 16 rather than Node 12.</p>
<p>This new major release removes the <code>stable</code> input, so there is no need to specify additional input to use pre-release versions. This release also corrects the pre-release versions syntax to satisfy the SemVer notation (1.18.0-beta1 -&gt; 1.18.0-beta.1, 1.18.0-rc1 -&gt; 1.18.0-rc.1).</p>
<pre lang="yaml"><code>steps:
  - uses: actions/checkout@v2
  - uses: actions/setup-go@v3
    with:
      go-version: '1.18.0-rc.1' 
  - run: go version
</code></pre>
<h2>Add check-latest input</h2>
<p>In scope of this release we add the <a href="https://github-redirect.dependabot.com/actions/setup-go/pull/186">check-latest</a> input. If <code>check-latest</code> is set to <code>true</code>, the action first checks if the cached version is the latest one. If the locally cached version is not the most up-to-date, a Go version will then be downloaded from <a href="https://github.com/actions/go-versions">go-versions</a> repository. By default <code>check-latest</code> is set to <code>false</code>.
Example of usage:</p>
<pre lang="yaml"><code>steps:
  - uses: actions/checkout@v2
  - uses: actions/setup-go@v2
    with:
      go-version: '1.16'
      check-latest: true
  - run: go version
</code></pre>
<p>Moreover, we updated <code>@actions/core</code> from <code>1.2.6</code> to <code>1.6.0</code></p>
<h2>v2.1.5</h2>
<p>In scope of this release we updated <code>matchers.json</code>  to improve the problem matcher pattern. For more information please refer to this <a href="https://github-redirect.dependabot.com/actions/setup-go/pull/98">pull request</a></p>
<h2>v2.1.4</h2>
<h2>What's Changed</h2>
<ul>
<li>Fix extractor selection on windows by <a href="https://github.com/paulcacheux"><code>@​paulcacheux</code></a> in <a href="https://github-redirect.dependabot.com/actions/setup-go/pull/141">actions/setup-go#141</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/paulcacheux"><code>@​paulcacheux</code></a> made their first contribution in <a href="https://github-redirect.dependabot.com/actions/setup-go/pull/141">actions/setup-go#141</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/setup-go/compare/v2.1.3...v2.1.4">https://github.com/actions/setup-go/compare/v2.1.3...v2.1.4</a></p>
<h2>v2.1.3</h2>
<ul>
<li>Updated communication with runner to use environment files rather then workflow commands</li>
</ul>
<h2>v2.1.2</h2>
<p>This release includes vendored licenses for this action's npm dependencies.</p>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/actions/setup-go/commit/f6164bd8c8acb4a71fb2791a8b6c4024ff038dab"><code>f6164bd</code></a> Remove stable input and fix SemVer notation (<a href="https://github-redirect.dependabot.com/actions/setup-go/issues/195">#195</a>)</li>
<li><a href="https://github.com/actions/setup-go/commit/2bb2aab2fd2586a4a6408b9cb041ed5f7e09e378"><code>2bb2aab</code></a> update types node (<a href="https://github-redirect.dependabot.com/actions/setup-go/issues/194">#194</a>)</li>
<li><a href="https://github.com/actions/setup-go/commit/edcbc0c2cd60ccbfc1f9b2cbae9a599b8d637beb"><code>edcbc0c</code></a> update lockfileVersion (<a href="https://github-redirect.dependabot.com/actions/setup-go/issues/193">#193</a>)</li>
<li><a href="https://github.com/actions/setup-go/commit/fb9a043dd8a5a4c2b4ea425ff1340755008a1f1d"><code>fb9a043</code></a> Update default runtime to node16 (<a href="https://github-redirect.dependabot.com/actions/setup-go/issues/192">#192</a>)</li>
<li><a href="https://github.com/actions/setup-go/commit/5b0ae0e97ddce24cca306eeb7a5edc2314c35877"><code>5b0ae0e</code></a> Bump pathval from 1.1.0 to 1.1.1 (<a href="https://github-redirect.dependabot.com/actions/setup-go/issues/188">#188</a>)</li>
<li>See full diff in <a href="https://github.com/actions/setup-go/compare/v2...v3">compare view</a></li>
</ul>
</details>
<br />

* Bumps [actions/checkout](https://github.com/actions/checkout) from 2 to 3.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/actions/checkout/releases">actions/checkout's releases</a>.</em></p>
<blockquote>
<h2>v3.0.0</h2>
<ul>
<li>Update default runtime to node16</li>
</ul>
<h2>v2.4.0</h2>
<ul>
<li>Convert SSH URLs like <code>org-&lt;ORG_ID&gt;@github.com:</code> to <code>https://github.com/</code> - <a href="https://github-redirect.dependabot.com/actions/checkout/pull/621">pr</a></li>
</ul>
<h2>v2.3.5</h2>
<p>Update dependencies</p>
<h2>v2.3.4</h2>
<ul>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/379">Add missing <code>await</code>s</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/360">Swap to Environment Files</a></li>
</ul>
<h2>v2.3.3</h2>
<ul>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/345">Remove Unneeded commit information from build logs</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/326">Add Licensed to verify third party dependencies</a></li>
</ul>
<h2>v2.3.2</h2>
<p><a href="https://github-redirect.dependabot.com/actions/checkout/pull/320">Add Third Party License Information to Dist Files</a></p>
<h2>v2.3.1</h2>
<p><a href="https://github-redirect.dependabot.com/actions/checkout/pull/284">Fix default branch resolution for .wiki and when using SSH</a></p>
<h2>v2.3.0</h2>
<p><a href="https://github-redirect.dependabot.com/actions/checkout/pull/278">Fallback to the default branch</a></p>
<h2>v2.2.0</h2>
<p><a href="https://github-redirect.dependabot.com/actions/checkout/pull/258">Fetch all history for all tags and branches when fetch-depth=0</a></p>
<h2>v2.1.1</h2>
<p>Changes to support GHES (<a href="https://github-redirect.dependabot.com/actions/checkout/pull/236">here</a> and <a href="https://github-redirect.dependabot.com/actions/checkout/pull/248">here</a>)</p>
<h2>v2.1.0</h2>
<ul>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/191">Group output</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/199">Changes to support GHES alpha release</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/184">Persist core.sshCommand for submodules</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/163">Add support ssh</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/179">Convert submodule SSH URL to HTTPS, when not using SSH</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/157">Add submodule support</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/144">Follow proxy settings</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/141">Fix ref for pr closed event when a pr is merged</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/128">Fix issue checking detached when git less than 2.22</a></li>
</ul>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/actions/checkout/blob/main/CHANGELOG.md">actions/checkout's changelog</a>.</em></p>
<blockquote>
<h1>Changelog</h1>
<h2>v2.3.1</h2>
<ul>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/284">Fix default branch resolution for .wiki and when using SSH</a></li>
</ul>
<h2>v2.3.0</h2>
<ul>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/278">Fallback to the default branch</a></li>
</ul>
<h2>v2.2.0</h2>
<ul>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/258">Fetch all history for all tags and branches when fetch-depth=0</a></li>
</ul>
<h2>v2.1.1</h2>
<ul>
<li>Changes to support GHES (<a href="https://github-redirect.dependabot.com/actions/checkout/pull/236">here</a> and <a href="https://github-redirect.dependabot.com/actions/checkout/pull/248">here</a>)</li>
</ul>
<h2>v2.1.0</h2>
<ul>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/191">Group output</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/199">Changes to support GHES alpha release</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/184">Persist core.sshCommand for submodules</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/163">Add support ssh</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/179">Convert submodule SSH URL to HTTPS, when not using SSH</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/157">Add submodule support</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/144">Follow proxy settings</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/141">Fix ref for pr closed event when a pr is merged</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/128">Fix issue checking detached when git less than 2.22</a></li>
</ul>
<h2>v2.0.0</h2>
<ul>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/108">Do not pass cred on command line</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/107">Add input persist-credentials</a></li>
<li><a href="https://github-redirect.dependabot.com/actions/checkout/pull/104">Fallback to REST API to download repo</a></li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/actions/checkout/commit/a12a3943b4bdde767164f792f33f40b04645d846"><code>a12a394</code></a> update readme for v3 (<a href="https://github-redirect.dependabot.com/actions/checkout/issues/708">#708</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/8f9e05e482293f862823fcca12d9eddfb3723131"><code>8f9e05e</code></a> Update to node 16 (<a href="https://github-redirect.dependabot.com/actions/checkout/issues/689">#689</a>)</li>
<li><a href="https://github.com/actions/checkout/commit/230611dbd0eb52da1e1f4f7bc8bb0c3a339fc8b7"><code>230611d</code></a> Change secret name for PAT to not start with GITHUB_ (<a href="https://github-redirect.dependabot.com/actions/checkout/issues/623">#623</a>)</li>
<li>See full diff in <a href="https://github.com/actions/checkout/compare/v2...v3">compare view</a></li>
</ul>
</details>
<br />
