### PR TITLE
Rename database fields and references from workspace to namespace where appropriate

### DIFF
--- a/backend-shared/config/db/apicrtodatabasemapping.go
+++ b/backend-shared/config/db/apicrtodatabasemapping.go
@@ -107,7 +107,7 @@ func (dbq *PostgreSQLDatabaseQueries) GetDatabaseMappingForAPICR(ctx context.Con
 
 }
 
-func (dbq *PostgreSQLDatabaseQueries) ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx context.Context, apiCRResourceType string, crName string, crNamespace string, crWorkspaceUID string, dbRelationType string, apiCRToDBMappingParam *[]APICRToDatabaseMapping) error {
+func (dbq *PostgreSQLDatabaseQueries) ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx context.Context, apiCRResourceType string, crName string, crNamespace string, crNamespaceUID string, dbRelationType string, apiCRToDBMappingParam *[]APICRToDatabaseMapping) error {
 
 	if err := validateQueryParamsEntity(apiCRToDBMappingParam, dbq); err != nil {
 		return err
@@ -117,7 +117,7 @@ func (dbq *PostgreSQLDatabaseQueries) ListAPICRToDatabaseMappingByAPINamespaceAn
 		"apiCRResourceType", apiCRResourceType,
 		"crName", crName,
 		"crNamespace", crNamespace,
-		"crWorkspaceUID", crWorkspaceUID,
+		"crNamespaceUID", crNamespaceUID,
 		"dbRelationType", dbRelationType,
 	); err != nil {
 		return err
@@ -131,7 +131,7 @@ func (dbq *PostgreSQLDatabaseQueries) ListAPICRToDatabaseMappingByAPINamespaceAn
 		Where("atdbm.api_resource_type = ?", apiCRResourceType).
 		Where("atdbm.api_resource_name = ?", crName).
 		Where("atdbm.api_resource_namespace = ?", crNamespace).
-		Where("atdbm.api_resource_workspace_uid = ?", crWorkspaceUID).
+		Where("atdbm.api_resource_namespace_uid = ?", crNamespaceUID).
 		Where("atdbm.db_relation_type = ?", dbRelationType).
 		Context(ctx).
 		Select(); err != nil {

--- a/backend-shared/config/db/apicrtodatabasemapping_test.go
+++ b/backend-shared/config/db/apicrtodatabasemapping_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Apicrtodatabasemapping Tests", func() {
 				APIResourceUID:       "test-k8s-uid",
 				APIResourceName:      "test-k8s-name",
 				APIResourceNamespace: "test-k8s-namespace",
-				WorkspaceUID:         "test-workspace-uid",
+				NamespaceUID:         "test-namespace-uid",
 				DBRelationType:       db.APICRToDatabaseMapping_DBRelationType_SyncOperation,
 				DBRelationKey:        "test-key",
 			}
@@ -44,7 +44,7 @@ var _ = Describe("Apicrtodatabasemapping Tests", func() {
 
 			var items []db.APICRToDatabaseMapping
 
-			err = dbq.ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx, item.APIResourceType, item.APIResourceName, item.APIResourceNamespace, item.WorkspaceUID, item.DBRelationType, &items)
+			err = dbq.ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx, item.APIResourceType, item.APIResourceName, item.APIResourceNamespace, item.NamespaceUID, item.DBRelationType, &items)
 			Expect(err).To(BeNil())
 			Expect(items[0]).Should(Equal(item))
 

--- a/backend-shared/config/db/db_field_constants.go
+++ b/backend-shared/config/db/db_field_constants.go
@@ -47,7 +47,7 @@ const (
 	DeploymentToApplicationMappingDeploymenttoapplicationmappingUIDIDLength = 48
 	DeploymentToApplicationMappingNameLength                                = 256
 	DeploymentToApplicationMappingNamespaceLength                           = 96
-	DeploymentToApplicationMappingWorkspaceUIDLength                        = 48
+	DeploymentToApplicationMappingNamespaceUIDLength                        = 48
 	DeploymentToApplicationMappingApplicationIDLength                       = 48
 	KubernetesToDBResourceMappingKubernetesResourceTypeLength               = 64
 	KubernetesToDBResourceMappingKubernetesResourceUIDLength                = 64
@@ -57,7 +57,7 @@ const (
 	APICRToDatabaseMappingApiResourceUIDLength                              = 64
 	APICRToDatabaseMappingApiResourceNameLength                             = 256
 	APICRToDatabaseMappingApiResourceNamespaceLength                        = 256
-	APICRToDatabaseMappingApiResourceWorkspaceUIDLength                     = 64
+	APICRToDatabaseMappingApiResourceNamespaceUIDLength                     = 64
 	APICRToDatabaseMappingDbRelationTypeLength                              = 32
 	APICRToDatabaseMappingDbRelationKeyLength                               = 64
 	SyncOperationSyncoperationIDLength                                      = 48
@@ -141,8 +141,7 @@ var DbFieldMap = map[string]int{
 	"DeploymentToApplicationMappingDeploymentNameLength":                      DeploymentToApplicationMappingNameLength,
 	"DeploymentToApplicationMappingNamespaceLength":                           DeploymentToApplicationMappingNamespaceLength,
 	"DeploymentToApplicationMappingDeploymentNamespaceLength":                 DeploymentToApplicationMappingNamespaceLength,
-	"DeploymentToApplicationMappingNamespaceUIDLength":                        DeploymentToApplicationMappingWorkspaceUIDLength,
-	"DeploymentToApplicationMappingWorkspaceUIDLength":                        DeploymentToApplicationMappingWorkspaceUIDLength,
+	"DeploymentToApplicationMappingNamespaceUIDLength":                        DeploymentToApplicationMappingNamespaceUIDLength,
 	"DeploymentToApplicationMappingApplicationIDLength":                       DeploymentToApplicationMappingApplicationIDLength,
 	"KubernetesToDBResourceMappingKubernetesResourceTypeLength":               KubernetesToDBResourceMappingKubernetesResourceTypeLength,
 	"KubernetesToDBResourceMappingKubernetesResourceUIDLength":                KubernetesToDBResourceMappingKubernetesResourceUIDLength,
@@ -158,8 +157,8 @@ var DbFieldMap = map[string]int{
 	"APICRToDatabaseMappingAPIResourceNameLength":                             APICRToDatabaseMappingApiResourceNameLength,
 	"APICRToDatabaseMappingApiResourceNamespaceLength":                        APICRToDatabaseMappingApiResourceNamespaceLength,
 	"APICRToDatabaseMappingAPIResourceNamespaceLength":                        APICRToDatabaseMappingApiResourceNamespaceLength,
-	"APICRToDatabaseMappingApiResourceWorkspaceUIDLength":                     APICRToDatabaseMappingApiResourceWorkspaceUIDLength,
-	"APICRToDatabaseMappingWorkspaceUIDLength":                                APICRToDatabaseMappingApiResourceWorkspaceUIDLength,
+	"APICRToDatabaseMappingApiResourceNamespaceUIDLength":                     APICRToDatabaseMappingApiResourceNamespaceUIDLength,
+	"APICRToDatabaseMappingNamespaceUIDLength":                                APICRToDatabaseMappingApiResourceNamespaceUIDLength,
 	"APICRToDatabaseMappingDbRelationTypeLength":                              APICRToDatabaseMappingDbRelationTypeLength,
 	"APICRToDatabaseMappingDBRelationTypeLength":                              APICRToDatabaseMappingDbRelationTypeLength,
 	"APICRToDatabaseMappingDbRelationKeyLength":                               APICRToDatabaseMappingDbRelationKeyLength,

--- a/backend-shared/config/db/deploymenttoapplicationmapping.go
+++ b/backend-shared/config/db/deploymenttoapplicationmapping.go
@@ -5,15 +5,15 @@ import (
 	"fmt"
 )
 
-func (dbq *PostgreSQLDatabaseQueries) ListDeploymentToApplicationMappingByWorkspaceUID(ctx context.Context, workspaceUID string,
+func (dbq *PostgreSQLDatabaseQueries) ListDeploymentToApplicationMappingByNamespaceUID(ctx context.Context, namespaceUID string,
 	deplToAppMappingParam *[]DeploymentToApplicationMapping) error {
 
 	if err := validateQueryParamsEntity(deplToAppMappingParam, dbq); err != nil {
 		return err
 	}
 
-	if err := isEmptyValues("ListDeploymentToApplicationMappingByWorkspaceUID",
-		"WorkspaceUID", workspaceUID,
+	if err := isEmptyValues("ListDeploymentToApplicationMappingByNamespaceUID",
+		"NamespaceUID", namespaceUID,
 	); err != nil {
 		return err
 	}
@@ -25,11 +25,11 @@ func (dbq *PostgreSQLDatabaseQueries) ListDeploymentToApplicationMappingByWorksp
 	// TODO: GITOPSRVCE-68 - PERF - Add index for this
 
 	if err := dbq.dbConnection.Model(&dbResults).
-		Where("dta.workspace_uid = ?", workspaceUID).
+		Where("dta.namespace_uid = ?", namespaceUID).
 		Context(ctx).
 		Select(); err != nil {
 
-		return fmt.Errorf("error on retrieving ListDeploymentToApplicationMappingByWorkspaceUID: %v", err)
+		return fmt.Errorf("error on retrieving ListDeploymentToApplicationMappingByNamespaceUID: %v", err)
 	}
 
 	*deplToAppMappingParam = dbResults
@@ -38,7 +38,7 @@ func (dbq *PostgreSQLDatabaseQueries) ListDeploymentToApplicationMappingByWorksp
 }
 
 func (dbq *PostgreSQLDatabaseQueries) ListDeploymentToApplicationMappingByNamespaceAndName(ctx context.Context, deploymentName string,
-	deploymentNamespace string, workspaceUID string, deplToAppMappingParam *[]DeploymentToApplicationMapping) error {
+	deploymentNamespace string, namespaceUID string, deplToAppMappingParam *[]DeploymentToApplicationMapping) error {
 
 	if err := validateQueryParamsEntity(deplToAppMappingParam, dbq); err != nil {
 		return err
@@ -47,7 +47,7 @@ func (dbq *PostgreSQLDatabaseQueries) ListDeploymentToApplicationMappingByNamesp
 	if err := isEmptyValues("ListDeploymentToApplicationMappingByNamespaceAndName",
 		"DeploymentName", deploymentName,
 		"DeploymentNamespace", deploymentNamespace,
-		"WorkspaceUID", workspaceUID,
+		"NamespaceUID", namespaceUID,
 	); err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func (dbq *PostgreSQLDatabaseQueries) ListDeploymentToApplicationMappingByNamesp
 	if err := dbq.dbConnection.Model(&dbResults).
 		Where("dta.name = ?", deploymentName).
 		Where("dta.namespace = ?", deploymentNamespace).
-		Where("dta.workspace_uid = ?", workspaceUID).
+		Where("dta.namespace_uid = ?", namespaceUID).
 		Context(ctx).
 		Select(); err != nil {
 
@@ -73,7 +73,7 @@ func (dbq *PostgreSQLDatabaseQueries) ListDeploymentToApplicationMappingByNamesp
 	return nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) DeleteDeploymentToApplicationMappingByNamespaceAndName(ctx context.Context, deploymentName string, deploymentNamespace string, workspaceUID string) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteDeploymentToApplicationMappingByNamespaceAndName(ctx context.Context, deploymentName string, deploymentNamespace string, namespaceUID string) (int, error) {
 
 	if err := validateQueryParamsNoPK(dbq); err != nil {
 		return 0, err
@@ -82,7 +82,7 @@ func (dbq *PostgreSQLDatabaseQueries) DeleteDeploymentToApplicationMappingByName
 	if err := isEmptyValues("DeleteDeploymentToApplicationMappingByNamespaceAndName",
 		"deploymentName", deploymentName,
 		"deploymentNamespace", deploymentNamespace,
-		"workspaceUID", workspaceUID); err != nil {
+		"namespaceUID", namespaceUID); err != nil {
 
 		return 0, err
 	}
@@ -92,7 +92,7 @@ func (dbq *PostgreSQLDatabaseQueries) DeleteDeploymentToApplicationMappingByName
 	deleteResult, err := dbq.dbConnection.Model(entity).
 		Where("dta.name = ?", deploymentName).
 		Where("dta.namespace = ?", deploymentNamespace).
-		Where("dta.workspace_uid = ?", workspaceUID).Context(ctx).Delete()
+		Where("dta.namespace_uid = ?", namespaceUID).Context(ctx).Delete()
 	if err != nil {
 		return 0, fmt.Errorf("error on deleting application: %v", err)
 	}

--- a/backend-shared/config/db/deploymenttoapplicationmapping_test.go
+++ b/backend-shared/config/db/deploymenttoapplicationmapping_test.go
@@ -44,7 +44,7 @@ var _ = Describe("DeploymentToApplicationMapping Tests", func() {
 				Application_id:                        application.Application_id,
 				DeploymentName:                        "test-deployment",
 				DeploymentNamespace:                   "test-namespace",
-				NamespaceUID:                          "demo-workspace",
+				NamespaceUID:                          "demo-namespace",
 			}
 
 			err = dbq.CreateDeploymentToApplicationMapping(ctx, deploymentToApplicationMapping)
@@ -94,7 +94,7 @@ var _ = Describe("DeploymentToApplicationMapping Tests", func() {
 				Application_id:                        application.Application_id,
 				DeploymentName:                        "test-deployment",
 				DeploymentNamespace:                   "test-namespace",
-				NamespaceUID:                          "demo-workspace",
+				NamespaceUID:                          "demo-namespace",
 			}
 
 			err = dbq.CreateDeploymentToApplicationMapping(ctx, deploymentToApplicationMapping)
@@ -104,7 +104,7 @@ var _ = Describe("DeploymentToApplicationMapping Tests", func() {
 				Deploymenttoapplicationmapping_uid_id: deploymentToApplicationMapping.Deploymenttoapplicationmapping_uid_id,
 			}
 
-			err = dbq.ListDeploymentToApplicationMappingByWorkspaceUID(ctx, "demo-workspace", &dbResults)
+			err = dbq.ListDeploymentToApplicationMappingByNamespaceUID(ctx, "demo-namespace", &dbResults)
 			Expect(err).To(BeNil())
 			Expect(len(dbResults)).Should(Equal(1))
 			Expect(dbResults[0]).Should(Equal(*deploymentToApplicationMapping))

--- a/backend-shared/config/db/queries.go
+++ b/backend-shared/config/db/queries.go
@@ -169,7 +169,7 @@ type ApplicationScopedQueries interface {
 	CreateDeploymentToApplicationMapping(ctx context.Context, obj *DeploymentToApplicationMapping) error
 	GetDeploymentToApplicationMappingByDeplId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping) error
 	ListDeploymentToApplicationMappingByNamespaceAndName(ctx context.Context, deploymentName string, deploymentNamespace string, namespaceUID string, deplToAppMappingParam *[]DeploymentToApplicationMapping) error
-	ListDeploymentToApplicationMappingByWorkspaceUID(ctx context.Context, namespaceUID string, deplToAppMappingParam *[]DeploymentToApplicationMapping) error
+	ListDeploymentToApplicationMappingByNamespaceUID(ctx context.Context, namespaceUID string, deplToAppMappingParam *[]DeploymentToApplicationMapping) error
 	DeleteDeploymentToApplicationMappingByDeplId(ctx context.Context, id string) (int, error)
 	DeleteDeploymentToApplicationMappingByNamespaceAndName(ctx context.Context, deploymentName string, deploymentNamespace string, namespaceUID string) (int, error)
 

--- a/backend-shared/config/db/types.go
+++ b/backend-shared/config/db/types.go
@@ -291,7 +291,7 @@ type DeploymentToApplicationMapping struct {
 
 	// UID (.metadata.uid) of the Namespace, containing the GitOpsDeployments
 	// value: (uid of namespace)
-	NamespaceUID string `pg:"workspace_uid"`
+	NamespaceUID string `pg:"namespace_uid"`
 
 	// Reference to the corresponding Application row
 	// -- Foreign key to: Application.Application_id
@@ -306,9 +306,9 @@ const (
 	APICRToDatabaseMapping_DBRelationType_SyncOperation = "SyncOperation"
 )
 
-// Maps API custom resources on the workspace (such as GitOpsDeploymentSyncRun), to a corresponding entry in the database.
+// Maps API custom resources on the API namespace (such as GitOpsDeploymentSyncRun), to a corresponding entry in the database.
 // This allows us to quickly go from API CR <-to-> Database entry, and also to identify database entries even when the API CR has been
-// deleted from the workspace.
+// deleted from the API namespace.
 //
 // See for details:
 // 'What are the DeploymentToApplicationMapping, KubernetesToDBResourceMapping, and APICRToDatabaseMapping, database tables for?:
@@ -323,7 +323,7 @@ type APICRToDatabaseMapping struct {
 
 	APIResourceName      string `pg:"api_resource_name"`
 	APIResourceNamespace string `pg:"api_resource_namespace"`
-	WorkspaceUID         string `pg:"api_resource_workspace_uid"`
+	NamespaceUID         string `pg:"api_resource_namespace_uid"`
 
 	DBRelationType string `pg:"db_relation_type"`
 	DBRelationKey  string `pg:"db_relation_key"`
@@ -332,7 +332,7 @@ type APICRToDatabaseMapping struct {
 }
 
 // Represents a generic relationship between Kubernetes CR <-> Database table
-// The Kubernetes CR can be either in the workspace, or in/on a GitOpsEngine cluster namespace.
+// The Kubernetes CR can be either in the API namespace, or in/on a GitOpsEngine cluster namespace.
 //
 // Example: when the cluster agent sees an Argo CD Application CR change within a namespace, it needs a way
 // to know which GitOpsEngineInstance database entries corresponds to the Argo CD namespace.

--- a/backend/controllers/managed-gitops/gitopsdeployment_controller.go
+++ b/backend/controllers/managed-gitops/gitopsdeployment_controller.go
@@ -34,7 +34,6 @@ import (
 // GitOpsDeploymentReconciler reconciles a GitOpsDeployment object
 type GitOpsDeploymentReconciler struct {
 	client.Client
-	WorkspaceName       string // not used
 	Scheme              *runtime.Scheme
 	PreprocessEventLoop *eventloop.PreprocessEventLoop
 }

--- a/backend/controllers/managed-gitops/gitopsdeploymentsyncrun_controller.go
+++ b/backend/controllers/managed-gitops/gitopsdeploymentsyncrun_controller.go
@@ -34,9 +34,7 @@ import (
 // GitOpsDeploymentSyncRunReconciler reconciles a GitOpsDeploymentSyncRun object
 type GitOpsDeploymentSyncRunReconciler struct {
 	client.Client
-	Scheme        *runtime.Scheme
-	WorkspaceName string
-	// EventLoop           *eventloop.EventLoop
+	Scheme              *runtime.Scheme
 	PreprocessEventLoop *eventloop.PreprocessEventLoop
 }
 

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
@@ -203,7 +203,7 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleSyncRun
 
 			APIResourceName:      syncRunCR.Name,
 			APIResourceNamespace: syncRunCR.Namespace,
-			WorkspaceUID:         eventlooptypes.GetWorkspaceIDFromNamespaceID(namespace),
+			NamespaceUID:         eventlooptypes.GetWorkspaceIDFromNamespaceID(namespace),
 		}
 		if err := dbQueries.CreateAPICRToDatabaseMapping(ctx, &newApiCRToDBMapping); err != nil {
 			log.Error(err, "unable to create api to db mapping in database")

--- a/backend/eventloop/eventlooptypes/types_test_util.go
+++ b/backend/eventloop/eventlooptypes/types_test_util.go
@@ -64,7 +64,7 @@ func GenericTestSetup() (*runtime.Scheme, *v1.Namespace, *v1.Namespace, *v1.Name
 		Spec: v1.NamespaceSpec{},
 	}
 
-	workspace := &v1.Namespace{
+	namespace := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-user",
 			UID:       uuid.NewUUID(),
@@ -73,6 +73,6 @@ func GenericTestSetup() (*runtime.Scheme, *v1.Namespace, *v1.Namespace, *v1.Name
 		Spec: v1.NamespaceSpec{},
 	}
 
-	return scheme, argocdNamespace, kubesystemNamespace, workspace, nil
+	return scheme, argocdNamespace, kubesystemNamespace, namespace, nil
 
 }

--- a/db-schema.sql
+++ b/db-schema.sql
@@ -266,7 +266,7 @@ CREATE TABLE ApplicationState (
 
 );
 
--- Represents the relationship from GitOpsDeployment CR in the API namespace (workspace), to an Application table row.
+-- Represents the relationship from GitOpsDeployment CR in the API namespace, to an Application table row.
 -- This means: if we see a change in a GitOpsDeployment CR, we can easily find the corresponding database entry
 -- by looking for a DeploymentToApplicationMapping that captures the relationship (and vice versa)
 --
@@ -278,12 +278,12 @@ CREATE TABLE DeploymentToApplicationMapping (
 	-- uid of our gitops deployment CR within the K8s namespace (or KCP control plane)
 	deploymenttoapplicationmapping_uid_id VARCHAR(48) UNIQUE NOT NULL PRIMARY KEY,
 	
-	-- name of the GitOpsDeployment CR in the API namespace (workspace)
+	-- name of the GitOpsDeployment CR in the API namespace
 	name VARCHAR ( 256 ),
-	-- name of the API namespace (workspace)
+	-- name of the API namespace
 	namespace VARCHAR ( 96 ),
-	-- uid of the API namespace (workspace)
-	workspace_uid VARCHAR ( 48 ), 
+	-- uid of the API namespace 
+	namespace_uid VARCHAR ( 48 ), 
 
 	-- The Application DB entry that corresponds to this GitOpsDeployment CR
 	-- (For example, deleting the GitOpsDeployment CR should delete the corresponding Application DB table, and likewise
@@ -297,7 +297,7 @@ CREATE TABLE DeploymentToApplicationMapping (
 );
 
 -- Represents a generic relationship between: Kubernetes CR <->  Database table
--- The Kubernetes CR can be either in the workspace, or in/on a GitOpsEngine cluster namespace.
+-- The Kubernetes CR can be either in the API namespace, or in/on a GitOpsEngine cluster namespace.
 --
 -- Example: when the cluster agent sees an Argo CD Application CR change within a namespace, it needs a way
 -- to know which GitOpsEngineInstance database entries corresponds to the Argo CD namespace.
@@ -341,9 +341,9 @@ CREATE TABLE KubernetesToDBResourceMapping  (
 CREATE INDEX idx_db_relation_uid ON KubernetesToDBResourceMapping(kubernetes_resource_type, kubernetes_resource_uid, db_relation_type);
 -- Used by: GetDBResourceMappingForKubernetesResource
 
--- Maps API custom resources on the workspace (such as GitOpsDeploymentSyncRun), to a corresponding entry in the database.
+-- Maps API custom resources in an API namespace (such as GitOpsDeploymentSyncRun), to a corresponding entry in the database.
 -- This allows us to quickly go from API CR <-to-> Database entry, and also to identify database entries even when the API CR has been
--- deleted from the workspace.
+-- deleted from the namespace/workspace.
 --
 -- See for details:
 -- 'What are the DeploymentToApplicationMapping, KubernetesToDBResourceMapping, and APICRToDatabaseMapping, database tables for?:
@@ -365,7 +365,7 @@ CREATE TABLE APICRToDatabaseMapping  (
 	api_resource_namespace VARCHAR(256) NOT NULL,
 	
 	-- The UID (from .metadata.uid field) of the namespace containing the k8s resource
-	api_resource_workspace_uid VARCHAR(64) NOT NULL,
+	api_resource_namespace_uid VARCHAR(64) NOT NULL,
 
 	-- The name of the database table being referenced. 
 	-- As of this writing (Jan 2022), the only supported value for this field is SyncOperation.


### PR DESCRIPTION

#### Description:
- I previously used the term "workspace" as a catch-all term, to refer to the namespace where users were creating our API resources (`GitOpsDeployment` resource, etc).
- However, now that we are moving to KCP, which has the concept of workspaces, this use of 'workspace' is confusing. 
- I have thus updated the code from workspace -> namespace, or workspace -> API namespace as appropriate. 
- This PR only updates names/fields/database rows, there are no functional changes.
#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-19
