### PR TITLE
Adds postgres-server packager to dockerfile, req by openshift-ci

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -5,4 +5,5 @@ SHELL ["/bin/bash", "-c"]
 # Install kubectl
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
-    mv ./kubectl /usr/local/bin
+    mv ./kubectl /usr/local/bin && \
+    yum -y install postgresql-server


### PR DESCRIPTION
#### Description:
- This is in regard to the story for enabling openshift-ci on managed-gitops. Adding postgres-server for the Dockerfile which is required in order to access psql binary required by the ci!

#### Link to JIRA Story (if applicable):  [GITOPSRVCE-139](https://issues.redhat.com/browse/GITOPSRVCE-139)
