### PR TITLE
Convert ArgoCD Sync tests to ginkgo #123

### DIFF
--- a/cluster-agent/utils/argocd_login_command_test.go
+++ b/cluster-agent/utils/argocd_login_command_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// These tests are expected to run in parallel with other test cases, We can run the ginkgo tests parallelly by passing "ginkgo -p" command in CLI.
 var _ = Describe("ArgoCD Login Command", func() {
 	Context("ArgoCD Login Command Test", func() {
 		It("Ensure we are able to login to get a token”", func() {

--- a/cluster-agent/utils/argocd_login_command_test.go
+++ b/cluster-agent/utils/argocd_login_command_test.go
@@ -1,34 +1,31 @@
 package utils
 
 import (
-	"testing"
-
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/session"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/managed-gitops/cluster-agent/utils/mocks"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-func TestArgoCDLoginCommand(t *testing.T) {
+var _ = Describe("ArgoCD Login Command", func() {
+	Context("ArgoCD Login Command Test", func() {
+		It("Ensure we are able to login to get a token”", func() {
 
-	// Ensure we are able to login to get a token
+			mockSessionClient := &mocks.SessionServiceClient{}
+			mockAppClient := &mocks.Client{}
 
-	t.Parallel()
+			mockAppClient.On("NewSettingsClient").Return(mockCloser{}, nil, nil)
+			mockAppClient.On("NewSessionClient").Return(mockCloser{}, mockSessionClient, nil)
 
-	mockSessionClient := &mocks.SessionServiceClient{}
+			mockSessionClient.On("Create", mock.Anything, &session.SessionCreateRequest{
+				Username: "admin",
+				Password: "password",
+				Token:    "",
+			}).Return(&session.SessionResponse{Token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDUyMDM1NDksImp0aSI6ImM0Nzc2MDgwLTk3NDgtNGRhNS1iODU5LWMwM2QyM2Y3MGZhMiIsImlhdCI6MTY0NTExNzE0OSwiaXNzIjoiYXJnb2NkIiwibmJmIjoxNjQ1MTE3MTQ5LCJzdWIiOiJhZG1pbjpsb2dpbiJ9.7Di4Eb7xdBEF6SiScWbM5JdwE2Z_Kgr2hfzYA-KSLFs"}, nil)
 
-	mockAppClient := &mocks.Client{}
-
-	mockAppClient.On("NewSettingsClient").Return(mockCloser{}, nil, nil)
-	mockAppClient.On("NewSessionClient").Return(mockCloser{}, mockSessionClient, nil)
-
-	mockSessionClient.On("Create", mock.Anything, &session.SessionCreateRequest{
-		Username: "admin",
-		Password: "password",
-		Token:    "",
-	}).Return(&session.SessionResponse{Token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDUyMDM1NDksImp0aSI6ImM0Nzc2MDgwLTk3NDgtNGRhNS1iODU5LWMwM2QyM2Y3MGZhMiIsImlhdCI6MTY0NTExNzE0OSwiaXNzIjoiYXJnb2NkIiwibmJmIjoxNjQ1MTE3MTQ5LCJzdWIiOiJhZG1pbjpsb2dpbiJ9.7Di4Eb7xdBEF6SiScWbM5JdwE2Z_Kgr2hfzYA-KSLFs"}, nil)
-
-	_, err := argoCDLoginCommand("admin", "password", mockAppClient)
-	assert.NoError(t, err)
-
-}
+			_, err := argoCDLoginCommand("admin", "password", mockAppClient)
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/cluster-agent/utils/argocd_login_credentials_test.go
+++ b/cluster-agent/utils/argocd_login_credentials_test.go
@@ -86,19 +86,19 @@ var _ = Describe("ArgoCD Login Credentials", func() {
 
 			creds, argoClient, err := cs.GetArgoCDLoginCredentials(context.Background(), "openshift-gitops", "12", true, k8sClient)
 			Expect(err).To(BeNil())
-			Expect(creds).ToNot(BeNil())
+			Expect(argoCDCredentials{} == creds).To(BeFalse())
 			Expect(argoClient).ToNot(BeNil())
 
 			By("A second call should work as well")
 			creds, argoClient, err = cs.GetArgoCDLoginCredentials(context.Background(), "openshift-gitops", "12", true, k8sClient)
 			Expect(err).To(BeNil())
-			Expect(creds).ToNot(BeNil())
+			Expect(argoCDCredentials{} == creds).To(BeFalse())
 			Expect(argoClient).ToNot(BeNil())
 
 			By("Acquire from the cache")
 			creds, argoClient, err = cs.GetArgoCDLoginCredentials(context.Background(), "openshift-gitops", "12", false, k8sClient)
 			Expect(err).To(BeNil())
-			Expect(creds).ToNot(BeNil())
+			Expect(argoCDCredentials{} == creds).To(BeFalse())
 			Expect(argoClient).ToNot(BeNil())
 
 		})

--- a/cluster-agent/utils/argocd_login_credentials_test.go
+++ b/cluster-agent/utils/argocd_login_credentials_test.go
@@ -2,118 +2,108 @@ package utils
 
 import (
 	"context"
-	"testing"
 
 	argocdclient "github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/session"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/version"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/redhat-appstudio/managed-gitops/cluster-agent/utils/mocks"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-func TestGetArgoCDLoginCredentials(t *testing.T) {
+var _ = Describe("ArgoCD Login Credentials", func() {
+	Context("ArgoCD Login Credentials Test", func() {
+		It("Get ArgoCD LoginCredentials to retrieve the login credentials for an Argo CD cluster", func() {
+			var err error
 
-	opts := zap.Options{
-		Development: true,
-	}
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+			var k8sClient client.Client
+			{
 
-	// Ensure we are able to login to get a token
+				namespace := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "openshift-gitops",
+						Namespace: "openshift-gitops",
+					},
+				}
 
-	t.Parallel()
+				loginSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "openshift-gitops-cluster",
+						Namespace: "openshift-gitops",
+					},
+					Data: map[string][]byte{
+						"admin.password": []byte("a1Y4c0RvdkgxcHFPUTNJYWxSaDRubXlaZ3c3QUJGcmQ="),
+					},
+				}
 
-	var err error
+				route := &routev1.Route{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "openshift-gitops-server",
+						Namespace: "openshift-gitops",
+					},
+					Spec: routev1.RouteSpec{
+						Port: &routev1.RoutePort{
+							TargetPort: intstr.FromString("https"),
+						},
+						Host: "route-host",
+					},
+					Status: routev1.RouteStatus{},
+				}
 
-	var k8sClient client.Client
-	{
+				k8sClient, err = generateFakeK8sClient(namespace, loginSecret, route)
+				Expect(err).To(BeNil())
+			}
 
-		namespace := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "openshift-gitops",
-				Namespace: "openshift-gitops",
-			},
-		}
+			mockVersionClient := &mocks.VersionServiceClient{}
+			mockSessionClient := &mocks.SessionServiceClient{}
+			mockAppClient := &mocks.Client{}
 
-		loginSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "openshift-gitops-cluster",
-				Namespace: "openshift-gitops",
-			},
-			Data: map[string][]byte{
-				"admin.password": []byte("a1Y4c0RvdkgxcHFPUTNJYWxSaDRubXlaZ3c3QUJGcmQ="),
-			},
-		}
+			mockAppClient.On("NewSettingsClient").Return(mockCloser{}, nil, nil)
+			mockAppClient.On("NewSessionClient").Return(mockCloser{}, mockSessionClient, nil)
 
-		route := &routev1.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "openshift-gitops-server",
-				Namespace: "openshift-gitops",
-			},
-			Spec: routev1.RouteSpec{
-				Port: &routev1.RoutePort{
-					TargetPort: intstr.FromString("https"),
-				},
-				Host: "route-host",
-			},
-			Status: routev1.RouteStatus{},
-		}
+			By("The code being tested only expects a version client that returns a non-error")
+			mockAppClient.On("NewVersionClient").Return(mockCloser{}, mockVersionClient, nil)
+			mockVersionClient.On("Version", mock.Anything, mock.Anything).Return(&version.VersionMessage{Version: ""}, nil)
 
-		k8sClient, err = generateFakeK8sClient(namespace, loginSecret, route)
-		assert.NoError(t, err)
-	}
+			mockSessionClient.On("Create", mock.Anything, &session.SessionCreateRequest{
+				Username: "admin",
+				Password: "a1Y4c0RvdkgxcHFPUTNJYWxSaDRubXlaZ3c3QUJGcmQ=",
+				Token:    "",
+			}).Return(&session.SessionResponse{Token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDUyMDM1NDksImp0aSI6ImM0Nzc2MDgwLTk3NDgtNGRhNS1iODU5LWMwM2QyM2Y3MGZhMiIsImlhdCI6MTY0NTExNzE0OSwiaXNzIjoiYXJnb2NkIiwibmJmIjoxNjQ1MTE3MTQ5LCJzdWIiOiJhZG1pbjpsb2dpbiJ9.7Di4Eb7xdBEF6SiScWbM5JdwE2Z_Kgr2hfzYA-KSLFs"}, nil)
 
-	mockVersionClient := &mocks.VersionServiceClient{}
+			clientGenerator := mockClientGenerator{
+				mockClient: mockAppClient,
+			}
 
-	mockSessionClient := &mocks.SessionServiceClient{}
+			cs := NewCredentialService(&clientGenerator, true)
+			Expect(err).To(BeNil())
 
-	mockAppClient := &mocks.Client{}
+			creds, argoClient, err := cs.GetArgoCDLoginCredentials(context.Background(), "openshift-gitops", "12", true, k8sClient)
+			Expect(err).To(BeNil())
+			Expect(creds).ToNot(BeNil())
+			Expect(argoClient).ToNot(BeNil())
 
-	mockAppClient.On("NewSettingsClient").Return(mockCloser{}, nil, nil)
-	mockAppClient.On("NewSessionClient").Return(mockCloser{}, mockSessionClient, nil)
+			By("A second call should work as well")
+			creds, argoClient, err = cs.GetArgoCDLoginCredentials(context.Background(), "openshift-gitops", "12", true, k8sClient)
+			Expect(err).To(BeNil())
+			Expect(creds).ToNot(BeNil())
+			Expect(argoClient).ToNot(BeNil())
 
-	// The code being tested only expects a version client that returns a non-error
-	mockAppClient.On("NewVersionClient").Return(mockCloser{}, mockVersionClient, nil)
-	mockVersionClient.On("Version", mock.Anything, mock.Anything).Return(&version.VersionMessage{Version: ""}, nil)
+			By("Acquire from the cache")
+			creds, argoClient, err = cs.GetArgoCDLoginCredentials(context.Background(), "openshift-gitops", "12", false, k8sClient)
+			Expect(err).To(BeNil())
+			Expect(creds).ToNot(BeNil())
+			Expect(argoClient).ToNot(BeNil())
 
-	mockSessionClient.On("Create", mock.Anything, &session.SessionCreateRequest{
-		Username: "admin",
-		Password: "a1Y4c0RvdkgxcHFPUTNJYWxSaDRubXlaZ3c3QUJGcmQ=",
-		Token:    "",
-	}).Return(&session.SessionResponse{Token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDUyMDM1NDksImp0aSI6ImM0Nzc2MDgwLTk3NDgtNGRhNS1iODU5LWMwM2QyM2Y3MGZhMiIsImlhdCI6MTY0NTExNzE0OSwiaXNzIjoiYXJnb2NkIiwibmJmIjoxNjQ1MTE3MTQ5LCJzdWIiOiJhZG1pbjpsb2dpbiJ9.7Di4Eb7xdBEF6SiScWbM5JdwE2Z_Kgr2hfzYA-KSLFs"}, nil)
-
-	clientGenerator := mockClientGenerator{
-		mockClient: mockAppClient,
-	}
-
-	cs := NewCredentialService(&clientGenerator, true)
-	assert.NoError(t, err)
-
-	creds, argoClient, err := cs.GetArgoCDLoginCredentials(context.Background(), "openshift-gitops", "12", true, k8sClient)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, creds)
-	assert.NotEmpty(t, argoClient)
-
-	// A second call should work as well
-	creds, argoClient, err = cs.GetArgoCDLoginCredentials(context.Background(), "openshift-gitops", "12", true, k8sClient)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, creds)
-	assert.NotEmpty(t, argoClient)
-
-	// Acquire from the cache
-	creds, argoClient, err = cs.GetArgoCDLoginCredentials(context.Background(), "openshift-gitops", "12", false, k8sClient)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, creds)
-	assert.NotEmpty(t, argoClient)
-
-}
+		})
+	})
+})
 
 type mockClientGenerator struct {
 	mockClient argocdclient.Client

--- a/cluster-agent/utils/argocd_sync_command_test.go
+++ b/cluster-agent/utils/argocd_sync_command_test.go
@@ -2,16 +2,16 @@ package utils
 
 import (
 	"context"
-	"testing"
 
 	applicationpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/session"
 	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/gitops-engine/pkg/health"
 	"github.com/argoproj/gitops-engine/pkg/sync/common"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/redhat-appstudio/managed-gitops/cluster-agent/utils/mocks"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,110 +19,114 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestAppSync(t *testing.T) {
+var _ = Describe("ArgoCD AppSync Command", func() {
+	Context("ArgoCD AppSync Command Test", func() {
+		It("Synchronize application on the given Argo CD appliatication, in the given namespace.", func() {
+			var err error
 
-	t.Parallel()
+			nowTime := metav1.Now()
 
-	var err error
-
-	nowTime := metav1.Now()
-
-	app := &appv1.Application{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-app",
-			Namespace: "openshift-gitops",
-		},
-		Status: appv1.ApplicationStatus{
-			ReconciledAt: &nowTime,
-			Health:       appv1.HealthStatus{Status: health.HealthStatusHealthy},
-			Sync: appv1.SyncStatus{
-				Status: appv1.SyncStatusCodeSynced,
-			},
-			OperationState: &appv1.OperationState{
-				Phase:      common.OperationSucceeded,
-				FinishedAt: &nowTime,
-			},
-		},
-	}
-
-	var k8sClient client.Client
-
-	{
-
-		namespace := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "openshift-gitops",
-				Namespace: "openshift-gitops",
-			},
-		}
-
-		loginSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "openshift-gitops-cluster",
-				Namespace: "openshift-gitops",
-			},
-			Data: map[string][]byte{
-				"admin.password": []byte("a1Y4c0RvdkgxcHFPUTNJYWxSaDRubXlaZ3c3QUJGcmQ="),
-			},
-		}
-
-		route := &routev1.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "openshift-gitops-server",
-				Namespace: "openshift-gitops",
-			},
-			Spec: routev1.RouteSpec{
-				Port: &routev1.RoutePort{
-					TargetPort: intstr.FromString("https"),
+			app := &appv1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-app",
+					Namespace: "openshift-gitops",
 				},
-				Host: "route-host",
-			},
-			Status: routev1.RouteStatus{},
-		}
+				Status: appv1.ApplicationStatus{
+					ReconciledAt: &nowTime,
+					Health:       appv1.HealthStatus{Status: health.HealthStatusHealthy},
+					Sync: appv1.SyncStatus{
+						Status: appv1.SyncStatusCodeSynced,
+					},
+					OperationState: &appv1.OperationState{
+						Phase:      common.OperationSucceeded,
+						FinishedAt: &nowTime,
+					},
+				},
+			}
 
-		k8sClient, err = generateFakeK8sClient(namespace, loginSecret, route, app)
-		assert.NoError(t, err)
-	}
+			var k8sClient client.Client
 
-	mockAppClient := &mocks.Client{}
-	mockSessionClient := &mocks.SessionServiceClient{}
+			{
 
-	// 1) The sync logic will login and create a session token
-	mockAppClient.On("NewSettingsClient").Return(mockCloser{}, nil, nil)
-	mockAppClient.On("NewSessionClient").Return(mockCloser{}, mockSessionClient, nil)
-	mockSessionClient.On("Create", mock.Anything, &session.SessionCreateRequest{
-		Username: "admin",
-		Password: "a1Y4c0RvdkgxcHFPUTNJYWxSaDRubXlaZ3c3QUJGcmQ=",
-		Token:    "",
-	}).Return(&session.SessionResponse{Token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDUyMDM1NDksImp0aSI6ImM0Nzc2MDgwLTk3NDgtNGRhNS1iODU5LWMwM2QyM2Y3MGZhMiIsImlhdCI6MTY0NTExNzE0OSwiaXNzIjoiYXJnb2NkIiwibmJmIjoxNjQ1MTE3MTQ5LCJzdWIiOiJhZG1pbjpsb2dpbiJ9.7Di4Eb7xdBEF6SiScWbM5JdwE2Z_Kgr2hfzYA-KSLFs"}, nil)
+				namespace := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "openshift-gitops",
+						Namespace: "openshift-gitops",
+					},
+				}
 
-	// 2) The Sync function of AppServiceClient will be called with the app name, revision, and other parameters
-	mockAppServiceClient := &mocks.ApplicationServiceClient{}
-	mockAppClient.On("NewApplicationClient").Return(mockCloser{}, mockAppServiceClient, nil)
-	appName := "my-app"
-	mockAppServiceClient.On("Sync", mock.Anything, mock.MatchedBy(func(asr *applicationpkg.ApplicationSyncRequest) bool {
-		return *asr.Name == appName && asr.Revision == "master" && !asr.Prune
-	})).Return(nil, nil)
+				loginSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "openshift-gitops-cluster",
+						Namespace: "openshift-gitops",
+					},
+					Data: map[string][]byte{
+						"admin.password": []byte("a1Y4c0RvdkgxcHFPUTNJYWxSaDRubXlaZ3c3QUJGcmQ="),
+					},
+				}
 
-	// 3) After Sync, a Get occurs for the app, then a watch is setup to wait for the sync operation to finish.
-	// We provide the post-sync version of the app, to both
-	mockAppServiceClient.On("Get", mock.Anything, &applicationpkg.ApplicationQuery{Name: &appName}).Return(app, nil)
-	awe := make(chan *appv1.ApplicationWatchEvent)
-	go func() {
-		// Simulate the Application status updating to its final version (operation is complete)
-		awe <- &appv1.ApplicationWatchEvent{
-			Application: *app,
-		}
-		// After the above event is sent, close the channel
-		close(awe)
-	}()
-	mockAppClient.On("WatchApplicationWithRetry", mock.Anything, app.Name, mock.Anything).Return(awe)
+				route := &routev1.Route{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "openshift-gitops-server",
+						Namespace: "openshift-gitops",
+					},
+					Spec: routev1.RouteSpec{
+						Port: &routev1.RoutePort{
+							TargetPort: intstr.FromString("https"),
+						},
+						Host: "route-host",
+					},
+					Status: routev1.RouteStatus{},
+				}
 
-	clientGenerator := mockClientGenerator{
-		mockClient: mockAppClient,
-	}
+				k8sClient, err = generateFakeK8sClient(namespace, loginSecret, route, app)
+				Expect(err).To(BeNil())
+			}
 
-	cs := NewCredentialService(&clientGenerator, true)
-	err = AppSync(context.Background(), appName, "master", "openshift-gitops", k8sClient, cs, true)
-	assert.NoError(t, err)
-}
+			mockAppClient := &mocks.Client{}
+			mockSessionClient := &mocks.SessionServiceClient{}
+
+			By(" 1) The sync logic will login and create a session token")
+			mockAppClient.On("NewSettingsClient").Return(mockCloser{}, nil, nil)
+			mockAppClient.On("NewSessionClient").Return(mockCloser{}, mockSessionClient, nil)
+			mockSessionClient.On("Create", mock.Anything, &session.SessionCreateRequest{
+				Username: "admin",
+				Password: "a1Y4c0RvdkgxcHFPUTNJYWxSaDRubXlaZ3c3QUJGcmQ=",
+				Token:    "",
+			}).Return(&session.SessionResponse{Token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NDUyMDM1NDksImp0aSI6ImM0Nzc2MDgwLTk3NDgtNGRhNS1iODU5LWMwM2QyM2Y3MGZhMiIsImlhdCI6MTY0NTExNzE0OSwiaXNzIjoiYXJnb2NkIiwibmJmIjoxNjQ1MTE3MTQ5LCJzdWIiOiJhZG1pbjpsb2dpbiJ9.7Di4Eb7xdBEF6SiScWbM5JdwE2Z_Kgr2hfzYA-KSLFs"}, nil)
+
+			By("2) The Sync function of AppServiceClient will be called with the app name, revision, and other parameters")
+
+			mockAppServiceClient := &mocks.ApplicationServiceClient{}
+			mockAppClient.On("NewApplicationClient").Return(mockCloser{}, mockAppServiceClient, nil)
+			appName := "my-app"
+			mockAppServiceClient.On("Sync", mock.Anything, mock.MatchedBy(func(asr *applicationpkg.ApplicationSyncRequest) bool {
+				return *asr.Name == appName && asr.Revision == "master" && !asr.Prune
+			})).Return(nil, nil)
+
+			By(" 3) After Sync, a Get occurs for the app, then a watch is setup to wait for the sync operation to finish. We provide the post-sync version of the app, to both")
+
+			mockAppServiceClient.On("Get", mock.Anything, &applicationpkg.ApplicationQuery{Name: &appName}).Return(app, nil)
+			awe := make(chan *appv1.ApplicationWatchEvent)
+			go func() {
+				By("Simulate the Application status updating to its final version (operation is complete)")
+
+				awe <- &appv1.ApplicationWatchEvent{
+					Application: *app,
+				}
+				By("After the above event is sent, close the channel")
+
+				close(awe)
+			}()
+			mockAppClient.On("WatchApplicationWithRetry", mock.Anything, app.Name, mock.Anything).Return(awe)
+
+			clientGenerator := mockClientGenerator{
+				mockClient: mockAppClient,
+			}
+
+			cs := NewCredentialService(&clientGenerator, true)
+			err = AppSync(context.Background(), appName, "master", "openshift-gitops", k8sClient, cs, true)
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/cluster-agent/utils/argocd_terminate_app_command_test.go
+++ b/cluster-agent/utils/argocd_terminate_app_command_test.go
@@ -2,16 +2,17 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"io"
-	"testing"
 	"time"
 
 	applicationpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/gitops-engine/pkg/sync/common"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/redhat-appstudio/managed-gitops/cluster-agent/utils/mocks"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,89 +23,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func TestTerminateOperation(t *testing.T) {
-
-	// If the operation never terminates, after we ask it to terminate, then an error should be returned.
-
-	t.Parallel()
-
-	var err error
-
-	argoCDNamespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "argocd", Namespace: "argocd", UID: uuid.NewUUID()}}
-
-	application := &appv1.Application{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-app",
-			Namespace: "argocd",
-		},
-		Status: appv1.ApplicationStatus{
-			OperationState: &appv1.OperationState{
-				Phase: common.OperationRunning,
-			},
-		},
-	}
-
-	k8sClient, err := generateFakeK8sClient(application)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	mockAppServiceClient := &mocks.ApplicationServiceClient{}
-
-	mockAppClient := &mocks.Client{}
-	mockAppClient.On("NewApplicationClient").Return(mockCloser{}, mockAppServiceClient, nil)
-
-	mockAppServiceClient.On("TerminateOperation", mock.Anything, &applicationpkg.OperationTerminateRequest{Name: &application.Name}).Return(nil, nil)
-
-	startTime := time.Now()
-
-	err = terminateOperation(context.Background(), application.Name, argoCDNamespace, mockAppClient, k8sClient,
-		time.Duration(2*time.Second), log.FromContext(context.Background()))
-
-	elapsedTime := time.Since(startTime)
-
-	t.Logf("elapsed time: %v", elapsedTime)
-
-	if elapsedTime < 2*time.Second {
-		t.Error("Not enough time passeed in terminate operation")
-		return
-	}
-
-	assert.EqualError(t, err, "application operation never terminated: my-app")
-
-}
-
-func TestTerminateOperation_OperationGoesToDone(t *testing.T) {
-
-	argoCDNamespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "argocd", Namespace: "argocd", UID: uuid.NewUUID()}}
-
-	// Confirm that once an operation goes to error/succeeded/failed, that the
-	// terminate operation exits without error.
-
-	testCases := []struct {
-		name       string
-		finalPhase common.OperationPhase
-	}{
-		{
-			name:       "error",
-			finalPhase: common.OperationError,
-		},
-		{
-			name:       "succeeded",
-			finalPhase: common.OperationSucceeded,
-		},
-		{
-			name:       "failed",
-			finalPhase: common.OperationFailed,
-		},
-	}
-
-	for _, testCase := range testCases {
-
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			var err error
+var _ = Describe("Terminate Operation on Argo CD Application", func() {
+	Context("Terminate Operation on Argo CD Application Test", func() {
+		It("If the operation never terminates, after we ask it to terminate, then an error should be returned.", func() {
+			argoCDNamespace := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd",
+					Namespace: "argocd",
+					UID:       uuid.NewUUID(),
+				},
+			}
 
 			application := &appv1.Application{
 				ObjectMeta: metav1.ObjectMeta{
@@ -119,120 +47,164 @@ func TestTerminateOperation_OperationGoesToDone(t *testing.T) {
 			}
 
 			k8sClient, err := generateFakeK8sClient(application)
-			if err != nil {
-				t.Error(err)
+			Expect(err).To(BeNil())
+
+			mockAppServiceClient := &mocks.ApplicationServiceClient{}
+			mockAppClient := &mocks.Client{}
+
+			mockAppClient.On("NewApplicationClient").Return(mockCloser{}, mockAppServiceClient, nil)
+			mockAppServiceClient.On("TerminateOperation", mock.Anything, &applicationpkg.OperationTerminateRequest{Name: &application.Name}).Return(nil, nil)
+
+			startTime := time.Now()
+
+			err = terminateOperation(context.Background(), application.Name, argoCDNamespace, mockAppClient, k8sClient,
+				time.Duration(2*time.Second), log.FromContext(context.Background()))
+
+			elapsedTime := time.Since(startTime)
+
+			fmt.Printf("elapsed time: %v", elapsedTime)
+
+			if elapsedTime < 2*time.Second {
+				Fail("Not enough time passed in terminate operation")
 				return
 			}
 
-			// application exists and has a running operation
-			// then application doesn't exist
-			// confirm no error
+			Expect(err).ToNot(BeNil())
+		})
+
+		Context("Terminate Operation Goes To Done Test", func() {
+			argoCDNamespace := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd",
+					Namespace: "argocd",
+					UID:       uuid.NewUUID(),
+				},
+			}
+			testCases := []struct {
+				name       string
+				finalPhase common.OperationPhase
+			}{
+				{
+					name:       "error",
+					finalPhase: common.OperationError,
+				},
+				{
+					name:       "succeeded",
+					finalPhase: common.OperationSucceeded,
+				},
+				{
+					name:       "failed",
+					finalPhase: common.OperationFailed,
+				},
+			}
+
+			for _, testCase := range testCases {
+				When(testCase.name, func() {
+					It("Confirm that once an operation goes "+testCase.name+" that the terminate operation exits without error.", func() {
+						application := &appv1.Application{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "my-app",
+								Namespace: "argocd",
+							},
+							Status: appv1.ApplicationStatus{
+								OperationState: &appv1.OperationState{
+									Phase: common.OperationRunning,
+								},
+							},
+						}
+
+						k8sClient, err := generateFakeK8sClient(application)
+						Expect(err).To(BeNil())
+
+						By("Application exists and has a running operation then application doesn't exist confirm no error")
+						mockAppServiceClient := &mocks.ApplicationServiceClient{}
+						mockAppClient := &mocks.Client{}
+
+						mockAppClient.On("NewApplicationClient").Return(mockCloser{}, mockAppServiceClient, nil)
+						mockAppServiceClient.On("TerminateOperation", mock.Anything, &applicationpkg.OperationTerminateRequest{Name: &application.Name}).Return(nil, nil)
+
+						go func() {
+							time.Sleep(time.Second * 2)
+							application.Status.OperationState.Phase = testCase.finalPhase
+
+							err := k8sClient.Status().Update(context.Background(), application)
+							Expect(err).To(BeNil())
+						}()
+
+						startTime := time.Now()
+
+						err = terminateOperation(context.Background(), application.Name, argoCDNamespace, mockAppClient, k8sClient, time.Duration(5*time.Second), log.FromContext(context.Background()))
+						Expect(err).To(BeNil())
+
+						elapsedTime := time.Since(startTime)
+
+						fmt.Printf("elapsed time: %v", elapsedTime)
+
+						if elapsedTime < 2*time.Second {
+							Fail("Not enough time passeed in terminate operation")
+							return
+						}
+					})
+
+				})
+			}
+		})
+
+		It("Verify that the terminate operation exits immediately, if the application is deleted (no longer exists)", func() {
+			argoCDNamespace := corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd",
+					Namespace: "argocd",
+					UID:       uuid.NewUUID(),
+				},
+			}
+
+			application := &appv1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-app",
+					Namespace: "argocd",
+				},
+				Status: appv1.ApplicationStatus{
+					OperationState: &appv1.OperationState{
+						Phase: common.OperationRunning,
+					},
+				},
+			}
+
+			By("Application exists and has a running operation then application doesn't exist confirm no error")
+			k8sClient, err := generateFakeK8sClient(application)
+			Expect(err).To(BeNil())
 
 			mockAppServiceClient := &mocks.ApplicationServiceClient{}
-
 			mockAppClient := &mocks.Client{}
-			mockAppClient.On("NewApplicationClient").Return(mockCloser{}, mockAppServiceClient, nil)
 
-			mockAppServiceClient.On("TerminateOperation", mock.Anything, &applicationpkg.OperationTerminateRequest{Name: &application.Name}).Return(nil, nil)
+			mockAppClient.On("NewApplicationClient").Return(mockCloser{}, mockAppServiceClient, nil)
+			mockAppServiceClient.On("TerminateOperation", mock.Anything,
+				&applicationpkg.OperationTerminateRequest{Name: &application.Name}).Return(nil, nil)
 
 			go func() {
-
 				time.Sleep(time.Second * 2)
-				application.Status.OperationState.Phase = testCase.finalPhase
-
-				if err := k8sClient.Status().Update(context.Background(), application); err != nil {
-					t.Error(err)
-					return
-				}
-
+				err := k8sClient.Delete(context.Background(), application)
+				Expect(err).To(BeNil())
 			}()
 
 			startTime := time.Now()
 
-			err = terminateOperation(context.Background(), application.Name, argoCDNamespace, mockAppClient, k8sClient, time.Duration(5*time.Second), log.FromContext(context.Background()))
-			if err != nil {
-				t.Error(err)
-				return
-			}
+			err = terminateOperation(context.Background(), application.Name, argoCDNamespace, mockAppClient, k8sClient,
+				time.Duration(5*time.Second), log.FromContext(context.Background()))
+			Expect(err).To(BeNil())
 
 			elapsedTime := time.Since(startTime)
 
-			t.Logf("elapsed time: %v", elapsedTime)
+			fmt.Printf("elapsed time: %v", elapsedTime)
 
 			if elapsedTime < 2*time.Second {
-				t.Error("Not enough time passeed in terminate operation")
+				Fail("Not enough time passeed in terminate operation")
 				return
 			}
 		})
-	}
-
-}
-
-func TestTerminateOperation_ExitIfAppDoesntExist(t *testing.T) {
-
-	argoCDNamespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "argocd", Namespace: "argocd", UID: uuid.NewUUID()}}
-
-	// Verify that the terminate operation exits immediately, if the application is deleted (no longer exists)
-
-	var err error
-
-	application := &appv1.Application{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-app",
-			Namespace: "argocd",
-		},
-		Status: appv1.ApplicationStatus{
-			OperationState: &appv1.OperationState{
-				Phase: common.OperationRunning,
-			},
-		},
-	}
-
-	// application exists and has a running operation
-	// then application doesn't exist
-	// confirm no error
-
-	k8sClient, err := generateFakeK8sClient(application)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	mockAppServiceClient := &mocks.ApplicationServiceClient{}
-
-	mockAppClient := &mocks.Client{}
-	mockAppClient.On("NewApplicationClient").Return(mockCloser{}, mockAppServiceClient, nil)
-
-	mockAppServiceClient.On("TerminateOperation", mock.Anything,
-		&applicationpkg.OperationTerminateRequest{Name: &application.Name}).Return(nil, nil)
-
-	go func() {
-
-		time.Sleep(time.Second * 2)
-		err := k8sClient.Delete(context.Background(), application)
-
-		assert.NoError(t, err)
-
-	}()
-
-	startTime := time.Now()
-
-	err = terminateOperation(context.Background(), application.Name, argoCDNamespace, mockAppClient, k8sClient,
-		time.Duration(5*time.Second), log.FromContext(context.Background()))
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	elapsedTime := time.Since(startTime)
-
-	t.Logf("elapsed time: %v", elapsedTime)
-
-	if elapsedTime < 2*time.Second {
-		t.Error("Not enough time passeed in terminate operation")
-		return
-	}
-
-}
+	})
+})
 
 func generateFakeK8sClient(initObjs ...client.Object) (client.WithWatch, error) {
 	scheme := runtime.NewScheme()

--- a/cluster-agent/utils/argocd_terminate_app_command_test.go
+++ b/cluster-agent/utils/argocd_terminate_app_command_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	applicationpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
@@ -69,7 +70,7 @@ var _ = Describe("Terminate Operation on Argo CD Application", func() {
 				return
 			}
 
-			Expect(err).ToNot(BeNil())
+			Expect(strings.Contains(err.Error(), "application operation never terminated: my-app")).To(BeTrue())
 		})
 
 		Context("Terminate Operation Goes To Done Test", func() {

--- a/cluster-agent/utils/argocd_terminate_app_command_test.go
+++ b/cluster-agent/utils/argocd_terminate_app_command_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Terminate Operation on Argo CD Application", func() {
 
 			elapsedTime := time.Since(startTime)
 
-			fmt.Printf("elapsed time: %v", elapsedTime)
+			fmt.Fprintf(GinkgoWriter, "elapsed time: %v", elapsedTime)
 
 			if elapsedTime < 2*time.Second {
 				Fail("Not enough time passed in terminate operation")
@@ -139,7 +139,7 @@ var _ = Describe("Terminate Operation on Argo CD Application", func() {
 
 						elapsedTime := time.Since(startTime)
 
-						fmt.Printf("elapsed time: %v", elapsedTime)
+						fmt.Fprintf(GinkgoWriter, "elapsed time: %v", elapsedTime)
 
 						if elapsedTime < 2*time.Second {
 							Fail("Not enough time passeed in terminate operation")
@@ -197,7 +197,7 @@ var _ = Describe("Terminate Operation on Argo CD Application", func() {
 
 			elapsedTime := time.Since(startTime)
 
-			fmt.Printf("elapsed time: %v", elapsedTime)
+			fmt.Fprintf(GinkgoWriter, "elapsed time: %v", elapsedTime)
 
 			if elapsedTime < 2*time.Second {
 				Fail("Not enough time passeed in terminate operation")

--- a/cluster-agent/utils/utils_suite_test.go
+++ b/cluster-agent/utils/utils_suite_test.go
@@ -1,0 +1,13 @@
+package utils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}


### PR DESCRIPTION
#### Description:
- This PR is about converting ArgoCD Sync tests to ginkgo in cluster-agent
- Test files which are converted are :
           cluster-agent/utils/argocd_login_credentials_test.go
           cluster-agent/utils/argocd_terminate_app_command_test.go
           cluster-agent/utils/argocd_login_command_test.go
           cluster-agent/utils/argocd_sync_command_test.go

#### Link to JIRA Story (if applicable):
https://issues.redhat.com/browse/GITOPSRVCE-123)
