### PR TITLE
Add ginkgo test migration for non-group files 

### DIFF
--- a/backend-shared/config/db/types_test.go
+++ b/backend-shared/config/db/types_test.go
@@ -1,446 +1,402 @@
-package db
+package db_test
 
 import (
 	"context"
 	"fmt"
-	"testing"
 
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	db "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
 )
 
-// Ensure that the we are able to select on all the fields of the database.
-func TestSelectOnAllTables(t *testing.T) {
-
-	SetupforTestingDB(t)
-	defer TestTeardown(t)
-	ctx := context.Background()
-
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer dbq.CloseDatabase()
-
-	var applicationStates []ApplicationState
-	err = dbq.UnsafeListAllApplicationStates(ctx, &applicationStates)
-	assert.NoError(t, err)
-
-	var applications []Application
-	err = dbq.UnsafeListAllApplications(ctx, &applications)
-	assert.NoError(t, err)
-
-	var clusterAccess []ClusterAccess
-	err = dbq.UnsafeListAllClusterAccess(ctx, &clusterAccess)
-	assert.NoError(t, err)
-
-	var clusterCredentials []ClusterCredentials
-	err = dbq.UnsafeListAllClusterCredentials(ctx, &clusterCredentials)
-	assert.NoError(t, err)
-
-	var clusterUsers []ClusterUser
-	err = dbq.UnsafeListAllClusterUsers(ctx, &clusterUsers)
-	assert.NoError(t, err)
-
-	var engineClusters []GitopsEngineCluster
-	err = dbq.UnsafeListAllGitopsEngineClusters(ctx, &engineClusters)
-	assert.NoError(t, err)
-
-	var engineInstances []GitopsEngineInstance
-	err = dbq.UnsafeListAllGitopsEngineInstances(ctx, &engineInstances)
-	assert.NoError(t, err)
-
-	var managedEnvironments []ManagedEnvironment
-	err = dbq.UnsafeListAllManagedEnvironments(ctx, &managedEnvironments)
-	assert.NoError(t, err)
-
-	var operations []Operation
-	err = dbq.UnsafeListAllOperations(ctx, &operations)
-	assert.NoError(t, err)
-
-}
-
-func TestCreateApplication(t *testing.T) {
-	SetupforTestingDB(t)
-	defer TestTeardown(t)
-
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer dbq.CloseDatabase()
-
-	ctx := context.Background()
-	_, managedEnvironment, _, gitopsEngineInstance, clusterAccess, err := CreateSampleData(dbq)
-	if !assert.NoError(t, err) {
-		return
+var _ = Describe("Types Test", func() {
+	var testClusterUser = &db.ClusterUser{
+		Clusteruser_id: "test-user",
+		User_name:      "test-user",
 	}
 
-	application := &Application{
-		Application_id:          "test-my-application",
-		Name:                    "my-application",
-		Spec_field:              "{}",
-		Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
-		Managed_environment_id:  managedEnvironment.Managedenvironment_id,
-	}
+	It("Should execute select on all the fields of the database.", func() {
 
-	err = dbq.CheckedCreateApplication(ctx, application, clusterAccess.Clusteraccess_user_id)
-	if !assert.NoError(t, err) {
-		return
-	}
+		err := db.SetupForTestingDBGinkgo()
+		Expect(err).To(BeNil())
 
-	retrievedApplication := Application{Application_id: application.Application_id}
+		ctx := context.Background()
 
-	err = dbq.GetApplicationById(ctx, &retrievedApplication)
-	if !assert.NoError(t, err) {
-		return
-	}
-	if !assert.Equal(t, application.Application_id, retrievedApplication.Application_id) {
-		return
-	}
+		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+		Expect(err).To(BeNil())
+		defer dbq.CloseDatabase()
 
-	rowsAffected, err := dbq.CheckedDeleteApplicationById(ctx, application.Application_id, clusterAccess.Clusteraccess_user_id)
-	if !assert.NoError(t, err) {
-		return
-	}
-	if !assert.Equal(t, rowsAffected, 1) {
-		return
-	}
+		var applicationStates []db.ApplicationState
+		err = dbq.UnsafeListAllApplicationStates(ctx, &applicationStates)
+		Expect(err).To(BeNil())
 
-	retrievedApplication = Application{Application_id: application.Application_id}
-	err = dbq.GetApplicationById(ctx, &retrievedApplication)
-	if !assert.Error(t, err) {
-		return
-	}
+		var applications []db.Application
+		err = dbq.UnsafeListAllApplications(ctx, &applications)
+		Expect(err).To(BeNil())
 
-}
+		var clusterAccess []db.ClusterAccess
+		err = dbq.UnsafeListAllClusterAccess(ctx, &clusterAccess)
+		Expect(err).To(BeNil())
 
-func TestDeploymentToApplicationMapping(t *testing.T) {
+		var clusterCredentials []db.ClusterCredentials
+		err = dbq.UnsafeListAllClusterCredentials(ctx, &clusterCredentials)
+		Expect(err).To(BeNil())
 
-	// TODO: GITOPSRVCE-67 - DEBT - Finish filling this in
+		var clusterUsers []db.ClusterUser
+		err = dbq.UnsafeListAllClusterUsers(ctx, &clusterUsers)
+		Expect(err).To(BeNil())
 
-	SetupforTestingDB(t)
-	defer TestTeardown(t)
-	ctx := context.Background()
+		var engineClusters []db.GitopsEngineCluster
+		err = dbq.UnsafeListAllGitopsEngineClusters(ctx, &engineClusters)
+		Expect(err).To(BeNil())
 
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer dbq.CloseDatabase()
+		var engineInstances []db.GitopsEngineInstance
+		err = dbq.UnsafeListAllGitopsEngineInstances(ctx, &engineInstances)
+		Expect(err).To(BeNil())
 
-	mapping := DeploymentToApplicationMapping{}
-	err = dbq.CheckedGetDeploymentToApplicationMappingByDeplId(ctx, &mapping, "")
-	fmt.Println(err, mapping)
+		var managedEnvironments []db.ManagedEnvironment
+		err = dbq.UnsafeListAllManagedEnvironments(ctx, &managedEnvironments)
+		Expect(err).To(BeNil())
 
-}
+		var operations []db.Operation
+		err = dbq.UnsafeListAllOperations(ctx, &operations)
+		Expect(err).To(BeNil())
+	})
 
-func TestGitopsEngineInstanceAndCluster(t *testing.T) {
+	It("Should CheckedCreate and CheckedDelete an application", func() {
 
-	SetupforTestingDB(t)
-	defer TestTeardown(t)
+		err := db.SetupForTestingDBGinkgo()
+		Expect(err).To(BeNil())
 
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer dbq.CloseDatabase()
-	ctx := context.Background()
+		ctx := context.Background()
 
-	_, _, gitopsEngineCluster, gitopsEngineInstance, clusterAccess, err := CreateSampleData(dbq)
-	if !assert.NoError(t, err) {
-		return
-	}
+		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+		Expect(err).To(BeNil())
+		defer dbq.CloseDatabase()
 
-	retrievedGitopsEngineCluster := &GitopsEngineCluster{Gitopsenginecluster_id: gitopsEngineCluster.Gitopsenginecluster_id}
-	if err = dbq.CheckedGetGitopsEngineClusterById(ctx, retrievedGitopsEngineCluster, testClusterUser.Clusteruser_id); !assert.NoError(t, err) {
-		return
-	}
-	if !assert.Equal(t, &gitopsEngineCluster, &retrievedGitopsEngineCluster) {
-		return
-	}
+		_, managedEnvironment, _, gitopsEngineInstance, clusterAccess, err := db.CreateSampleData(dbq)
+		Expect(err).To(BeNil())
 
-	rowsAffected, err := dbq.DeleteClusterAccessById(ctx, clusterAccess.Clusteraccess_user_id, clusterAccess.Clusteraccess_managed_environment_id, clusterAccess.Clusteraccess_gitops_engine_instance_id)
-	assert.NoError(t, err)
-	assert.Equal(t, rowsAffected, 1)
-
-	rowsAffected, err = dbq.DeleteGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id)
-	assert.NoError(t, err)
-	assert.Equal(t, rowsAffected, 1)
-
-	// get should return not found, after the delete
-	gitopsEngineInstance = &GitopsEngineInstance{Gitopsengineinstance_id: gitopsEngineCluster.Gitopsenginecluster_id}
-	if err = dbq.CheckedGetGitopsEngineInstanceById(ctx, gitopsEngineInstance, testClusterUser.Clusteruser_id); !assert.Error(t, err) {
-		return
-	}
-	assert.True(t, IsResultNotFoundError(err))
-
-	rowsAffected, err = dbq.DeleteGitopsEngineClusterById(ctx, gitopsEngineCluster.Gitopsenginecluster_id)
-	assert.Equal(t, rowsAffected, 1)
-	assert.NoError(t, err)
-
-	retrievedGitopsEngineCluster = &GitopsEngineCluster{Gitopsenginecluster_id: gitopsEngineCluster.Gitopsenginecluster_id}
-	err = dbq.CheckedGetGitopsEngineClusterById(ctx, retrievedGitopsEngineCluster, testClusterUser.Clusteruser_id)
-	assert.Error(t, err)
-	assert.True(t, IsResultNotFoundError(err))
-}
-
-func TestManagedEnvironment(t *testing.T) {
-	SetupforTestingDB(t)
-	defer TestTeardown(t)
-	ctx := context.Background()
-
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer dbq.CloseDatabase()
-
-	_, managedEnvironment, _, _, clusterAccess, err := CreateSampleData(dbq)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	result := ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
-	err = dbq.CheckedGetManagedEnvironmentById(ctx, &result, testClusterUser.Clusteruser_id)
-	if !assert.NoError(t, err) {
-		return
-	}
-	assert.Equal(t, managedEnvironment.Name, result.Name)
-
-	result = ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
-	err = dbq.CheckedGetManagedEnvironmentById(ctx, &result, "another-user")
-	assert.NotNil(t, err)
-	// deleting from another user should fail
-	assert.True(t, IsResultNotFoundError(err))
-
-	rowsAffected, err := dbq.DeleteClusterAccessById(ctx, clusterAccess.Clusteraccess_user_id, clusterAccess.Clusteraccess_managed_environment_id, clusterAccess.Clusteraccess_gitops_engine_instance_id)
-	assert.NoError(t, err)
-	assert.Equal(t, rowsAffected, 1)
-
-	rowsAffected, err = dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
-	assert.NoError(t, err)
-	assert.Equal(t, rowsAffected, 1)
-
-	result = ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
-	err = dbq.CheckedGetManagedEnvironmentById(ctx, &result, testClusterUser.Clusteruser_id)
-	assert.NotNil(t, err)
-	assert.True(t, IsResultNotFoundError(err))
-
-}
-
-func TestOperation(t *testing.T) {
-	SetupforTestingDB(t)
-	defer TestTeardown(t)
-
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer dbq.CloseDatabase()
-	ctx := context.Background()
-	_, _, _, gitopsEngineInstance, _, err := CreateSampleData(dbq)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	operation := &Operation{
-		Operation_id:            "test-operation",
-		Instance_id:             gitopsEngineInstance.Gitopsengineinstance_id,
-		Resource_id:             "fake resource id",
-		Resource_type:           "GitopsEngineInstance",
-		State:                   OperationState_Waiting,
-		Operation_owner_user_id: testClusterUser.Clusteruser_id,
-	}
-
-	err = dbq.CreateOperation(ctx, operation, operation.Operation_owner_user_id)
-	assert.NoError(t, err)
-
-	result := Operation{Operation_id: operation.Operation_id}
-	err = dbq.CheckedGetOperationById(ctx, &result, operation.Operation_owner_user_id)
-	assert.NoError(t, err)
-	assert.Equal(t, result.Operation_id, operation.Operation_id)
-
-	result = Operation{Operation_id: operation.Operation_id}
-	err = dbq.CheckedGetOperationById(ctx, &result, "another-user")
-	if !assert.Error(t, err) {
-		return
-	}
-	assert.True(t, IsResultNotFoundError(err))
-	rowsAffected, _ := dbq.CheckedDeleteOperationById(ctx, operation.Operation_id, "another-user")
-	assert.Equal(t, rowsAffected, 0)
-
-	rowsAffected, err = dbq.CheckedDeleteOperationById(ctx, operation.Operation_id, operation.Operation_owner_user_id)
-	assert.Equal(t, rowsAffected, 1)
-	assert.NoError(t, err)
-}
-
-func TestClusterUser(t *testing.T) {
-	SetupforTestingDB(t)
-	defer TestTeardown(t)
-	ctx := context.Background()
-
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer dbq.CloseDatabase()
-
-	clusterUser := ClusterUser{
-		Clusteruser_id: "test-my-cluster-user-2",
-		User_name:      "cluster-mccluster",
-	}
-	err = dbq.CreateClusterUser(ctx, &clusterUser)
-	assert.NoError(t, err)
-
-	retrievedClusterUser := ClusterUser{Clusteruser_id: clusterUser.Clusteruser_id}
-	err = dbq.GetClusterUserById(ctx, &retrievedClusterUser)
-	assert.NoError(t, err)
-	assert.Equal(t, clusterUser.User_name, retrievedClusterUser.User_name)
-
-	rowsAffected, err := dbq.DeleteClusterUserById(ctx, clusterUser.Clusteruser_id)
-	assert.Equal(t, rowsAffected, 1)
-	assert.NoError(t, err)
-
-	retrievedClusterUser = ClusterUser{Clusteruser_id: clusterUser.Clusteruser_id}
-	if err = dbq.GetClusterUserById(ctx, &retrievedClusterUser); !assert.Error(t, err) {
-		return
-	}
-	assert.True(t, IsResultNotFoundError(err), err)
-
-	retrievedClusterUser = ClusterUser{Clusteruser_id: "does-not-exist"}
-	if err = dbq.GetClusterUserById(ctx, &retrievedClusterUser); !assert.Error(t, err) {
-		return
-	}
-	assert.True(t, IsResultNotFoundError(err))
-
-}
-
-func TestClusterCredentials(t *testing.T) {
-
-	SetupforTestingDB(t)
-	defer TestTeardown(t)
-
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer dbq.CloseDatabase()
-	ctx := context.Background()
-
-	clusterCredentials := ClusterCredentials{
-		Clustercredentials_cred_id:  "test-cluster-creds-test",
-		Host:                        "host",
-		Kube_config:                 "kube-config",
-		Kube_config_context:         "kube-config-context",
-		Serviceaccount_bearer_token: "serviceaccount_bearer_token",
-		Serviceaccount_ns:           "Serviceaccount_ns",
-	}
-
-	err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)
-	assert.NoError(t, err)
-
-	var gitopsEngineCluster GitopsEngineCluster
-	var gitopsEngineInstance GitopsEngineInstance
-	var clusterAccess ClusterAccess
-	var managedEnvironment ManagedEnvironment
-
-	// Create managed environment, and cluster access, so the non-unsafe get works below
-	{
-		managedEnvironment = ManagedEnvironment{
-			Managedenvironment_id: "test-managed-env-914",
-			Clustercredentials_id: clusterCredentials.Clustercredentials_cred_id,
-			Name:                  "my env",
-		}
-		err = dbq.CreateManagedEnvironment(ctx, &managedEnvironment)
-		if !assert.NoError(t, err) {
-			return
+		application := &db.Application{
+			Application_id:          "test-my-application",
+			Name:                    "my-application",
+			Spec_field:              "{}",
+			Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
+			Managed_environment_id:  managedEnvironment.Managedenvironment_id,
 		}
 
-		gitopsEngineCluster = GitopsEngineCluster{
-			Gitopsenginecluster_id: "test-fake-cluster-914",
-			Clustercredentials_id:  clusterCredentials.Clustercredentials_cred_id,
+		err = dbq.CheckedCreateApplication(ctx, application, clusterAccess.Clusteraccess_user_id)
+		Expect(err).To(BeNil())
+
+		retrievedApplication := db.Application{Application_id: application.Application_id}
+
+		err = dbq.GetApplicationById(ctx, &retrievedApplication)
+		Expect(err).To(BeNil())
+		Expect(application.Application_id).Should(Equal(retrievedApplication.Application_id))
+
+		rowsAffected, err := dbq.CheckedDeleteApplicationById(ctx, application.Application_id, clusterAccess.Clusteraccess_user_id)
+		Expect(err).To(BeNil())
+		Expect(rowsAffected).Should(Equal(1))
+
+		retrievedApplication = db.Application{Application_id: application.Application_id}
+		err = dbq.GetApplicationById(ctx, &retrievedApplication)
+		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+	})
+
+	It("Should test deploymenttoapplication mapping", func() {
+
+		err := db.SetupForTestingDBGinkgo()
+		Expect(err).To(BeNil())
+
+		ctx := context.Background()
+
+		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+		Expect(err).To(BeNil())
+		defer dbq.CloseDatabase()
+
+		mapping := db.DeploymentToApplicationMapping{}
+		err = dbq.CheckedGetDeploymentToApplicationMappingByDeplId(ctx, &mapping, "")
+		fmt.Println(err, mapping)
+
+	})
+
+	It("Should test GitopsEngineInstance and GitOpsEngineCluster", func() {
+
+		err := db.SetupForTestingDBGinkgo()
+		Expect(err).To(BeNil())
+
+		ctx := context.Background()
+
+		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+		Expect(err).To(BeNil())
+		defer dbq.CloseDatabase()
+
+		_, _, gitopsEngineCluster, gitopsEngineInstance, clusterAccess, err := db.CreateSampleData(dbq)
+		Expect(err).To(BeNil())
+
+		retrievedGitopsEngineCluster := &db.GitopsEngineCluster{Gitopsenginecluster_id: gitopsEngineCluster.Gitopsenginecluster_id}
+		err = dbq.CheckedGetGitopsEngineClusterById(ctx, retrievedGitopsEngineCluster, testClusterUser.Clusteruser_id)
+		Expect(err).To(BeNil())
+		Expect(&gitopsEngineCluster).Should(Equal(&retrievedGitopsEngineCluster))
+
+		rowsAffected, err := dbq.DeleteClusterAccessById(ctx, clusterAccess.Clusteraccess_user_id, clusterAccess.Clusteraccess_managed_environment_id, clusterAccess.Clusteraccess_gitops_engine_instance_id)
+		Expect(err).To(BeNil())
+		Expect(rowsAffected).Should(Equal(1))
+
+		rowsAffected, err = dbq.DeleteGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id)
+		Expect(err).To(BeNil())
+		Expect(rowsAffected).Should(Equal(1))
+
+		gitopsEngineInstance = &db.GitopsEngineInstance{Gitopsengineinstance_id: gitopsEngineInstance.Gitopsengineinstance_id}
+		err = dbq.CheckedGetGitopsEngineInstanceById(ctx, gitopsEngineInstance, testClusterUser.Clusteruser_id)
+		Expect(err).ToNot(BeNil())
+		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+		rowsAffected, err = dbq.DeleteGitopsEngineClusterById(ctx, gitopsEngineCluster.Gitopsenginecluster_id)
+		Expect(err).To(BeNil())
+		Expect(rowsAffected).Should(Equal(1))
+
+		retrievedGitopsEngineCluster = &db.GitopsEngineCluster{Gitopsenginecluster_id: gitopsEngineCluster.Gitopsenginecluster_id}
+		err = dbq.CheckedGetGitopsEngineClusterById(ctx, retrievedGitopsEngineCluster, testClusterUser.Clusteruser_id)
+		Expect(err).ToNot(BeNil())
+		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+	})
+
+	It("Should test ManagedEnvironment", func() {
+
+		err := db.SetupForTestingDBGinkgo()
+		Expect(err).To(BeNil())
+
+		ctx := context.Background()
+
+		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+		Expect(err).To(BeNil())
+		defer dbq.CloseDatabase()
+
+		_, managedEnvironment, _, _, clusterAccess, err := db.CreateSampleData(dbq)
+		Expect(err).To(BeNil())
+
+		result := &db.ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
+
+		err = dbq.CheckedGetManagedEnvironmentById(ctx, result, testClusterUser.Clusteruser_id)
+		Expect(err).To(BeNil())
+
+		Expect(managedEnvironment).Should(Equal(result))
+
+		result = &db.ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
+		err = dbq.CheckedGetManagedEnvironmentById(ctx, result, "another-user-test")
+		Expect(err).ToNot(BeNil())
+		// deleting from another user should fail
+		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+		rowsAffected, err := dbq.DeleteClusterAccessById(ctx, clusterAccess.Clusteraccess_user_id, clusterAccess.Clusteraccess_managed_environment_id, clusterAccess.Clusteraccess_gitops_engine_instance_id)
+		Expect(err).To(BeNil())
+		Expect(rowsAffected).Should(Equal(1))
+
+		rowsAffected, err = dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
+		Expect(err).To(BeNil())
+		Expect(rowsAffected).Should(Equal(1))
+
+		result = &db.ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
+		err = dbq.CheckedGetManagedEnvironmentById(ctx, result, testClusterUser.Clusteruser_id)
+		Expect(err).ToNot(BeNil())
+		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+	})
+
+	It("Should test Operations", func() {
+
+		err := db.SetupForTestingDBGinkgo()
+		Expect(err).To(BeNil())
+
+		ctx := context.Background()
+
+		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+		Expect(err).To(BeNil())
+		defer dbq.CloseDatabase()
+
+		_, _, _, gitopsEngineInstance, _, err := db.CreateSampleData(dbq)
+		Expect(err).To(BeNil())
+
+		operation := &db.Operation{
+			Operation_id:            "test-operation",
+			Instance_id:             gitopsEngineInstance.Gitopsengineinstance_id,
+			Resource_id:             "fake resource id",
+			Resource_type:           "GitopsEngineInstance",
+			State:                   db.OperationState_Waiting,
+			Operation_owner_user_id: testClusterUser.Clusteruser_id,
 		}
-		err = dbq.CreateGitopsEngineCluster(ctx, &gitopsEngineCluster)
-		if !assert.NoError(t, err) {
-			return
+
+		err = dbq.CreateOperation(ctx, operation, operation.Operation_owner_user_id)
+		Expect(err).To(BeNil())
+
+		result := db.Operation{Operation_id: operation.Operation_id}
+		err = dbq.CheckedGetOperationById(ctx, &result, operation.Operation_owner_user_id)
+		Expect(err).To(BeNil())
+		Expect(operation.Operation_id).Should(Equal(result.Operation_id))
+
+		result = db.Operation{Operation_id: operation.Operation_id}
+		err = dbq.CheckedGetOperationById(ctx, &result, "another-user-test")
+		Expect(err).ToNot(BeNil())
+		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+		rowsAffected, _ := dbq.CheckedDeleteOperationById(ctx, operation.Operation_id, "another-user")
+		Expect(rowsAffected).Should(Equal(0))
+
+		rowsAffected, err = dbq.CheckedDeleteOperationById(ctx, operation.Operation_id, operation.Operation_owner_user_id)
+		Expect(rowsAffected).Should(Equal(1))
+		Expect(err).To(BeNil())
+	})
+	It("Should test ClusterUser", func() {
+
+		err := db.SetupForTestingDBGinkgo()
+		Expect(err).To(BeNil())
+
+		ctx := context.Background()
+
+		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+		Expect(err).To(BeNil())
+		defer dbq.CloseDatabase()
+
+		clusterUser := db.ClusterUser{
+			Clusteruser_id: "test-my-cluster-user-2",
+			User_name:      "cluster-mccluster",
+		}
+		err = dbq.CreateClusterUser(ctx, &clusterUser)
+		Expect(err).To(BeNil())
+
+		retrievedClusterUser := db.ClusterUser{Clusteruser_id: clusterUser.Clusteruser_id}
+		err = dbq.GetClusterUserById(ctx, &retrievedClusterUser)
+		Expect(err).To(BeNil())
+		Expect(clusterUser.User_name).Should(Equal(retrievedClusterUser.User_name))
+
+		rowsAffected, err := dbq.DeleteClusterUserById(ctx, clusterUser.Clusteruser_id)
+		Expect(rowsAffected).Should(Equal(1))
+		Expect(err).To(BeNil())
+
+		retrievedClusterUser = db.ClusterUser{Clusteruser_id: clusterUser.Clusteruser_id}
+		err = dbq.GetClusterUserById(ctx, &retrievedClusterUser)
+		Expect(err).ToNot(BeNil())
+		Expect(db.IsResultNotFoundError(err)).To(Equal(true))
+
+		retrievedClusterUser = db.ClusterUser{Clusteruser_id: "does-not-exist"}
+		err = dbq.GetClusterUserById(ctx, &retrievedClusterUser)
+		Expect(err).ToNot(BeNil())
+		Expect(db.IsResultNotFoundError(err)).To(Equal(true))
+	})
+
+	It("Should test ClusterCredentials", func() {
+
+		err := db.SetupForTestingDBGinkgo()
+		Expect(err).To(BeNil())
+
+		ctx := context.Background()
+
+		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+		Expect(err).To(BeNil())
+		defer dbq.CloseDatabase()
+
+		clusterCredentials := db.ClusterCredentials{
+			Clustercredentials_cred_id:  "test-cluster-creds-test",
+			Host:                        "host",
+			Kube_config:                 "kube-config",
+			Kube_config_context:         "kube-config-context",
+			Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+			Serviceaccount_ns:           "Serviceaccount_ns",
 		}
 
-		gitopsEngineInstance = GitopsEngineInstance{
-			Gitopsengineinstance_id: "test-fake-engine-instance-id",
-			Namespace_name:          "test-fake-namespace",
-			Namespace_uid:           "test-fake-namespace-914",
-			EngineCluster_id:        gitopsEngineCluster.Gitopsenginecluster_id,
+		err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)
+		Expect(err).To(BeNil())
+
+		var gitopsEngineCluster db.GitopsEngineCluster
+		var gitopsEngineInstance db.GitopsEngineInstance
+		var clusterAccess db.ClusterAccess
+		var managedEnvironment db.ManagedEnvironment
+
+		// Create managed environment, and cluster access, so the non-unsafe get works below
+		{
+			managedEnvironment = db.ManagedEnvironment{
+				Managedenvironment_id: "test-managed-env-914",
+				Clustercredentials_id: clusterCredentials.Clustercredentials_cred_id,
+				Name:                  "my env",
+			}
+			err = dbq.CreateManagedEnvironment(ctx, &managedEnvironment)
+			Expect(err).To(BeNil())
+
+			gitopsEngineCluster = db.GitopsEngineCluster{
+				Gitopsenginecluster_id: "test-fake-cluster-914",
+				Clustercredentials_id:  clusterCredentials.Clustercredentials_cred_id,
+			}
+			err = dbq.CreateGitopsEngineCluster(ctx, &gitopsEngineCluster)
+			Expect(err).To(BeNil())
+
+			gitopsEngineInstance = db.GitopsEngineInstance{
+				Gitopsengineinstance_id: "test-fake-engine-instance-id",
+				Namespace_name:          "test-fake-namespace",
+				Namespace_uid:           "test-fake-namespace-914",
+				EngineCluster_id:        gitopsEngineCluster.Gitopsenginecluster_id,
+			}
+			err = dbq.CreateGitopsEngineInstance(ctx, &gitopsEngineInstance)
+			Expect(err).To(BeNil())
+
+			clusterAccess = db.ClusterAccess{
+				Clusteraccess_user_id:                   testClusterUser.Clusteruser_id,
+				Clusteraccess_managed_environment_id:    managedEnvironment.Managedenvironment_id,
+				Clusteraccess_gitops_engine_instance_id: gitopsEngineInstance.Gitopsengineinstance_id,
+			}
+			err = dbq.CreateClusterAccess(ctx, &clusterAccess)
+			Expect(err).To(BeNil())
+
 		}
-		err = dbq.CreateGitopsEngineInstance(ctx, &gitopsEngineInstance)
-		if !assert.NoError(t, err) {
-			return
+
+		retrievedClusterCredentials := &db.ClusterCredentials{
+			Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
 		}
+		err = dbq.GetClusterCredentialsById(ctx, retrievedClusterCredentials)
+		Expect(err).To(BeNil())
 
-		clusterAccess = ClusterAccess{
-			Clusteraccess_user_id:                   testClusterUser.Clusteruser_id,
-			Clusteraccess_managed_environment_id:    managedEnvironment.Managedenvironment_id,
-			Clusteraccess_gitops_engine_instance_id: gitopsEngineInstance.Gitopsengineinstance_id,
+		Expect(clusterCredentials.Host).Should(Equal(retrievedClusterCredentials.Host))
+		Expect(clusterCredentials.Kube_config).Should(Equal(retrievedClusterCredentials.Kube_config))
+		Expect(clusterCredentials.Kube_config_context).Should(Equal(retrievedClusterCredentials.Kube_config_context))
+
+		retrievedClusterCredentials = &db.ClusterCredentials{
+			Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
 		}
+		err = dbq.CheckedGetClusterCredentialsById(ctx, retrievedClusterCredentials, testClusterUser.Clusteruser_id)
+		Expect(err).To(BeNil())
+		Expect(retrievedClusterCredentials).ToNot(BeNil())
 
-		err = dbq.CreateClusterAccess(ctx, &clusterAccess)
-		if !assert.NoError(t, err) {
-			return
+		Expect(clusterCredentials.Host).Should(Equal(retrievedClusterCredentials.Host))
+		Expect(clusterCredentials.Kube_config).Should(Equal(retrievedClusterCredentials.Kube_config))
+		Expect(clusterCredentials.Kube_config_context).Should(Equal(retrievedClusterCredentials.Kube_config_context))
+
+		rowsAffected, err := dbq.DeleteClusterAccessById(ctx, clusterAccess.Clusteraccess_user_id, clusterAccess.Clusteraccess_managed_environment_id, clusterAccess.Clusteraccess_gitops_engine_instance_id)
+		Expect(rowsAffected).Should(Equal(1))
+		Expect(err).To(BeNil())
+
+		rowsAffected, err = dbq.DeleteGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id)
+		Expect(rowsAffected).Should(Equal(1))
+		Expect(err).To(BeNil())
+
+		rowsAffected, err = dbq.DeleteGitopsEngineClusterById(ctx, gitopsEngineCluster.Gitopsenginecluster_id)
+		Expect(rowsAffected).Should(Equal(1))
+		Expect(err).To(BeNil())
+
+		rowsAffected, err = dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
+		Expect(rowsAffected).Should(Equal(1))
+		Expect(err).To(BeNil())
+
+		rowsAffected, err = dbq.DeleteClusterCredentialsById(ctx, clusterCredentials.Clustercredentials_cred_id)
+		Expect(rowsAffected).Should(Equal(1))
+		Expect(err).To(BeNil())
+
+		retrievedClusterCredentials = &db.ClusterCredentials{
+			Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
 		}
-	}
+		err = dbq.GetClusterCredentialsById(ctx, retrievedClusterCredentials)
+		Expect(err).ToNot(BeNil())
+		Expect(db.IsResultNotFoundError(err)).To(Equal(true))
+	})
 
-	retrievedClusterCredentials := &ClusterCredentials{
-		Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
-	}
-	err = dbq.GetClusterCredentialsById(ctx, retrievedClusterCredentials)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	assert.Equal(t, clusterCredentials.Host, retrievedClusterCredentials.Host)
-	assert.Equal(t, clusterCredentials.Kube_config, retrievedClusterCredentials.Kube_config)
-	assert.Equal(t, clusterCredentials.Kube_config_context, retrievedClusterCredentials.Kube_config_context)
-
-	retrievedClusterCredentials = &ClusterCredentials{
-		Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
-	}
-	err = dbq.CheckedGetClusterCredentialsById(ctx, retrievedClusterCredentials, testClusterUser.Clusteruser_id)
-	if !assert.NoError(t, err) ||
-		!assert.NotNil(t, retrievedClusterCredentials) {
-		return
-	}
-
-	assert.Equal(t, clusterCredentials.Host, retrievedClusterCredentials.Host)
-	assert.Equal(t, clusterCredentials.Kube_config, retrievedClusterCredentials.Kube_config)
-	assert.Equal(t, clusterCredentials.Kube_config_context, retrievedClusterCredentials.Kube_config_context)
-
-	rowsAffected, err := dbq.DeleteClusterAccessById(ctx, clusterAccess.Clusteraccess_user_id, clusterAccess.Clusteraccess_managed_environment_id, clusterAccess.Clusteraccess_gitops_engine_instance_id)
-	assert.NoError(t, err)
-	assert.Equal(t, rowsAffected, 1)
-
-	rowsAffected, err = dbq.DeleteGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id)
-	assert.NoError(t, err)
-	assert.Equal(t, rowsAffected, 1)
-
-	rowsAffected, err = dbq.DeleteGitopsEngineClusterById(ctx, gitopsEngineCluster.Gitopsenginecluster_id)
-	assert.NoError(t, err)
-	assert.Equal(t, rowsAffected, 1)
-
-	rowsAffected, err = dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
-	assert.NoError(t, err)
-	assert.Equal(t, rowsAffected, 1)
-
-	rowsAffected, err = dbq.DeleteClusterCredentialsById(ctx, clusterCredentials.Clustercredentials_cred_id)
-	// add delete options for other tables table as well!
-	assert.NoError(t, err)
-	assert.Equal(t, rowsAffected, 1)
-
-	retrievedClusterCredentials = &ClusterCredentials{
-		Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
-	}
-	err = dbq.GetClusterCredentialsById(ctx, retrievedClusterCredentials)
-	if !assert.Error(t, err) {
-		return
-	}
-	assert.True(t, IsResultNotFoundError(err))
-
-}
+})

--- a/backend-shared/config/db/types_test.go
+++ b/backend-shared/config/db/types_test.go
@@ -10,393 +10,396 @@ import (
 )
 
 var _ = Describe("Types Test", func() {
-	var testClusterUser = &db.ClusterUser{
-		Clusteruser_id: "test-user",
-		User_name:      "test-user",
-	}
+	Context("Tests all the functions for types.go", func() {
 
-	It("Should execute select on all the fields of the database.", func() {
-
-		err := db.SetupForTestingDBGinkgo()
-		Expect(err).To(BeNil())
-
-		ctx := context.Background()
-
-		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
-		Expect(err).To(BeNil())
-		defer dbq.CloseDatabase()
-
-		var applicationStates []db.ApplicationState
-		err = dbq.UnsafeListAllApplicationStates(ctx, &applicationStates)
-		Expect(err).To(BeNil())
-
-		var applications []db.Application
-		err = dbq.UnsafeListAllApplications(ctx, &applications)
-		Expect(err).To(BeNil())
-
-		var clusterAccess []db.ClusterAccess
-		err = dbq.UnsafeListAllClusterAccess(ctx, &clusterAccess)
-		Expect(err).To(BeNil())
-
-		var clusterCredentials []db.ClusterCredentials
-		err = dbq.UnsafeListAllClusterCredentials(ctx, &clusterCredentials)
-		Expect(err).To(BeNil())
-
-		var clusterUsers []db.ClusterUser
-		err = dbq.UnsafeListAllClusterUsers(ctx, &clusterUsers)
-		Expect(err).To(BeNil())
-
-		var engineClusters []db.GitopsEngineCluster
-		err = dbq.UnsafeListAllGitopsEngineClusters(ctx, &engineClusters)
-		Expect(err).To(BeNil())
-
-		var engineInstances []db.GitopsEngineInstance
-		err = dbq.UnsafeListAllGitopsEngineInstances(ctx, &engineInstances)
-		Expect(err).To(BeNil())
-
-		var managedEnvironments []db.ManagedEnvironment
-		err = dbq.UnsafeListAllManagedEnvironments(ctx, &managedEnvironments)
-		Expect(err).To(BeNil())
-
-		var operations []db.Operation
-		err = dbq.UnsafeListAllOperations(ctx, &operations)
-		Expect(err).To(BeNil())
-	})
-
-	It("Should CheckedCreate and CheckedDelete an application", func() {
-
-		err := db.SetupForTestingDBGinkgo()
-		Expect(err).To(BeNil())
-
-		ctx := context.Background()
-
-		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
-		Expect(err).To(BeNil())
-		defer dbq.CloseDatabase()
-
-		_, managedEnvironment, _, gitopsEngineInstance, clusterAccess, err := db.CreateSampleData(dbq)
-		Expect(err).To(BeNil())
-
-		application := &db.Application{
-			Application_id:          "test-my-application",
-			Name:                    "my-application",
-			Spec_field:              "{}",
-			Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
-			Managed_environment_id:  managedEnvironment.Managedenvironment_id,
+		var testClusterUser = &db.ClusterUser{
+			Clusteruser_id: "test-user",
+			User_name:      "test-user",
 		}
 
-		err = dbq.CheckedCreateApplication(ctx, application, clusterAccess.Clusteraccess_user_id)
-		Expect(err).To(BeNil())
+		It("Should execute select on all the fields of the database.", func() {
 
-		retrievedApplication := db.Application{Application_id: application.Application_id}
-
-		err = dbq.GetApplicationById(ctx, &retrievedApplication)
-		Expect(err).To(BeNil())
-		Expect(application.Application_id).Should(Equal(retrievedApplication.Application_id))
-
-		rowsAffected, err := dbq.CheckedDeleteApplicationById(ctx, application.Application_id, clusterAccess.Clusteraccess_user_id)
-		Expect(err).To(BeNil())
-		Expect(rowsAffected).Should(Equal(1))
-
-		retrievedApplication = db.Application{Application_id: application.Application_id}
-		err = dbq.GetApplicationById(ctx, &retrievedApplication)
-		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
-
-	})
-
-	It("Should test deploymenttoapplication mapping", func() {
-
-		err := db.SetupForTestingDBGinkgo()
-		Expect(err).To(BeNil())
-
-		ctx := context.Background()
-
-		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
-		Expect(err).To(BeNil())
-		defer dbq.CloseDatabase()
-
-		mapping := db.DeploymentToApplicationMapping{}
-		err = dbq.CheckedGetDeploymentToApplicationMappingByDeplId(ctx, &mapping, "")
-		fmt.Println(err, mapping)
-
-	})
-
-	It("Should test GitopsEngineInstance and GitOpsEngineCluster", func() {
-
-		err := db.SetupForTestingDBGinkgo()
-		Expect(err).To(BeNil())
-
-		ctx := context.Background()
-
-		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
-		Expect(err).To(BeNil())
-		defer dbq.CloseDatabase()
-
-		_, _, gitopsEngineCluster, gitopsEngineInstance, clusterAccess, err := db.CreateSampleData(dbq)
-		Expect(err).To(BeNil())
-
-		retrievedGitopsEngineCluster := &db.GitopsEngineCluster{Gitopsenginecluster_id: gitopsEngineCluster.Gitopsenginecluster_id}
-		err = dbq.CheckedGetGitopsEngineClusterById(ctx, retrievedGitopsEngineCluster, testClusterUser.Clusteruser_id)
-		Expect(err).To(BeNil())
-		Expect(&gitopsEngineCluster).Should(Equal(&retrievedGitopsEngineCluster))
-
-		rowsAffected, err := dbq.DeleteClusterAccessById(ctx, clusterAccess.Clusteraccess_user_id, clusterAccess.Clusteraccess_managed_environment_id, clusterAccess.Clusteraccess_gitops_engine_instance_id)
-		Expect(err).To(BeNil())
-		Expect(rowsAffected).Should(Equal(1))
-
-		rowsAffected, err = dbq.DeleteGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id)
-		Expect(err).To(BeNil())
-		Expect(rowsAffected).Should(Equal(1))
-
-		gitopsEngineInstance = &db.GitopsEngineInstance{Gitopsengineinstance_id: gitopsEngineInstance.Gitopsengineinstance_id}
-		err = dbq.CheckedGetGitopsEngineInstanceById(ctx, gitopsEngineInstance, testClusterUser.Clusteruser_id)
-		Expect(err).ToNot(BeNil())
-		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
-
-		rowsAffected, err = dbq.DeleteGitopsEngineClusterById(ctx, gitopsEngineCluster.Gitopsenginecluster_id)
-		Expect(err).To(BeNil())
-		Expect(rowsAffected).Should(Equal(1))
-
-		retrievedGitopsEngineCluster = &db.GitopsEngineCluster{Gitopsenginecluster_id: gitopsEngineCluster.Gitopsenginecluster_id}
-		err = dbq.CheckedGetGitopsEngineClusterById(ctx, retrievedGitopsEngineCluster, testClusterUser.Clusteruser_id)
-		Expect(err).ToNot(BeNil())
-		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
-	})
-
-	It("Should test ManagedEnvironment", func() {
-
-		err := db.SetupForTestingDBGinkgo()
-		Expect(err).To(BeNil())
-
-		ctx := context.Background()
-
-		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
-		Expect(err).To(BeNil())
-		defer dbq.CloseDatabase()
-
-		_, managedEnvironment, _, _, clusterAccess, err := db.CreateSampleData(dbq)
-		Expect(err).To(BeNil())
-
-		result := &db.ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
-
-		err = dbq.CheckedGetManagedEnvironmentById(ctx, result, testClusterUser.Clusteruser_id)
-		Expect(err).To(BeNil())
-
-		Expect(managedEnvironment).Should(Equal(result))
-
-		result = &db.ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
-		err = dbq.CheckedGetManagedEnvironmentById(ctx, result, "another-user-test")
-		Expect(err).ToNot(BeNil())
-		// deleting from another user should fail
-		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
-
-		rowsAffected, err := dbq.DeleteClusterAccessById(ctx, clusterAccess.Clusteraccess_user_id, clusterAccess.Clusteraccess_managed_environment_id, clusterAccess.Clusteraccess_gitops_engine_instance_id)
-		Expect(err).To(BeNil())
-		Expect(rowsAffected).Should(Equal(1))
-
-		rowsAffected, err = dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
-		Expect(err).To(BeNil())
-		Expect(rowsAffected).Should(Equal(1))
-
-		result = &db.ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
-		err = dbq.CheckedGetManagedEnvironmentById(ctx, result, testClusterUser.Clusteruser_id)
-		Expect(err).ToNot(BeNil())
-		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
-
-	})
-
-	It("Should test Operations", func() {
-
-		err := db.SetupForTestingDBGinkgo()
-		Expect(err).To(BeNil())
-
-		ctx := context.Background()
-
-		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
-		Expect(err).To(BeNil())
-		defer dbq.CloseDatabase()
-
-		_, _, _, gitopsEngineInstance, _, err := db.CreateSampleData(dbq)
-		Expect(err).To(BeNil())
-
-		operation := &db.Operation{
-			Operation_id:            "test-operation",
-			Instance_id:             gitopsEngineInstance.Gitopsengineinstance_id,
-			Resource_id:             "fake resource id",
-			Resource_type:           "GitopsEngineInstance",
-			State:                   db.OperationState_Waiting,
-			Operation_owner_user_id: testClusterUser.Clusteruser_id,
-		}
-
-		err = dbq.CreateOperation(ctx, operation, operation.Operation_owner_user_id)
-		Expect(err).To(BeNil())
-
-		result := db.Operation{Operation_id: operation.Operation_id}
-		err = dbq.CheckedGetOperationById(ctx, &result, operation.Operation_owner_user_id)
-		Expect(err).To(BeNil())
-		Expect(operation.Operation_id).Should(Equal(result.Operation_id))
-
-		result = db.Operation{Operation_id: operation.Operation_id}
-		err = dbq.CheckedGetOperationById(ctx, &result, "another-user-test")
-		Expect(err).ToNot(BeNil())
-		Expect(true).To(Equal(db.IsResultNotFoundError(err)))
-
-		rowsAffected, _ := dbq.CheckedDeleteOperationById(ctx, operation.Operation_id, "another-user")
-		Expect(rowsAffected).Should(Equal(0))
-
-		rowsAffected, err = dbq.CheckedDeleteOperationById(ctx, operation.Operation_id, operation.Operation_owner_user_id)
-		Expect(rowsAffected).Should(Equal(1))
-		Expect(err).To(BeNil())
-	})
-	It("Should test ClusterUser", func() {
-
-		err := db.SetupForTestingDBGinkgo()
-		Expect(err).To(BeNil())
-
-		ctx := context.Background()
-
-		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
-		Expect(err).To(BeNil())
-		defer dbq.CloseDatabase()
-
-		clusterUser := db.ClusterUser{
-			Clusteruser_id: "test-my-cluster-user-2",
-			User_name:      "cluster-mccluster",
-		}
-		err = dbq.CreateClusterUser(ctx, &clusterUser)
-		Expect(err).To(BeNil())
-
-		retrievedClusterUser := db.ClusterUser{Clusteruser_id: clusterUser.Clusteruser_id}
-		err = dbq.GetClusterUserById(ctx, &retrievedClusterUser)
-		Expect(err).To(BeNil())
-		Expect(clusterUser.User_name).Should(Equal(retrievedClusterUser.User_name))
-
-		rowsAffected, err := dbq.DeleteClusterUserById(ctx, clusterUser.Clusteruser_id)
-		Expect(rowsAffected).Should(Equal(1))
-		Expect(err).To(BeNil())
-
-		retrievedClusterUser = db.ClusterUser{Clusteruser_id: clusterUser.Clusteruser_id}
-		err = dbq.GetClusterUserById(ctx, &retrievedClusterUser)
-		Expect(err).ToNot(BeNil())
-		Expect(db.IsResultNotFoundError(err)).To(Equal(true))
-
-		retrievedClusterUser = db.ClusterUser{Clusteruser_id: "does-not-exist"}
-		err = dbq.GetClusterUserById(ctx, &retrievedClusterUser)
-		Expect(err).ToNot(BeNil())
-		Expect(db.IsResultNotFoundError(err)).To(Equal(true))
-	})
-
-	It("Should test ClusterCredentials", func() {
-
-		err := db.SetupForTestingDBGinkgo()
-		Expect(err).To(BeNil())
-
-		ctx := context.Background()
-
-		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
-		Expect(err).To(BeNil())
-		defer dbq.CloseDatabase()
-
-		clusterCredentials := db.ClusterCredentials{
-			Clustercredentials_cred_id:  "test-cluster-creds-test",
-			Host:                        "host",
-			Kube_config:                 "kube-config",
-			Kube_config_context:         "kube-config-context",
-			Serviceaccount_bearer_token: "serviceaccount_bearer_token",
-			Serviceaccount_ns:           "Serviceaccount_ns",
-		}
-
-		err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)
-		Expect(err).To(BeNil())
-
-		var gitopsEngineCluster db.GitopsEngineCluster
-		var gitopsEngineInstance db.GitopsEngineInstance
-		var clusterAccess db.ClusterAccess
-		var managedEnvironment db.ManagedEnvironment
-
-		// Create managed environment, and cluster access, so the non-unsafe get works below
-		{
-			managedEnvironment = db.ManagedEnvironment{
-				Managedenvironment_id: "test-managed-env-914",
-				Clustercredentials_id: clusterCredentials.Clustercredentials_cred_id,
-				Name:                  "my env",
-			}
-			err = dbq.CreateManagedEnvironment(ctx, &managedEnvironment)
+			err := db.SetupForTestingDBGinkgo()
 			Expect(err).To(BeNil())
 
-			gitopsEngineCluster = db.GitopsEngineCluster{
-				Gitopsenginecluster_id: "test-fake-cluster-914",
-				Clustercredentials_id:  clusterCredentials.Clustercredentials_cred_id,
-			}
-			err = dbq.CreateGitopsEngineCluster(ctx, &gitopsEngineCluster)
+			ctx := context.Background()
+
+			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+			Expect(err).To(BeNil())
+			defer dbq.CloseDatabase()
+
+			var applicationStates []db.ApplicationState
+			err = dbq.UnsafeListAllApplicationStates(ctx, &applicationStates)
 			Expect(err).To(BeNil())
 
-			gitopsEngineInstance = db.GitopsEngineInstance{
-				Gitopsengineinstance_id: "test-fake-engine-instance-id",
-				Namespace_name:          "test-fake-namespace",
-				Namespace_uid:           "test-fake-namespace-914",
-				EngineCluster_id:        gitopsEngineCluster.Gitopsenginecluster_id,
-			}
-			err = dbq.CreateGitopsEngineInstance(ctx, &gitopsEngineInstance)
+			var applications []db.Application
+			err = dbq.UnsafeListAllApplications(ctx, &applications)
 			Expect(err).To(BeNil())
 
-			clusterAccess = db.ClusterAccess{
-				Clusteraccess_user_id:                   testClusterUser.Clusteruser_id,
-				Clusteraccess_managed_environment_id:    managedEnvironment.Managedenvironment_id,
-				Clusteraccess_gitops_engine_instance_id: gitopsEngineInstance.Gitopsengineinstance_id,
-			}
-			err = dbq.CreateClusterAccess(ctx, &clusterAccess)
+			var clusterAccess []db.ClusterAccess
+			err = dbq.UnsafeListAllClusterAccess(ctx, &clusterAccess)
 			Expect(err).To(BeNil())
 
-		}
+			var clusterCredentials []db.ClusterCredentials
+			err = dbq.UnsafeListAllClusterCredentials(ctx, &clusterCredentials)
+			Expect(err).To(BeNil())
 
-		retrievedClusterCredentials := &db.ClusterCredentials{
-			Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
-		}
-		err = dbq.GetClusterCredentialsById(ctx, retrievedClusterCredentials)
-		Expect(err).To(BeNil())
+			var clusterUsers []db.ClusterUser
+			err = dbq.UnsafeListAllClusterUsers(ctx, &clusterUsers)
+			Expect(err).To(BeNil())
 
-		Expect(clusterCredentials.Host).Should(Equal(retrievedClusterCredentials.Host))
-		Expect(clusterCredentials.Kube_config).Should(Equal(retrievedClusterCredentials.Kube_config))
-		Expect(clusterCredentials.Kube_config_context).Should(Equal(retrievedClusterCredentials.Kube_config_context))
+			var engineClusters []db.GitopsEngineCluster
+			err = dbq.UnsafeListAllGitopsEngineClusters(ctx, &engineClusters)
+			Expect(err).To(BeNil())
 
-		retrievedClusterCredentials = &db.ClusterCredentials{
-			Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
-		}
-		err = dbq.CheckedGetClusterCredentialsById(ctx, retrievedClusterCredentials, testClusterUser.Clusteruser_id)
-		Expect(err).To(BeNil())
-		Expect(retrievedClusterCredentials).ToNot(BeNil())
+			var engineInstances []db.GitopsEngineInstance
+			err = dbq.UnsafeListAllGitopsEngineInstances(ctx, &engineInstances)
+			Expect(err).To(BeNil())
 
-		Expect(clusterCredentials.Host).Should(Equal(retrievedClusterCredentials.Host))
-		Expect(clusterCredentials.Kube_config).Should(Equal(retrievedClusterCredentials.Kube_config))
-		Expect(clusterCredentials.Kube_config_context).Should(Equal(retrievedClusterCredentials.Kube_config_context))
+			var managedEnvironments []db.ManagedEnvironment
+			err = dbq.UnsafeListAllManagedEnvironments(ctx, &managedEnvironments)
+			Expect(err).To(BeNil())
 
-		rowsAffected, err := dbq.DeleteClusterAccessById(ctx, clusterAccess.Clusteraccess_user_id, clusterAccess.Clusteraccess_managed_environment_id, clusterAccess.Clusteraccess_gitops_engine_instance_id)
-		Expect(rowsAffected).Should(Equal(1))
-		Expect(err).To(BeNil())
+			var operations []db.Operation
+			err = dbq.UnsafeListAllOperations(ctx, &operations)
+			Expect(err).To(BeNil())
+		})
 
-		rowsAffected, err = dbq.DeleteGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id)
-		Expect(rowsAffected).Should(Equal(1))
-		Expect(err).To(BeNil())
+		It("Should CheckedCreate and CheckedDelete an application", func() {
 
-		rowsAffected, err = dbq.DeleteGitopsEngineClusterById(ctx, gitopsEngineCluster.Gitopsenginecluster_id)
-		Expect(rowsAffected).Should(Equal(1))
-		Expect(err).To(BeNil())
+			err := db.SetupForTestingDBGinkgo()
+			Expect(err).To(BeNil())
 
-		rowsAffected, err = dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
-		Expect(rowsAffected).Should(Equal(1))
-		Expect(err).To(BeNil())
+			ctx := context.Background()
 
-		rowsAffected, err = dbq.DeleteClusterCredentialsById(ctx, clusterCredentials.Clustercredentials_cred_id)
-		Expect(rowsAffected).Should(Equal(1))
-		Expect(err).To(BeNil())
+			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+			Expect(err).To(BeNil())
+			defer dbq.CloseDatabase()
 
-		retrievedClusterCredentials = &db.ClusterCredentials{
-			Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
-		}
-		err = dbq.GetClusterCredentialsById(ctx, retrievedClusterCredentials)
-		Expect(err).ToNot(BeNil())
-		Expect(db.IsResultNotFoundError(err)).To(Equal(true))
+			_, managedEnvironment, _, gitopsEngineInstance, clusterAccess, err := db.CreateSampleData(dbq)
+			Expect(err).To(BeNil())
+
+			application := &db.Application{
+				Application_id:          "test-my-application",
+				Name:                    "my-application",
+				Spec_field:              "{}",
+				Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
+				Managed_environment_id:  managedEnvironment.Managedenvironment_id,
+			}
+
+			err = dbq.CheckedCreateApplication(ctx, application, clusterAccess.Clusteraccess_user_id)
+			Expect(err).To(BeNil())
+
+			retrievedApplication := db.Application{Application_id: application.Application_id}
+
+			err = dbq.GetApplicationById(ctx, &retrievedApplication)
+			Expect(err).To(BeNil())
+			Expect(application.Application_id).Should(Equal(retrievedApplication.Application_id))
+
+			rowsAffected, err := dbq.CheckedDeleteApplicationById(ctx, application.Application_id, clusterAccess.Clusteraccess_user_id)
+			Expect(err).To(BeNil())
+			Expect(rowsAffected).Should(Equal(1))
+
+			retrievedApplication = db.Application{Application_id: application.Application_id}
+			err = dbq.GetApplicationById(ctx, &retrievedApplication)
+			Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+		})
+
+		It("Should test deploymenttoapplication mapping", func() {
+
+			err := db.SetupForTestingDBGinkgo()
+			Expect(err).To(BeNil())
+
+			ctx := context.Background()
+
+			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+			Expect(err).To(BeNil())
+			defer dbq.CloseDatabase()
+
+			mapping := db.DeploymentToApplicationMapping{}
+			err = dbq.CheckedGetDeploymentToApplicationMappingByDeplId(ctx, &mapping, "")
+			fmt.Println(err, mapping)
+
+		})
+
+		It("Should test GitopsEngineInstance and GitOpsEngineCluster", func() {
+
+			err := db.SetupForTestingDBGinkgo()
+			Expect(err).To(BeNil())
+
+			ctx := context.Background()
+
+			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+			Expect(err).To(BeNil())
+			defer dbq.CloseDatabase()
+
+			_, _, gitopsEngineCluster, gitopsEngineInstance, clusterAccess, err := db.CreateSampleData(dbq)
+			Expect(err).To(BeNil())
+
+			retrievedGitopsEngineCluster := &db.GitopsEngineCluster{Gitopsenginecluster_id: gitopsEngineCluster.Gitopsenginecluster_id}
+			err = dbq.CheckedGetGitopsEngineClusterById(ctx, retrievedGitopsEngineCluster, testClusterUser.Clusteruser_id)
+			Expect(err).To(BeNil())
+			Expect(&gitopsEngineCluster).Should(Equal(&retrievedGitopsEngineCluster))
+
+			rowsAffected, err := dbq.DeleteClusterAccessById(ctx, clusterAccess.Clusteraccess_user_id, clusterAccess.Clusteraccess_managed_environment_id, clusterAccess.Clusteraccess_gitops_engine_instance_id)
+			Expect(err).To(BeNil())
+			Expect(rowsAffected).Should(Equal(1))
+
+			rowsAffected, err = dbq.DeleteGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id)
+			Expect(err).To(BeNil())
+			Expect(rowsAffected).Should(Equal(1))
+
+			gitopsEngineInstance = &db.GitopsEngineInstance{Gitopsengineinstance_id: gitopsEngineInstance.Gitopsengineinstance_id}
+			err = dbq.CheckedGetGitopsEngineInstanceById(ctx, gitopsEngineInstance, testClusterUser.Clusteruser_id)
+			Expect(err).ToNot(BeNil())
+			Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+			rowsAffected, err = dbq.DeleteGitopsEngineClusterById(ctx, gitopsEngineCluster.Gitopsenginecluster_id)
+			Expect(err).To(BeNil())
+			Expect(rowsAffected).Should(Equal(1))
+
+			retrievedGitopsEngineCluster = &db.GitopsEngineCluster{Gitopsenginecluster_id: gitopsEngineCluster.Gitopsenginecluster_id}
+			err = dbq.CheckedGetGitopsEngineClusterById(ctx, retrievedGitopsEngineCluster, testClusterUser.Clusteruser_id)
+			Expect(err).ToNot(BeNil())
+			Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+		})
+
+		It("Should test ManagedEnvironment", func() {
+
+			err := db.SetupForTestingDBGinkgo()
+			Expect(err).To(BeNil())
+
+			ctx := context.Background()
+
+			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+			Expect(err).To(BeNil())
+			defer dbq.CloseDatabase()
+
+			_, managedEnvironment, _, _, clusterAccess, err := db.CreateSampleData(dbq)
+			Expect(err).To(BeNil())
+
+			result := &db.ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
+
+			err = dbq.CheckedGetManagedEnvironmentById(ctx, result, testClusterUser.Clusteruser_id)
+			Expect(err).To(BeNil())
+
+			Expect(managedEnvironment).Should(Equal(result))
+
+			result = &db.ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
+			err = dbq.CheckedGetManagedEnvironmentById(ctx, result, "another-user-test")
+			Expect(err).ToNot(BeNil())
+			// deleting from another user should fail
+			Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+			rowsAffected, err := dbq.DeleteClusterAccessById(ctx, clusterAccess.Clusteraccess_user_id, clusterAccess.Clusteraccess_managed_environment_id, clusterAccess.Clusteraccess_gitops_engine_instance_id)
+			Expect(err).To(BeNil())
+			Expect(rowsAffected).Should(Equal(1))
+
+			rowsAffected, err = dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
+			Expect(err).To(BeNil())
+			Expect(rowsAffected).Should(Equal(1))
+
+			result = &db.ManagedEnvironment{Managedenvironment_id: managedEnvironment.Managedenvironment_id}
+			err = dbq.CheckedGetManagedEnvironmentById(ctx, result, testClusterUser.Clusteruser_id)
+			Expect(err).ToNot(BeNil())
+			Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+		})
+
+		It("Should test Operations", func() {
+
+			err := db.SetupForTestingDBGinkgo()
+			Expect(err).To(BeNil())
+
+			ctx := context.Background()
+
+			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+			Expect(err).To(BeNil())
+			defer dbq.CloseDatabase()
+
+			_, _, _, gitopsEngineInstance, _, err := db.CreateSampleData(dbq)
+			Expect(err).To(BeNil())
+
+			operation := &db.Operation{
+				Operation_id:            "test-operation",
+				Instance_id:             gitopsEngineInstance.Gitopsengineinstance_id,
+				Resource_id:             "fake resource id",
+				Resource_type:           "GitopsEngineInstance",
+				State:                   db.OperationState_Waiting,
+				Operation_owner_user_id: testClusterUser.Clusteruser_id,
+			}
+
+			err = dbq.CreateOperation(ctx, operation, operation.Operation_owner_user_id)
+			Expect(err).To(BeNil())
+
+			result := db.Operation{Operation_id: operation.Operation_id}
+			err = dbq.CheckedGetOperationById(ctx, &result, operation.Operation_owner_user_id)
+			Expect(err).To(BeNil())
+			Expect(operation.Operation_id).Should(Equal(result.Operation_id))
+
+			result = db.Operation{Operation_id: operation.Operation_id}
+			err = dbq.CheckedGetOperationById(ctx, &result, "another-user-test")
+			Expect(err).ToNot(BeNil())
+			Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+
+			rowsAffected, _ := dbq.CheckedDeleteOperationById(ctx, operation.Operation_id, "another-user")
+			Expect(rowsAffected).Should(Equal(0))
+
+			rowsAffected, err = dbq.CheckedDeleteOperationById(ctx, operation.Operation_id, operation.Operation_owner_user_id)
+			Expect(rowsAffected).Should(Equal(1))
+			Expect(err).To(BeNil())
+		})
+		It("Should test ClusterUser", func() {
+
+			err := db.SetupForTestingDBGinkgo()
+			Expect(err).To(BeNil())
+
+			ctx := context.Background()
+
+			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+			Expect(err).To(BeNil())
+			defer dbq.CloseDatabase()
+
+			clusterUser := db.ClusterUser{
+				Clusteruser_id: "test-my-cluster-user-2",
+				User_name:      "cluster-mccluster",
+			}
+			err = dbq.CreateClusterUser(ctx, &clusterUser)
+			Expect(err).To(BeNil())
+
+			retrievedClusterUser := db.ClusterUser{Clusteruser_id: clusterUser.Clusteruser_id}
+			err = dbq.GetClusterUserById(ctx, &retrievedClusterUser)
+			Expect(err).To(BeNil())
+			Expect(clusterUser.User_name).Should(Equal(retrievedClusterUser.User_name))
+
+			rowsAffected, err := dbq.DeleteClusterUserById(ctx, clusterUser.Clusteruser_id)
+			Expect(rowsAffected).Should(Equal(1))
+			Expect(err).To(BeNil())
+
+			retrievedClusterUser = db.ClusterUser{Clusteruser_id: clusterUser.Clusteruser_id}
+			err = dbq.GetClusterUserById(ctx, &retrievedClusterUser)
+			Expect(err).ToNot(BeNil())
+			Expect(db.IsResultNotFoundError(err)).To(Equal(true))
+
+			retrievedClusterUser = db.ClusterUser{Clusteruser_id: "does-not-exist"}
+			err = dbq.GetClusterUserById(ctx, &retrievedClusterUser)
+			Expect(err).ToNot(BeNil())
+			Expect(db.IsResultNotFoundError(err)).To(Equal(true))
+		})
+
+		It("Should test ClusterCredentials", func() {
+
+			err := db.SetupForTestingDBGinkgo()
+			Expect(err).To(BeNil())
+
+			ctx := context.Background()
+
+			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+			Expect(err).To(BeNil())
+			defer dbq.CloseDatabase()
+
+			clusterCredentials := db.ClusterCredentials{
+				Clustercredentials_cred_id:  "test-cluster-creds-test",
+				Host:                        "host",
+				Kube_config:                 "kube-config",
+				Kube_config_context:         "kube-config-context",
+				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_ns:           "Serviceaccount_ns",
+			}
+
+			err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)
+			Expect(err).To(BeNil())
+
+			var gitopsEngineCluster db.GitopsEngineCluster
+			var gitopsEngineInstance db.GitopsEngineInstance
+			var clusterAccess db.ClusterAccess
+			var managedEnvironment db.ManagedEnvironment
+
+			// Create managed environment, and cluster access, so the non-unsafe get works below
+			{
+				managedEnvironment = db.ManagedEnvironment{
+					Managedenvironment_id: "test-managed-env-914",
+					Clustercredentials_id: clusterCredentials.Clustercredentials_cred_id,
+					Name:                  "my env",
+				}
+				err = dbq.CreateManagedEnvironment(ctx, &managedEnvironment)
+				Expect(err).To(BeNil())
+
+				gitopsEngineCluster = db.GitopsEngineCluster{
+					Gitopsenginecluster_id: "test-fake-cluster-914",
+					Clustercredentials_id:  clusterCredentials.Clustercredentials_cred_id,
+				}
+				err = dbq.CreateGitopsEngineCluster(ctx, &gitopsEngineCluster)
+				Expect(err).To(BeNil())
+
+				gitopsEngineInstance = db.GitopsEngineInstance{
+					Gitopsengineinstance_id: "test-fake-engine-instance-id",
+					Namespace_name:          "test-fake-namespace",
+					Namespace_uid:           "test-fake-namespace-914",
+					EngineCluster_id:        gitopsEngineCluster.Gitopsenginecluster_id,
+				}
+				err = dbq.CreateGitopsEngineInstance(ctx, &gitopsEngineInstance)
+				Expect(err).To(BeNil())
+
+				clusterAccess = db.ClusterAccess{
+					Clusteraccess_user_id:                   testClusterUser.Clusteruser_id,
+					Clusteraccess_managed_environment_id:    managedEnvironment.Managedenvironment_id,
+					Clusteraccess_gitops_engine_instance_id: gitopsEngineInstance.Gitopsengineinstance_id,
+				}
+				err = dbq.CreateClusterAccess(ctx, &clusterAccess)
+				Expect(err).To(BeNil())
+
+			}
+
+			retrievedClusterCredentials := &db.ClusterCredentials{
+				Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
+			}
+			err = dbq.GetClusterCredentialsById(ctx, retrievedClusterCredentials)
+			Expect(err).To(BeNil())
+
+			Expect(clusterCredentials.Host).Should(Equal(retrievedClusterCredentials.Host))
+			Expect(clusterCredentials.Kube_config).Should(Equal(retrievedClusterCredentials.Kube_config))
+			Expect(clusterCredentials.Kube_config_context).Should(Equal(retrievedClusterCredentials.Kube_config_context))
+
+			retrievedClusterCredentials = &db.ClusterCredentials{
+				Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
+			}
+			err = dbq.CheckedGetClusterCredentialsById(ctx, retrievedClusterCredentials, testClusterUser.Clusteruser_id)
+			Expect(err).To(BeNil())
+			Expect(retrievedClusterCredentials).ToNot(BeNil())
+
+			Expect(clusterCredentials.Host).Should(Equal(retrievedClusterCredentials.Host))
+			Expect(clusterCredentials.Kube_config).Should(Equal(retrievedClusterCredentials.Kube_config))
+			Expect(clusterCredentials.Kube_config_context).Should(Equal(retrievedClusterCredentials.Kube_config_context))
+
+			rowsAffected, err := dbq.DeleteClusterAccessById(ctx, clusterAccess.Clusteraccess_user_id, clusterAccess.Clusteraccess_managed_environment_id, clusterAccess.Clusteraccess_gitops_engine_instance_id)
+			Expect(rowsAffected).Should(Equal(1))
+			Expect(err).To(BeNil())
+
+			rowsAffected, err = dbq.DeleteGitopsEngineInstanceById(ctx, gitopsEngineInstance.Gitopsengineinstance_id)
+			Expect(rowsAffected).Should(Equal(1))
+			Expect(err).To(BeNil())
+
+			rowsAffected, err = dbq.DeleteGitopsEngineClusterById(ctx, gitopsEngineCluster.Gitopsenginecluster_id)
+			Expect(rowsAffected).Should(Equal(1))
+			Expect(err).To(BeNil())
+
+			rowsAffected, err = dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
+			Expect(rowsAffected).Should(Equal(1))
+			Expect(err).To(BeNil())
+
+			rowsAffected, err = dbq.DeleteClusterCredentialsById(ctx, clusterCredentials.Clustercredentials_cred_id)
+			Expect(rowsAffected).Should(Equal(1))
+			Expect(err).To(BeNil())
+
+			retrievedClusterCredentials = &db.ClusterCredentials{
+				Clustercredentials_cred_id: clusterCredentials.Clustercredentials_cred_id,
+			}
+			err = dbq.GetClusterCredentialsById(ctx, retrievedClusterCredentials)
+			Expect(err).ToNot(BeNil())
+			Expect(db.IsResultNotFoundError(err)).To(Equal(true))
+		})
+
 	})
-
 })

--- a/backend-shared/config/db/util/application_info_cache_test.go
+++ b/backend-shared/config/db/util/application_info_cache_test.go
@@ -165,7 +165,7 @@ var _ = Describe("application_info_cache Test", func() {
 
 			//testId doesn't exist, the test should report an error
 			app, valuefromCache, errGet := asc.GetApplicationById(ctx, testId)
-			Expect(errGet).To(BeNil())
+			Expect(errGet).ToNot(BeNil())
 			// since no entry in the valuefromcache should be false, appState should be empty
 			Expect(valuefromCache).To(BeFalse())
 			Expect(app).To(Equal(db.Application{}))

--- a/backend-shared/config/db/util/application_info_cache_test.go
+++ b/backend-shared/config/db/util/application_info_cache_test.go
@@ -11,139 +11,195 @@ import (
 )
 
 var _ = Describe("application_info_cache Test", func() {
-	It("Test to Create, Update and Delete an ApplicationInfoCache", func() {
-		err := db.SetupForTestingDBGinkgo()
-		Expect(err).To(BeNil())
+	Context("Tests all the functions for ApplicationInfoCache", func() {
 
-		ctx := context.Background()
-		asc := util.NewApplicationInfoCache()
-		defer asc.DebugOnly_Shutdown(ctx)
+		It("Test to Create, Update and Delete an ApplicationState", func() {
+			err := db.SetupForTestingDBGinkgo()
+			Expect(err).To(BeNil())
 
-		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+			ctx := context.Background()
+			asc := util.NewApplicationInfoCache()
+			defer asc.DebugOnly_Shutdown(ctx)
 
-		Expect(err).To(BeNil())
-		defer dbq.CloseDatabase()
+			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
 
-		_, managedEnvironment, _, gitopsEngineInstance, _, err := db.CreateSampleData(dbq)
-		Expect(err).To(BeNil())
+			Expect(err).To(BeNil())
+			defer dbq.CloseDatabase()
 
-		application := &db.Application{
-			Application_id:          "test-my-application",
-			Name:                    "my-application",
-			Spec_field:              "{}",
-			Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
-			Managed_environment_id:  managedEnvironment.Managedenvironment_id,
-		}
+			_, managedEnvironment, _, gitopsEngineInstance, _, err := db.CreateSampleData(dbq)
+			Expect(err).To(BeNil())
 
-		// An entry for the application should be there in order to create an entry for applicationState
-		err = dbq.CreateApplication(ctx, application)
-		Expect(err).To(BeNil())
+			application := &db.Application{
+				Application_id:          "test-my-application",
+				Name:                    "my-application",
+				Spec_field:              "{}",
+				Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
+				Managed_environment_id:  managedEnvironment.Managedenvironment_id,
+			}
 
-		testAppState := db.ApplicationState{
-			Applicationstate_application_id: application.Application_id,
-			Health:                          "Healthy",
-			Sync_Status:                     "Synced",
-		}
-		errCreate := asc.CreateApplicationState(ctx, testAppState)
-		Expect(errCreate).To(BeNil())
+			// An entry for the application should be there in order to create an entry for applicationState
+			err = dbq.CreateApplication(ctx, application)
+			Expect(err).To(BeNil())
 
-		dbAppStateObj := db.ApplicationState{
-			Applicationstate_application_id: testAppState.Applicationstate_application_id,
-		}
-		errGet := dbq.GetApplicationStateById(ctx, &dbAppStateObj)
-		Expect(errGet).To(BeNil())
-		Expect(testAppState).To(Equal(dbAppStateObj))
+			testAppState := db.ApplicationState{
+				Applicationstate_application_id: application.Application_id,
+				Health:                          "Healthy",
+				Sync_Status:                     "Synced",
+			}
+			errCreate := asc.CreateApplicationState(ctx, testAppState)
+			Expect(errCreate).To(BeNil())
 
-		_, fromCache, err := asc.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
-		Expect(err).To(BeNil())
-		Expect(fromCache).To(BeTrue())
+			dbAppStateObj := db.ApplicationState{
+				Applicationstate_application_id: testAppState.Applicationstate_application_id,
+			}
+			errGet := dbq.GetApplicationStateById(ctx, &dbAppStateObj)
+			Expect(errGet).To(BeNil())
+			Expect(testAppState).To(Equal(dbAppStateObj))
 
-		testAppState.Health = "Unhealthy"
-		errUpdate := asc.UpdateApplicationState(ctx, testAppState)
-		Expect(errUpdate).To(BeNil())
+			_, fromCache, err := asc.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
+			Expect(err).To(BeNil())
+			Expect(fromCache).To(BeTrue())
 
-		appState, isFromCache, errGet := asc.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
-		Expect(errGet).To(BeNil())
-		Expect(isFromCache).To(BeTrue())
-		Expect(testAppState).To(Equal(appState))
+			testAppState.Health = "Unhealthy"
+			errUpdate := asc.UpdateApplicationState(ctx, testAppState)
+			Expect(errUpdate).To(BeNil())
 
-		testDeleteAppState := db.ApplicationState{
-			Applicationstate_application_id: testAppState.Applicationstate_application_id,
-		}
+			appState, isFromCache, errGet := asc.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
+			Expect(errGet).To(BeNil())
+			Expect(isFromCache).To(BeTrue())
+			Expect(testAppState).To(Equal(appState))
 
-		rowsAffected, errCreate := asc.DeleteApplicationStateById(ctx, testDeleteAppState.Applicationstate_application_id)
-		Expect(errCreate).To(BeNil())
-		Expect(rowsAffected).Should(Equal(1))
+			testDeleteAppState := db.ApplicationState{
+				Applicationstate_application_id: testAppState.Applicationstate_application_id,
+			}
 
-		// check for entry in db, which should report an error
-		errGet = dbq.GetApplicationStateById(ctx, &testDeleteAppState)
-		Expect(errGet).ToNot(BeNil())
+			rowsAffected, errCreate := asc.DeleteApplicationStateById(ctx, testDeleteAppState.Applicationstate_application_id)
+			Expect(errCreate).To(BeNil())
+			Expect(rowsAffected).Should(Equal(1))
 
-	})
-	It("Test to Get an ApplicationInfoCache", func() {
-		err := db.SetupForTestingDBGinkgo()
-		Expect(err).To(BeNil())
+			// check for entry in db, which should report an error
+			errGet = dbq.GetApplicationStateById(ctx, &testDeleteAppState)
+			Expect(errGet).ToNot(BeNil())
 
-		ctx := context.Background()
-		asc := util.NewApplicationInfoCache()
-		defer asc.DebugOnly_Shutdown(ctx)
+		})
+		It("Tests GetApplicationStateById", func() {
+			err := db.SetupForTestingDBGinkgo()
+			Expect(err).To(BeNil())
 
-		dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+			ctx := context.Background()
+			asc := util.NewApplicationInfoCache()
+			defer asc.DebugOnly_Shutdown(ctx)
 
-		Expect(err).To(BeNil())
-		defer dbq.CloseDatabase()
-		defer dbq.CloseDatabase()
+			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
 
-		// check if the application state entry is in the cache?
-		testId := "test-get-appState"
+			Expect(err).To(BeNil())
+			defer dbq.CloseDatabase()
 
-		//testId doesn't exist, the test should report an error
-		appState, isFromCache, errGet := asc.GetApplicationStateById(ctx, testId)
-		Expect(errGet).ToNot(BeNil())
-		// since no entry in the valuefromcache should be false, appState should be empty
-		Expect(isFromCache).To(BeFalse())
-		Expect(appState).To(Equal(db.ApplicationState{}))
+			// check if the application state entry is in the cache?
+			testId := "test-get-appState"
 
-		_, managedEnvironment, _, gitopsEngineInstance, _, err := db.CreateSampleData(dbq)
-		Expect(err).To(BeNil())
+			//testId doesn't exist, the test should report an error
+			appState, isFromCache, errGet := asc.GetApplicationStateById(ctx, testId)
+			Expect(errGet).ToNot(BeNil())
+			// since no entry in the valuefromcache should be false, appState should be empty
+			Expect(isFromCache).To(BeFalse())
+			Expect(appState).To(Equal(db.ApplicationState{}))
 
-		application := &db.Application{
-			Application_id:          testId,
-			Name:                    "my-application",
-			Spec_field:              "{}",
-			Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
-			Managed_environment_id:  managedEnvironment.Managedenvironment_id,
-		}
+			_, managedEnvironment, _, gitopsEngineInstance, _, err := db.CreateSampleData(dbq)
+			Expect(err).To(BeNil())
 
-		// An entry for the application should be there in order to create an entry for applicationState
-		err = dbq.CreateApplication(ctx, application)
-		Expect(err).To(BeNil())
+			application := &db.Application{
+				Application_id:          testId,
+				Name:                    "my-application",
+				Spec_field:              "{}",
+				Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
+				Managed_environment_id:  managedEnvironment.Managedenvironment_id,
+			}
 
-		// create an applicationstate then try to get it
-		testAppState := db.ApplicationState{
-			Applicationstate_application_id: testId,
-			Health:                          "Healthy",
-			Sync_Status:                     "Synced",
-		}
-		err = dbq.CreateApplicationState(ctx, &testAppState)
-		Expect(err).To(BeNil())
+			// An entry for the application should be there in order to create an entry for applicationState
+			err = dbq.CreateApplication(ctx, application)
+			Expect(err).To(BeNil())
 
-		getAppState, isFromCache, errGet := asc.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
-		// ideally the appState should now report an ApplicationState obj
-		// isFromCache should be false since initially the value will be coming from db
-		Expect(errGet).To(BeNil())
-		Expect(isFromCache).To(BeFalse())
-		Expect(testAppState).To(Equal(getAppState))
+			// create an applicationstate then try to get it
+			testAppState := db.ApplicationState{
+				Applicationstate_application_id: testId,
+				Health:                          "Healthy",
+				Sync_Status:                     "Synced",
+			}
+			err = dbq.CreateApplicationState(ctx, &testAppState)
+			Expect(err).To(BeNil())
 
-		//calling the same GetApplicationStateById again should come from cache, hence isFromCache should be True
-		_, isFromCache, errGet = asc.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
-		Expect(errGet).To(BeNil())
-		Expect(isFromCache).To(BeTrue())
+			getAppState, isFromCache, errGet := asc.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
+			// ideally the appState should now report an ApplicationState obj
+			// isFromCache should be false since initially the value will be coming from db
+			Expect(errGet).To(BeNil())
+			Expect(isFromCache).To(BeFalse())
+			Expect(testAppState).To(Equal(getAppState))
 
-		// checking if the entry for the above exists in the database
-		errGet = dbq.GetApplicationStateById(ctx, &testAppState)
-		Expect(errGet).To(BeNil())
-		Expect(testAppState).To(Equal(getAppState))
+			//calling the same GetApplicationStateById again should come from cache, hence isFromCache should be True
+			_, isFromCache, errGet = asc.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
+			Expect(errGet).To(BeNil())
+			Expect(isFromCache).To(BeTrue())
+
+			// checking if the entry for the above exists in the database
+			errGet = dbq.GetApplicationStateById(ctx, &testAppState)
+			Expect(errGet).To(BeNil())
+			Expect(testAppState).To(Equal(getAppState))
+		})
+		It("Tests GetApplicationById", func() {
+			err := db.SetupForTestingDBGinkgo()
+			Expect(err).To(BeNil())
+
+			ctx := context.Background()
+			asc := util.NewApplicationInfoCache()
+			defer asc.DebugOnly_Shutdown(ctx)
+
+			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+
+			Expect(err).To(BeNil())
+			defer dbq.CloseDatabase()
+
+			// check if the application state entry is in the cache?
+			testId := "test-get-appState"
+
+			//testId doesn't exist, the test should report an error
+			app, valuefromCache, errGet := asc.GetApplicationById(ctx, testId)
+			Expect(err).To(BeNil())
+			// since no entry in the valuefromcache should be false, appState should be empty
+			Expect(valuefromCache).To(BeFalse())
+			Expect(app).To(Equal(db.ApplicationState{}))
+
+			_, managedEnvironment, _, gitopsEngineInstance, _, err := db.CreateSampleData(dbq)
+			Expect(err).To(BeNil())
+
+			testapplication := db.Application{
+				Application_id:          testId,
+				Name:                    "my-application",
+				Spec_field:              "{}",
+				Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
+				Managed_environment_id:  managedEnvironment.Managedenvironment_id,
+			}
+
+			err = dbq.CreateApplication(ctx, &testapplication)
+			Expect(err).To(BeNil())
+
+			getApp, isFromCache, errGet := asc.GetApplicationById(ctx, testapplication.Application_id)
+			// ideally the appState should now report an Application obj
+			Expect(errGet).To(BeNil())
+			Expect(isFromCache).To(BeFalse())
+			Expect(getApp).To(Equal(testapplication))
+
+			//calling the same GetApplicationById again should come from cache, hence ifFromCache should be True
+			_, isFromCache, errGet = asc.GetApplicationById(ctx, testapplication.Application_id)
+			Expect(errGet).To(BeNil())
+			Expect(isFromCache).To(BeTrue())
+
+			// checking if the entry for the above exists in the database
+			errGet = dbq.GetApplicationById(ctx, &testapplication)
+			Expect(errGet).To(BeNil())
+			Expect(getApp).To(Equal(testapplication))
+		})
+
 	})
 
 })

--- a/backend-shared/config/db/util/application_info_cache_test.go
+++ b/backend-shared/config/db/util/application_info_cache_test.go
@@ -146,6 +146,7 @@ var _ = Describe("application_info_cache Test", func() {
 			Expect(errGet).To(BeNil())
 			Expect(testAppState).To(Equal(getAppState))
 		})
+
 		It("Tests GetApplicationById", func() {
 			err := db.SetupForTestingDBGinkgo()
 			Expect(err).To(BeNil())
@@ -167,7 +168,7 @@ var _ = Describe("application_info_cache Test", func() {
 			Expect(err).To(BeNil())
 			// since no entry in the valuefromcache should be false, appState should be empty
 			Expect(valuefromCache).To(BeFalse())
-			Expect(app).To(Equal(db.ApplicationState{}))
+			Expect(app).To(Equal(db.Application{}))
 
 			_, managedEnvironment, _, gitopsEngineInstance, _, err := db.CreateSampleData(dbq)
 			Expect(err).To(BeNil())

--- a/backend-shared/config/db/util/application_info_cache_test.go
+++ b/backend-shared/config/db/util/application_info_cache_test.go
@@ -73,13 +73,13 @@ var _ = Describe("application_info_cache Test", func() {
 				Applicationstate_application_id: testAppState.Applicationstate_application_id,
 			}
 
-			rowsAffected, errCreate := asc.DeleteApplicationStateById(ctx, testDeleteAppState.Applicationstate_application_id)
-			Expect(errCreate).To(BeNil())
+			rowsAffected, errDelete := asc.DeleteApplicationStateById(ctx, testDeleteAppState.Applicationstate_application_id)
+			Expect(errDelete).To(BeNil())
 			Expect(rowsAffected).Should(Equal(1))
 
 			// check for entry in db, which should report an error
 			errGet = dbq.GetApplicationStateById(ctx, &testDeleteAppState)
-			Expect(errGet).ToNot(BeNil())
+			Expect(db.IsResultNotFoundError(errGet)).To(BeTrue())
 
 		})
 		It("Tests GetApplicationStateById", func() {

--- a/backend-shared/config/db/util/application_info_cache_test.go
+++ b/backend-shared/config/db/util/application_info_cache_test.go
@@ -165,7 +165,7 @@ var _ = Describe("application_info_cache Test", func() {
 
 			//testId doesn't exist, the test should report an error
 			app, valuefromCache, errGet := asc.GetApplicationById(ctx, testId)
-			Expect(err).To(BeNil())
+			Expect(errGet).To(BeNil())
 			// since no entry in the valuefromcache should be false, appState should be empty
 			Expect(valuefromCache).To(BeFalse())
 			Expect(app).To(Equal(db.Application{}))

--- a/backend-shared/config/db/util/util_suite_test.go
+++ b/backend-shared/config/db/util/util_suite_test.go
@@ -1,0 +1,13 @@
+package util_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
+}


### PR DESCRIPTION
#### Description:
Adds ginkgo tests for : 
- db/types_test.go
- db/util/application_info_cache_test.go

#### Link to JIRA Story :

[GITOPSRVCE-124](https://issues.redhat.com/browse/GITOPSRVCE-124)
