### PR TITLE
Fix vendor issue at openshift-ci

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -1,8 +1,11 @@
 FROM registry.ci.openshift.org/openshift/release:golang-1.17
 
+# make sure Go doesn't use the vendors folder, unless we want to
+ENV GOFLAGS=""
+
 SHELL ["/bin/bash", "-c"]
 
-# Install kubectl
+# Install kubectl, postgresql-server
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin && \


### PR DESCRIPTION
#### Description:

The PR is fixing the issue demonstrated at: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/28655/rehearse-28655-pull-ci-redhat-appstudio-managed-gitops-main-managed-gitops-unit-tests/1527220348532035584/build-log.txt

You can reproduce it like this:

```
docker run --rm -it registry.ci.openshift.org/openshift/release:golang-1.17 /bin/bash
# Once inside the container, run:
# mkdir $GOPATH/src/github.com/redhat-studio
# cd $GOPATH/src/github.com/redhat-studio
# git clone https://github.com/redhat-appstudio/managed-gitops
# cd managed-gitops/backend
# go fmt ./...
```

You will see lots of errors. This is because we get one error per every single module we have in `go.mod`. The error looks like this:

```
github.com/emicklei/go-restful/v3@v3.7.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
... # skip the rest of them for brevity
github.com/redhat-appstudio/managed-gitops/backend-shared: is replaced in go.mod, but not marked as replaced in vendor/modules.txt

	To ignore the vendor directory, use -mod=readonly or -mod=mod.
	To sync the vendor directory, run:
		go mod vendor
```

This is happening because the Docker image it is using by default the flag: `GOFLAGS="-mod=vendor"` (you can do `go env` to witness this). That means it **expects**  a vendor folder to be present. But there is not such folder created, unless we do `go mod vendor` first. We explicitly have `vendor` inside our `.gitignore` because we don't need to commit these changes. 

So what happens when go fmt ./… is running and expects the vendor folder to be present?
It seems that Go compares the `go.mod` with ... nothing (because we don’t have vendor/modules.txt and it complains that they are not in sync. How could they be? There is not even a file to compare in the first place :stuck_out_tongue: 

If you ask me this error message is misleading, as it complains about a comparison that nevers happens. To me this looks like a bug in Go tooling. I would expect to get a message like "vendor/modules.txt is not found. To create it, run: go mod vendor". 

But anyway, the solution here is to reset the `GOFLAGS=""` go env.

#### Link to JIRA Story (if applicable):

* [GITOPSRVCE-139](https://issues.redhat.com/browse/GITOPSRVCE-139)
* https://github.com/redhat-appstudio/managed-gitops/pull/125