### PR TITLE
Add ginkgo migration for existing test files

### DIFF
--- a/backend-shared/config/db/application_test.go
+++ b/backend-shared/config/db/application_test.go
@@ -2,6 +2,7 @@ package db_test
 
 import (
 	"context"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -10,7 +11,7 @@ import (
 )
 
 var _ = Describe("Application Test", func() {
-
+	var seq = 101
 	It("Should Create, Get, Update and Delete an Application", func() {
 		err := db.SetupForTestingDBGinkgo()
 		Expect(err).To(BeNil())
@@ -20,67 +21,31 @@ var _ = Describe("Application Test", func() {
 		Expect(err).To(BeNil())
 		defer dbq.CloseDatabase()
 
-		clusterCredentials := db.ClusterCredentials{
-			Clustercredentials_cred_id:  "test-cluster-creds-test",
-			Host:                        "host",
-			Kube_config:                 "kube-config",
-			Kube_config_context:         "kube-config-context",
-			Serviceaccount_bearer_token: "serviceaccount_bearer_token",
-			Serviceaccount_ns:           "Serviceaccount_ns",
-		}
+		_, managedEnvironment, _, gitopsEngineInstance, _, err := db.CreateSampleData(dbq)
+		Expect(err).To(BeNil())
 
-		managedEnvironment := db.ManagedEnvironment{
-			Managedenvironment_id: "test-managed-env-914",
-			Clustercredentials_id: clusterCredentials.Clustercredentials_cred_id,
-			Name:                  "my env",
-		}
-
-		gitopsEngineCluster := db.GitopsEngineCluster{
-			Gitopsenginecluster_id: "test-fake-cluster-914",
-			Clustercredentials_id:  clusterCredentials.Clustercredentials_cred_id,
-		}
-
-		gitopsEngineInstance := db.GitopsEngineInstance{
-			Gitopsengineinstance_id: "test-fake-engine-instance-id",
-			Namespace_name:          "test-fake-namespace",
-			Namespace_uid:           "test-fake-namespace-914",
-			EngineCluster_id:        gitopsEngineCluster.Gitopsenginecluster_id,
-		}
-
-		application := db.Application{
-			Application_id:          "test-my-application-1",
-			Name:                    "test-application",
+		applicationput := db.Application{
+			Application_id:          "test-my-application",
+			Name:                    "my-application",
 			Spec_field:              "{}",
 			Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
 			Managed_environment_id:  managedEnvironment.Managedenvironment_id,
 		}
 
-		err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)
-		Expect(err).To(BeNil())
-
-		err = dbq.CreateManagedEnvironment(ctx, &managedEnvironment)
-		Expect(err).To(BeNil())
-
-		err = dbq.CreateGitopsEngineCluster(ctx, &gitopsEngineCluster)
-		Expect(err).To(BeNil())
-
-		err = dbq.CreateGitopsEngineInstance(ctx, &gitopsEngineInstance)
-		Expect(err).To(BeNil())
-
-		err = dbq.CreateApplication(ctx, &application)
+		err = dbq.CreateApplication(ctx, &applicationput)
 		Expect(err).To(BeNil())
 
 		applicationget := db.Application{
-			Application_id: application.Application_id,
+			Application_id: applicationput.Application_id,
 		}
 
 		err = dbq.GetApplicationById(ctx, &applicationget)
 		Expect(err).To(BeNil())
-		Expect(application).Should(Equal(applicationget))
+		Expect(applicationput).Should(Equal(applicationget))
 
 		applicationupdate := db.Application{
 
-			Application_id:          application.Application_id,
+			Application_id:          applicationput.Application_id,
 			Name:                    "test-application-update",
 			Spec_field:              "{}",
 			Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
@@ -95,12 +60,26 @@ var _ = Describe("Application Test", func() {
 		Expect(err).To(BeNil())
 		Expect(applicationupdate).ShouldNot(Equal(applicationget))
 
-		rowsAffected, err := dbq.DeleteApplicationById(ctx, application.Application_id)
+		rowsAffected, err := dbq.DeleteApplicationById(ctx, applicationput.Application_id)
 		Expect(err).To(BeNil())
 		Expect(rowsAffected).Should(Equal(1))
 
-		err = dbq.GetApplicationById(ctx, &application)
+		err = dbq.GetApplicationById(ctx, &applicationput)
 		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+		applicationget = db.Application{
+			Application_id: "does-not-exist",
+		}
+		err = dbq.GetApplicationById(ctx, &applicationget)
+		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+		applicationupdate.Name = strings.Repeat("abc", 100)
+		err = dbq.UpdateApplication(ctx, &applicationupdate)
+		Expect(true).To(Equal(db.IsMaxLengthError(err)))
+
+		applicationput.Name = strings.Repeat("abc", 100)
+		err = dbq.CreateApplication(ctx, &applicationput)
+		Expect(true).To(Equal(db.IsMaxLengthError(err)))
 
 	})
 })

--- a/backend-shared/config/db/gitopsenginecluster_test.go
+++ b/backend-shared/config/db/gitopsenginecluster_test.go
@@ -2,6 +2,7 @@ package db_test
 
 import (
 	"context"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -53,5 +54,15 @@ var _ = Describe("Gitopsenginecluster Test", func() {
 
 		err = dbq.GetGitopsEngineClusterById(ctx, &gitopsEngineClusterget)
 		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+		gitopsEngineClusterget = db.GitopsEngineCluster{
+			Gitopsenginecluster_id: "does-not-exist"}
+		err = dbq.GetGitopsEngineClusterById(ctx, &gitopsEngineClusterget)
+		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+		gitopsEngineClusterput.Clustercredentials_id = strings.Repeat("abc", 100)
+		err = dbq.CreateGitopsEngineCluster(ctx, &gitopsEngineClusterput)
+		Expect(true).To(Equal(db.IsMaxLengthError(err)))
+
 	})
 })

--- a/backend-shared/config/db/gitopsengineinstance_test.go
+++ b/backend-shared/config/db/gitopsengineinstance_test.go
@@ -2,6 +2,7 @@ package db_test
 
 import (
 	"context"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -61,5 +62,16 @@ var _ = Describe("Gitopsengineinstance Test", func() {
 
 		err = dbq.GetGitopsEngineInstanceById(ctx, &gitopsEngineInstanceget)
 		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+		gitopsEngineInstanceget = db.GitopsEngineInstance{
+			Gitopsengineinstance_id: "does-not-exist",
+		}
+		err = dbq.GetGitopsEngineInstanceById(ctx, &gitopsEngineInstanceget)
+		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+		gitopsEngineInstanceput.EngineCluster_id = strings.Repeat("abc", 100)
+		err = dbq.CreateGitopsEngineInstance(ctx, &gitopsEngineInstanceput)
+		Expect(true).To(Equal(db.IsMaxLengthError(err)))
+
 	})
 })

--- a/backend-shared/config/db/kubernetesresourcetodbresourcemapping_test.go
+++ b/backend-shared/config/db/kubernetesresourcetodbresourcemapping_test.go
@@ -1,130 +1,49 @@
-package db
+package db_test
 
 import (
 	"context"
-	"strings"
-	"testing"
 
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	db "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
 )
 
-func TestCreateKubernetesResourceToDBResourceMapping(t *testing.T) {
-	SetupforTestingDB(t)
-	defer TestTeardown(t)
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer dbq.CloseDatabase()
+var _ = Describe("Kubernetesresourcetodbresourcemapping Test", func() {
+	It("Should Create, Get and Delete a KubernetesToDBResourceMapping", func() {
+		err := db.SetupForTestingDBGinkgo()
+		Expect(err).To(BeNil())
 
-	ctx := context.Background()
+		ctx := context.Background()
+		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+		Expect(err).To(BeNil())
+		defer dbq.CloseDatabase()
 
-	kubernetesToDBResourceMappingpost := KubernetesToDBResourceMapping{
-		KubernetesResourceType: "test-resource_1",
-		KubernetesResourceUID:  "test-resource_uid",
-		DBRelationType:         "test-relation_type",
-		DBRelationKey:          "test-relation_key",
-	}
-	err = dbq.CreateKubernetesResourceToDBResourceMapping(ctx, &kubernetesToDBResourceMappingpost)
-	assert.NoError(t, err)
+		kubernetesToDBResourceMapping := db.KubernetesToDBResourceMapping{
+			KubernetesResourceType: "test-resource_2",
+			KubernetesResourceUID:  "test-resource_uid",
+			DBRelationType:         "test-relation_type",
+			DBRelationKey:          "test-relation_key",
+		}
+		err = dbq.CreateKubernetesResourceToDBResourceMapping(ctx, &kubernetesToDBResourceMapping)
+		Expect(err).To(BeNil())
 
-	kubernetesToDBResourceMappingget := KubernetesToDBResourceMapping{
-		KubernetesResourceType: "test-resource_1",
-		KubernetesResourceUID:  "test-resource_uid",
-		DBRelationType:         "test-relation_type",
-		DBRelationKey:          "test-relation_key",
-	}
+		kubernetesToDBResourceMappingget := db.KubernetesToDBResourceMapping{
+			KubernetesResourceType: kubernetesToDBResourceMapping.KubernetesResourceType,
+			KubernetesResourceUID:  kubernetesToDBResourceMapping.KubernetesResourceUID,
+			DBRelationType:         kubernetesToDBResourceMapping.DBRelationType,
+			DBRelationKey:          kubernetesToDBResourceMapping.DBRelationType,
+		}
 
-	err = dbq.GetDBResourceMappingForKubernetesResource(ctx, &kubernetesToDBResourceMappingget)
-	if !assert.NoError(t, err) {
-		return
-	}
-	assert.Equal(t, kubernetesToDBResourceMappingpost, kubernetesToDBResourceMappingget)
+		err = dbq.GetDBResourceMappingForKubernetesResource(ctx, &kubernetesToDBResourceMappingget)
+		Expect(err).To(BeNil())
+		Expect(kubernetesToDBResourceMappingget).Should(Equal(kubernetesToDBResourceMapping))
 
-}
+		rowsAffected, err := dbq.DeleteKubernetesResourceToDBResourceMapping(ctx, &kubernetesToDBResourceMapping)
+		Expect(err).To(BeNil())
+		Expect(rowsAffected).Should(Equal(1))
 
-func TestGetDBResourceMappingForKubernetesResource(t *testing.T) {
-	SetupforTestingDB(t)
-	defer TestTeardown(t)
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer dbq.CloseDatabase()
-
-	ctx := context.Background()
-
-	kubernetesToDBResourceMappingpost := KubernetesToDBResourceMapping{
-		KubernetesResourceType: "test-resource_2",
-		KubernetesResourceUID:  "test-resource_uid",
-		DBRelationType:         "test-relation_type",
-		DBRelationKey:          "test-relation_key",
-	}
-	err = dbq.CreateKubernetesResourceToDBResourceMapping(ctx, &kubernetesToDBResourceMappingpost)
-	assert.NoError(t, err)
-
-	kubernetesToDBResourceMappingget := KubernetesToDBResourceMapping{
-		KubernetesResourceType: "test-resource_2",
-		KubernetesResourceUID:  "test-resource_uid",
-		DBRelationType:         "test-relation_type",
-		DBRelationKey:          "test-relation_key",
-	}
-
-	err = dbq.GetDBResourceMappingForKubernetesResource(ctx, &kubernetesToDBResourceMappingget)
-	if !assert.NoError(t, err) {
-		return
-	}
-	assert.Equal(t, kubernetesToDBResourceMappingpost, kubernetesToDBResourceMappingget)
-
-	kubernetesToDBResourceMappingNotExist := KubernetesToDBResourceMapping{
-		KubernetesResourceType: "test-resource_2_not_exist",
-		KubernetesResourceUID:  "test-resource_uid_not_exist",
-		DBRelationType:         "test-relation_type_not_exist",
-		DBRelationKey:          "test-relation_key_not_exist",
-	}
-	//check for inexistent primary key
-	err = dbq.GetDBResourceMappingForKubernetesResource(ctx, &kubernetesToDBResourceMappingNotExist)
-	if !assert.True(t, IsResultNotFoundError(err)) {
-		return
-	}
-
-	// Set the invalid value
-	kubernetesToDBResourceMappingpost.DBRelationType = strings.Repeat("abc", 100)
-	err = dbq.CreateKubernetesResourceToDBResourceMapping(ctx, &kubernetesToDBResourceMappingpost)
-	assert.True(t, IsMaxLengthError(err))
-}
-
-func TestDeleteKubernetesResourceToDBResourceMapping(t *testing.T) {
-	SetupforTestingDB(t)
-	defer TestTeardown(t)
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer dbq.CloseDatabase()
-
-	ctx := context.Background()
-
-	kubernetesToDBResourceMapping := KubernetesToDBResourceMapping{
-		KubernetesResourceType: "test-resource_11",
-		KubernetesResourceUID:  "test-resource_uid",
-		DBRelationType:         "test-relation_type",
-		DBRelationKey:          "test-relation_key",
-	}
-
-	err = dbq.CreateKubernetesResourceToDBResourceMapping(ctx, &kubernetesToDBResourceMapping)
-	assert.NoError(t, err)
-
-	err = dbq.GetDBResourceMappingForKubernetesResource(ctx, &kubernetesToDBResourceMapping)
-	assert.NoError(t, err)
-
-	rowsAffected, err := dbq.DeleteKubernetesResourceToDBResourceMapping(ctx, &kubernetesToDBResourceMapping)
-	assert.NoError(t, err)
-	assert.Equal(t, rowsAffected, 1)
-
-	err = dbq.GetDBResourceMappingForKubernetesResource(ctx, &kubernetesToDBResourceMapping)
-	if !assert.True(t, IsResultNotFoundError(err)) {
-		return
-	}
-
-}
+		err = dbq.GetDBResourceMappingForKubernetesResource(ctx, &kubernetesToDBResourceMappingget)
+		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+	})
+})

--- a/backend-shared/config/db/kubernetesresourcetodbresourcemapping_test.go
+++ b/backend-shared/config/db/kubernetesresourcetodbresourcemapping_test.go
@@ -2,6 +2,7 @@ package db_test
 
 import (
 	"context"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -45,5 +46,19 @@ var _ = Describe("Kubernetesresourcetodbresourcemapping Test", func() {
 
 		err = dbq.GetDBResourceMappingForKubernetesResource(ctx, &kubernetesToDBResourceMappingget)
 		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+		kubernetesToDBResourceMappingNotExist := db.KubernetesToDBResourceMapping{
+			KubernetesResourceType: "test-resource_2_not_exist",
+			KubernetesResourceUID:  "test-resource_uid_not_exist",
+			DBRelationType:         "test-relation_type_not_exist",
+			DBRelationKey:          "test-relation_key_not_exist",
+		}
+		err = dbq.GetDBResourceMappingForKubernetesResource(ctx, &kubernetesToDBResourceMappingNotExist)
+		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+		kubernetesToDBResourceMapping.DBRelationType = strings.Repeat("abc", 100)
+		err = dbq.CreateKubernetesResourceToDBResourceMapping(ctx, &kubernetesToDBResourceMapping)
+		Expect(true).To(Equal(db.IsMaxLengthError(err)))
+
 	})
 })

--- a/backend-shared/config/db/managedenvironment_test.go
+++ b/backend-shared/config/db/managedenvironment_test.go
@@ -1,264 +1,134 @@
-package db
+package db_test
 
 import (
 	"context"
-	"strings"
-	"testing"
 
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	db "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
 )
 
-func TestCreateManagedEnvironment(t *testing.T) {
-	SetupforTestingDB(t)
-	defer TestTeardown(t)
+var _ = Describe("Managedenvironment Test", func() {
+	It("Should Create, Get and Delete a ManagedEnvironment", func() {
+		err := db.SetupForTestingDBGinkgo()
+		Expect(err).To(BeNil())
 
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer dbq.CloseDatabase()
+		ctx := context.Background()
+		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+		Expect(err).To(BeNil())
+		defer dbq.CloseDatabase()
 
-	ctx := context.Background()
+		clusterCredentials := db.ClusterCredentials{
+			Clustercredentials_cred_id:  "test-cluster-creds-test-3",
+			Host:                        "host",
+			Kube_config:                 "kube-config",
+			Kube_config_context:         "kube-config-context",
+			Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+			Serviceaccount_ns:           "Serviceaccount_ns",
+		}
 
-	clusterCredentials := ClusterCredentials{
-		Clustercredentials_cred_id:  "test-cluster-creds-test-3",
-		Host:                        "host",
-		Kube_config:                 "kube-config",
-		Kube_config_context:         "kube-config-context",
-		Serviceaccount_bearer_token: "serviceaccount_bearer_token",
-		Serviceaccount_ns:           "Serviceaccount_ns",
-	}
+		managedEnvironment := db.ManagedEnvironment{
+			Managedenvironment_id: "test-managed-env-3",
+			Clustercredentials_id: clusterCredentials.Clustercredentials_cred_id,
+			Name:                  "my env101",
+		}
 
-	err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)
-	assert.NoError(t, err)
+		err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)
+		Expect(err).To(BeNil())
 
-	managedEnvironment := ManagedEnvironment{
-		Managedenvironment_id: "test-managed-env-3",
-		Clustercredentials_id: clusterCredentials.Clustercredentials_cred_id,
-		Name:                  "my env101",
-	}
-	post := dbq.CreateManagedEnvironment(ctx, &managedEnvironment)
-	if !assert.NoError(t, post) {
-		return
-	}
+		err = dbq.CreateManagedEnvironment(ctx, &managedEnvironment)
+		Expect(err).To(BeNil())
 
-	getmanagedEnvironment := ManagedEnvironment{
-		Managedenvironment_id: "test-managed-env-3",
-		Clustercredentials_id: clusterCredentials.Clustercredentials_cred_id,
-		Name:                  "my env101",
-	}
-	get := dbq.GetManagedEnvironmentById(ctx, &getmanagedEnvironment)
-	if !assert.NoError(t, get) {
-		return
-	}
-	assert.Equal(t, managedEnvironment, getmanagedEnvironment)
+		getmanagedEnvironment := db.ManagedEnvironment{
+			Managedenvironment_id: managedEnvironment.Managedenvironment_id,
+			SeqID:                 managedEnvironment.SeqID,
+			Name:                  managedEnvironment.Name,
+			Clustercredentials_id: managedEnvironment.Clustercredentials_id,
+		}
+		err = dbq.GetManagedEnvironmentById(ctx, &getmanagedEnvironment)
+		Expect(err).To(BeNil())
+		Expect(managedEnvironment).Should(Equal(getmanagedEnvironment))
 
-}
+		rowsAffected, err := dbq.DeleteManagedEnvironmentById(ctx, getmanagedEnvironment.Managedenvironment_id)
+		Expect(err).To(BeNil())
+		Expect(rowsAffected).Should(Equal(1))
 
-func TestGetManagedEnvironmentById(t *testing.T) {
+		err = dbq.GetManagedEnvironmentById(ctx, &getmanagedEnvironment)
+		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
 
-	SetupforTestingDB(t)
-	defer TestTeardown(t)
+	})
 
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer dbq.CloseDatabase()
+	It("Should List all the ManagedEnvironment entries", func() {
+		ctx := context.Background()
+		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+		Expect(err).To(BeNil())
+		defer dbq.CloseDatabase()
 
-	ctx := context.Background()
+		var clusterUser = &db.ClusterUser{
+			Clusteruser_id: "test-user-application",
+			User_name:      "test-user-application",
+		}
 
-	clusterCredentials := ClusterCredentials{
-		Clustercredentials_cred_id:  "test-cluster-creds-test-4",
-		Host:                        "host",
-		Kube_config:                 "kube-config",
-		Kube_config_context:         "kube-config-context",
-		Serviceaccount_bearer_token: "serviceaccount_bearer_token",
-		Serviceaccount_ns:           "Serviceaccount_ns",
-	}
+		clusterCredentials := db.ClusterCredentials{
+			Clustercredentials_cred_id:  "test-cluster-creds-test-6",
+			Host:                        "host",
+			Kube_config:                 "kube-config",
+			Kube_config_context:         "kube-config-context",
+			Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+			Serviceaccount_ns:           "Serviceaccount_ns",
+		}
 
-	err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)
-	assert.NoError(t, err)
+		managedEnvironment := db.ManagedEnvironment{
+			Managedenvironment_id: "test-managed-env-6",
+			Clustercredentials_id: clusterCredentials.Clustercredentials_cred_id,
+			Name:                  "my env101",
+		}
 
-	managedEnvironment := ManagedEnvironment{
-		Managedenvironment_id: "test-managed-env-4",
-		Clustercredentials_id: clusterCredentials.Clustercredentials_cred_id,
-		Name:                  "my env101",
-	}
-	post := dbq.CreateManagedEnvironment(ctx, &managedEnvironment)
-	if !assert.NoError(t, post) {
-		return
-	}
+		gitopsEngineCluster := db.GitopsEngineCluster{
+			Gitopsenginecluster_id: "test-fake-cluster-6",
+			Clustercredentials_id:  clusterCredentials.Clustercredentials_cred_id,
+		}
 
-	getmanagedEnvironment := ManagedEnvironment{
-		Managedenvironment_id: "test-managed-env-4",
-		Clustercredentials_id: clusterCredentials.Clustercredentials_cred_id,
-		Name:                  "my env101",
-	}
-	get := dbq.GetManagedEnvironmentById(ctx, &getmanagedEnvironment)
-	if !assert.NoError(t, get) {
-		return
-	}
-	assert.Equal(t, managedEnvironment, getmanagedEnvironment)
+		gitopsEngineInstance := db.GitopsEngineInstance{
+			Gitopsengineinstance_id: "test-fake-engine-instance-id",
+			Namespace_name:          "test-fake-namespace",
+			Namespace_uid:           "test-fake-namespace-6",
+			EngineCluster_id:        gitopsEngineCluster.Gitopsenginecluster_id,
+		}
 
-	//check for inexistent primary key
+		clusterAccess := db.ClusterAccess{
+			Clusteraccess_user_id:                   clusterUser.Clusteruser_id,
+			Clusteraccess_managed_environment_id:    managedEnvironment.Managedenvironment_id,
+			Clusteraccess_gitops_engine_instance_id: gitopsEngineInstance.Gitopsengineinstance_id,
+		}
 
-	managedEnvironmentNotExist := ManagedEnvironment{
-		Managedenvironment_id: "test-managed-env-4-not-exist",
-		Clustercredentials_id: clusterCredentials.Clustercredentials_cred_id,
-		Name:                  "my env101-not-exist",
-	}
+		var managedEnvironmentget []db.ManagedEnvironment
 
-	err = dbq.GetManagedEnvironmentById(ctx, &managedEnvironmentNotExist)
-	if !assert.True(t, IsResultNotFoundError(err)) {
-		return
-	}
+		err = dbq.CreateClusterUser(ctx, clusterUser)
+		Expect(err).To(BeNil())
 
-}
+		err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)
+		Expect(err).To(BeNil())
 
-func TestDeleteManagedEnvironmentById(t *testing.T) {
-	SetupforTestingDB(t)
-	defer TestTeardown(t)
+		err = dbq.CreateManagedEnvironment(ctx, &managedEnvironment)
+		Expect(err).To(BeNil())
 
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer dbq.CloseDatabase()
+		err = dbq.CreateGitopsEngineCluster(ctx, &gitopsEngineCluster)
+		Expect(err).To(BeNil())
 
-	ctx := context.Background()
+		err = dbq.CreateGitopsEngineInstance(ctx, &gitopsEngineInstance)
+		Expect(err).To(BeNil())
 
-	clusterCredentials := ClusterCredentials{
-		Clustercredentials_cred_id:  "test-cluster-creds-test-5",
-		Host:                        "host",
-		Kube_config:                 "kube-config",
-		Kube_config_context:         "kube-config-context",
-		Serviceaccount_bearer_token: "serviceaccount_bearer_token",
-		Serviceaccount_ns:           "Serviceaccount_ns",
-	}
+		err = dbq.CreateClusterAccess(ctx, &clusterAccess)
+		Expect(err).To(BeNil())
 
-	err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)
-	assert.NoError(t, err)
+		err = dbq.ListManagedEnvironmentForClusterCredentialsAndOwnerId(ctx, clusterCredentials.Clustercredentials_cred_id, clusterAccess.Clusteraccess_user_id, &managedEnvironmentget)
+		Expect(err).To(BeNil())
 
-	managedEnvironment := ManagedEnvironment{
-		Managedenvironment_id: "test-managed-env-5",
-		Clustercredentials_id: clusterCredentials.Clustercredentials_cred_id,
-		Name:                  "my env101",
-	}
-	post := dbq.CreateManagedEnvironment(ctx, &managedEnvironment)
-	if !assert.NoError(t, post) {
-		return
-	}
+		Expect(managedEnvironmentget[0]).Should(Equal(managedEnvironment))
+		Expect(len(managedEnvironmentget)).Should(Equal(1))
 
-	rowsAffected, err := dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
-	assert.NoError(t, err)
-	assert.Equal(t, rowsAffected, 1)
+	})
 
-	rowsAffected, err = dbq.DeleteClusterCredentialsById(ctx, clusterCredentials.Clustercredentials_cred_id)
-	assert.NoError(t, err)
-	assert.Equal(t, rowsAffected, 1)
-
-	err = dbq.GetManagedEnvironmentById(ctx, &managedEnvironment)
-	if !assert.True(t, IsResultNotFoundError(err)) {
-		return
-	}
-
-	err = dbq.GetClusterCredentialsById(ctx, &clusterCredentials)
-	if !assert.True(t, IsResultNotFoundError(err)) {
-		return
-	}
-
-}
-
-func TestListManagedEnvironmentForClusterCredentialsAndOwnerId(t *testing.T) {
-	SetupforTestingDB(t)
-	defer TestTeardown(t)
-
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer dbq.CloseDatabase()
-
-	ctx := context.Background()
-
-	var clusterUser = &ClusterUser{
-		Clusteruser_id: "test-user-application",
-		User_name:      "test-user-application",
-	}
-	err = dbq.CreateClusterUser(ctx, clusterUser)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	clusterCredentials := ClusterCredentials{
-		Clustercredentials_cred_id:  "test-cluster-creds-test-6",
-		Host:                        "host",
-		Kube_config:                 "kube-config",
-		Kube_config_context:         "kube-config-context",
-		Serviceaccount_bearer_token: "serviceaccount_bearer_token",
-		Serviceaccount_ns:           "Serviceaccount_ns",
-	}
-
-	managedEnvironment := ManagedEnvironment{
-		Managedenvironment_id: "test-managed-env-6",
-		Clustercredentials_id: clusterCredentials.Clustercredentials_cred_id,
-		Name:                  "my env101",
-	}
-
-	gitopsEngineCluster := GitopsEngineCluster{
-		Gitopsenginecluster_id: "test-fake-cluster-6",
-		Clustercredentials_id:  clusterCredentials.Clustercredentials_cred_id,
-	}
-
-	gitopsEngineInstance := GitopsEngineInstance{
-		Gitopsengineinstance_id: "test-fake-engine-instance-id",
-		Namespace_name:          "test-fake-namespace",
-		Namespace_uid:           "test-fake-namespace-6",
-		EngineCluster_id:        gitopsEngineCluster.Gitopsenginecluster_id,
-	}
-
-	clusterAccess := ClusterAccess{
-		Clusteraccess_user_id:                   clusterUser.Clusteruser_id,
-		Clusteraccess_managed_environment_id:    managedEnvironment.Managedenvironment_id,
-		Clusteraccess_gitops_engine_instance_id: gitopsEngineInstance.Gitopsengineinstance_id,
-	}
-
-	var managedEnvironments []ManagedEnvironment
-
-	err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	err = dbq.CreateManagedEnvironment(ctx, &managedEnvironment)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	err = dbq.CreateGitopsEngineCluster(ctx, &gitopsEngineCluster)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	err = dbq.CreateGitopsEngineInstance(ctx, &gitopsEngineInstance)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	err = dbq.CreateClusterAccess(ctx, &clusterAccess)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	err = dbq.ListManagedEnvironmentForClusterCredentialsAndOwnerId(ctx, clusterCredentials.Clustercredentials_cred_id, clusterAccess.Clusteraccess_user_id, &managedEnvironments)
-	assert.NoError(t, err)
-
-	assert.Equal(t, managedEnvironments[0], managedEnvironment)
-	assert.Equal(t, len(managedEnvironments), 1)
-
-	// Set the invalid value
-	managedEnvironment.Clustercredentials_id = strings.Repeat("abc", 100)
-	err = dbq.CreateManagedEnvironment(ctx, &managedEnvironment)
-	assert.True(t, IsMaxLengthError(err))
-}
+})


### PR DESCRIPTION
#### Description:
Migrates the following test files into ginkgo : 
- application_test.go
- gitopsenginecluster_test.go
- gitopsengineinstance_test.go
- kubernetestodbresourcemapping_test.go
- managedenvironment_test.go
- operation_test.go


#### Link to JIRA Story :

(https://issues.redhat.com/browse/GITOPSRVCE-121)