### PR TITLE
Add 'URL' to db constants check

### DIFF
--- a/backend-shared/hack/db-schema-sync-check/main.go
+++ b/backend-shared/hack/db-schema-sync-check/main.go
@@ -125,7 +125,7 @@ func convertSnakeCaseToCamelCase(fieldName string) string {
 	var fieldNameInCamelCase string
 
 	for i := 0; i < len(splitFieldName); i++ {
-		if splitFieldName[i] == "id" || splitFieldName[i] == "uid" {
+		if splitFieldName[i] == "id" || splitFieldName[i] == "uid" || splitFieldName[i] == "url" {
 			fieldNameInCamelCase += strings.ToUpper(splitFieldName[i])
 		} else {
 			fieldNameInCamelCase += strings.Title(splitFieldName[i])


### PR DESCRIPTION
This PR add the `URL` to be part of the check, as upper-case.
For example:

* db-schema.sql: `repository_url VARCHAR (512) NOT NULL,`
* db_field_constants.go: `RepositoryCredentialRepositoryURLLength`

This fails without this patch.
