### PR TITLE
Rename cluster-agent's eventloop.go to operation_event_loop.go

### DIFF
--- a/cluster-agent/controllers/managed-gitops/operation_controller.go
+++ b/cluster-agent/controllers/managed-gitops/operation_controller.go
@@ -32,7 +32,7 @@ import (
 type OperationReconciler struct {
 	client.Client
 	Scheme              *runtime.Scheme
-	ControllerEventLoop *eventloop.ControllerEventLoop
+	ControllerEventLoop *eventloop.OperationEventLoop
 }
 
 //+kubebuilder:rbac:groups=managed-gitops.redhat.com,resources=operations,verbs=get;list;watch;create;update;patch;delete

--- a/cluster-agent/main.go
+++ b/cluster-agent/main.go
@@ -95,7 +95,7 @@ func main() {
 	if err = (&controllers.OperationReconciler{
 		Client:              mgr.GetClient(),
 		Scheme:              mgr.GetScheme(),
-		ControllerEventLoop: eventloop.NewControllerEventLoop(),
+		ControllerEventLoop: eventloop.NewOperationEventLoop(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Operation")
 		os.Exit(1)


### PR DESCRIPTION
#### Description:
- Very simple PR, just renaming cluster-agent's `eventloop.go` to `operation_event_loop.go`.
- Likewise updating the name of the struct, from `ControllerEventLoop` to `OperationEventLoop`
    - The name change is to better clarify the role of this file: receiving events related to `Operation` resource.
- More code comments

#### Link to JIRA Story (if applicable): N/A