### PR TITLE
add hacbs-core-service pipeline

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -16,7 +16,7 @@ spec:
       value: 'quay.io/redhat-appstudio/pull-request-builds:mgiops-{{revision}}'
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/build-templates-bundle:0866720a87aec4675074069cd16662d8e01237cf
+    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
   workspaces:
     - name: workspace
       persistentVolumeClaim:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -19,9 +19,12 @@ spec:
       value: .
     - name: dockerfile
       value: Dockerfile
+    - name: infra-deployment-update-script
+      value: |
+        sed -i -e 's|\(https://raw.githubusercontent.com/jgwest/managed-gitops/\)[^/]*\(/.*\)|\1{{ revision }}\2|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/gitops/kustomization.yaml
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/build-templates-bundle:0866720a87aec4675074069cd16662d8e01237cf
+    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
   workspaces:
     - name: workspace
       persistentVolumeClaim:


### PR DESCRIPTION
#### Description:
Update the pipelineRef bundle with hacbs-core-service-templates-bundle, which is an extension of hacbs, for core services of AppStudio/HACBS, allows creating MR in infra-deployments and also add the infra-deployment update script.

#### Link to JIRA Story (if applicable):
(https://issues.redhat.com/browse/PLNSRVCE-271)