### PR TITLE
Add Dockerfile in .ci/ for to run kubectl in openshift-ci

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -1,0 +1,8 @@
+FROM registry.ci.openshift.org/openshift/release:golang-1.17
+
+SHELL ["/bin/bash", "-c"]
+
+# Install kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin


### PR DESCRIPTION
#### Description:
- This is in regard to the story for enabling openshift-ci on managed-gitops, for the same when we do `make devenv-k8s` in our Makefile we are extensively using kubectl. But, kubectl is not installed in openshift-ci and reports an error as below. 
Error:

```
kubectl create namespace gitops 2> /dev/null || true
kubectl -n gitops apply -f  /go/src/github.com/redhat-appstudio/managed-gitops/backend/config/crd/bases/managed-gitops.redhat.com_gitopsdeployments.yaml
make: kubectl: Command not found
make: *** [deploy-backend-crd] Error 127
{"component":"entrypoint","error":"wrapped process failed: exit status 2","file":"k8s.io/test-infra/prow/entrypoint/run.go:80","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2022-05-18T11:41:05Z"}
error: failed to execute wrapped command: exit status 2
---
Link to step on registry info site: https://steps.ci.openshift.org/reference/managed-gitops-unit-tests
Link to job on registry info site: https://steps.ci.openshift.org/job?org=redhat-appstudio&repo=managed-gitops&branch=main&test=managed-gitops-unit-tests}
```

- In order to do so, this PR adds a simple Dockerfile that installs kubectl in the cluster, simple approach is adopted by the [e2e-tests repository](https://github.com/redhat-appstudio/e2e-tests/blob/main/.ci/openshift-ci/Dockerfile) under redhat-appstudio.

#### Link to JIRA Story (if applicable):  [GITOPSRVCE-139](https://issues.redhat.com/browse/GITOPSRVCE-139)
