### PR TITLE
Add functionality to skip ephemeralPostgres_test in openshift-ci

### DIFF
--- a/backend-shared/config/db/ephemeralPostgres_test.go
+++ b/backend-shared/config/db/ephemeralPostgres_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Note: This function is not tested in an openshift-ci  enviroment
 func TestEphemeralCode(t *testing.T) {
-
+	skipOpenshiftCI(t)
 	ctx := context.Background()
 	// Create ephemeral DB
 	ephemeralDB, err := NewEphemeralCreateTestFramework()

--- a/backend-shared/config/db/utils.go
+++ b/backend-shared/config/db/utils.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"runtime/debug"
 	"strings"
@@ -673,4 +674,11 @@ func SetupforTestingDB(t *testing.T) {
 
 func TestTeardown(t *testing.T) {
 	// Currently unused
+}
+
+// This functions skips the testing in Openshift CI enviroment
+func skipOpenshiftCI(t *testing.T) {
+	if os.Getenv("OPENSHIFT_CI") != "" {
+		t.Skip("Skipping testing in OpenShift CI environment")
+	}
 }


### PR DESCRIPTION
### Description:

#### Error:
On testing the `TestEphemeralCode` function on Openshift-CI
 
```
--- FAIL: TestEphemeralCode (0.00s)
    ephemeralPostgres_test.go:18: 
        	Error Trace:	ephemeralPostgres_test.go:18
        	Error:      	Received unexpected error:
        	            	unable to create docker network: exec: "docker": executable file not found in $PATH. Do a 'docker system prune', for now
        	Test:       	TestEphemeralCode
```
#### Reason:

This is trying to execute a docker command within the openshift-ci spinned cluster which ideally doesn't have a docker binary installed. Plus, spinning up a container within the container is not a good practice and should be avoided. If folks have more opinions/suggestions around it, please let me know.

#### Fix:
The fix to the above failure is to simply skip this test in the Openshift-ci, this is done via checking the environment in which the tests are running, for the CI environment points to [OPENSHIFT_CI](https://github.com/redhat-appstudio/e2e-tests/blob/main/scripts/e2e-openshift-ci.sh#L9).

### Link to JIRA Story (if applicable): [GITOPSRVCE-139](https://issues.redhat.com/browse/GITOPSRVCE-139)
