### PR TITLE
Fix: Reset getErr variable to be used in next step

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/application_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/application_controller.go
@@ -254,6 +254,8 @@ func getGitOpsRepoData(asApplication applicationv1alpha1.Application) (string, s
 		// Ignore KeyNotFoundErrors, but otherwise report the error and return
 		if _, ok := (getErr).(*attributes.KeyNotFoundError); !ok {
 			return "", "", "", fmt.Errorf("unable to retrieve gitops repo branch: %v", getErr)
+		} else {
+			getErr = nil
 		}
 	}
 


### PR DESCRIPTION
getErr with ignored error was passed into next part where context load
failed on this ignored error.


#### Description:
- Fixing issue when branch is not defined, that error is ignored but in context check the error is still set.

