### PR TITLE
If AppStudio Application uses '/' as Git Repo Path, rewrite it to ., to make Argo CD happy

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/application_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/application_controller.go
@@ -274,6 +274,12 @@ func getGitOpsRepoData(asApplication applicationv1alpha1.Application) (string, s
 		return "", "", "", fmt.Errorf("gitops repo context is empty: %v", err)
 	}
 
+	// Argo CD expects a "non-absolute" path here. Argo CD interprets "/" as absolute, so change it to "."
+	// to indicate the root.
+	if context == "/" {
+		context = "."
+	}
+
 	return gitopsURL, branch, context, nil
 
 }


### PR DESCRIPTION
#### Description:
- This fixes a bug seen by [Scott on Red Hat Slack](https://coreos.slack.com/archives/C02C3SE8QS2/p1651755902793099?thread_ts=1651697197.950829&cid=C02C3SE8QS2), where Argo CD did not like a path value of '/' which we were setting in the source field of Argo CD `Application` resource.
- Argo CD  treats '/' as an absolute path, which it does not like :stuck_out_tongue:.
- So if the user specifies `/` in the AppStudio `Application` gitopsrepo context field, we will rewrite it to `.`, so that Argo CD is happy.

#### Link to JIRA Story (if applicable): N/A