### PR TITLE
ci: bump actions/setup-go from 3.0.0 to 3.2.0

### DIFF
--- a/.github/workflows/schema-sync.yml
+++ b/.github/workflows/schema-sync.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v3.2.0
       with:
         go-version: "1.17.6"
     - uses: actions/checkout@v3

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v3.2.0
         with:
           go-version: "1.17.6"
       - name: "Run make fmt and then 'git diff' to see if anything changed: to fix this check, run make fmt and then commit the changes."
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v3.2.0
         with:
           go-version: "1.17.6"
       - name: "Install gosec"
@@ -96,7 +96,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v3.2.0
         with:
           go-version: "1.17.6"
 
@@ -158,7 +158,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v3.2.0
         with:
           go-version: "1.17.6"
       - name: "Start PostgreSQL"
@@ -191,7 +191,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v3.2.0
         with:
           go-version: "1.17.6"
       - name: "appstudio-shared: Run 'make generate manifests' and report any diff"


### PR DESCRIPTION
#### Description:

This allows us to hardcode a Go supported [version for the project in a file](https://github.com/actions/setup-go/issues/23#issuecomment-606215099), so then the Go GitHub Action can read that file and run the CI based on _this specific_ Go version. I am wondering if OpenShift CI has something similar (just tagging @samyak-jn to me him aware of this).

The rest of the changelog:

Bumps [actions/setup-go](https://github.com/actions/setup-go) from 3.0.0 to 3.2.0.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/actions/setup-go/releases">actions/setup-go's releases</a>.</em></p>
<blockquote>
<h2>Support for caching dependency files and compiler's build outputs</h2>
<p>This release introduces support for caching dependency files and compiler's build outputs <a href="https://github-redirect.dependabot.com/actions/setup-go/pull/228">#228</a>. For that action uses <a href="https://github.com/actions/toolkit/tree/main/packages/cache"><code>@​toolkit/cache</code></a> library under the hood that in turn allows getting rid of configuring <a href="https://github.com/actions/cache"><code>@​actions/cache</code></a> action separately and simplifies the whole workflow.</p>
<p>Such input parameters as <code>cache</code> and <code>cache-dependency-path</code> were added. The <code>cache</code> input is optional, and caching is turned off by default, <code>cache-dependency-path</code> is used to specify the path to a dependency file - <code>go.sum</code>.</p>
<p><strong>Examples of use-cases:</strong></p>
<ul>
<li><code>cache</code> input only:</li>
</ul>
<pre lang="yaml"><code>steps:
- uses: actions/checkout@v3
- uses: actions/setup-go@v3
  with:
    go-version: '18'
    cache: true
</code></pre>
<ul>
<li><code>cache</code> along with <code>cache-dependency-path</code>:</li>
</ul>
<pre lang="yaml"><code>steps:
- uses: actions/checkout@v3
- uses: actions/setup-go@v3
  with:
    go-version: '18'
    cache: true
    cache-dependency-path: subdir/go.sum
</code></pre>
<h2>Add go-version-file input</h2>
<h3>Adding Go version file support</h3>
<p>In scope of this release we add the <a href="https://github-redirect.dependabot.com/actions/setup-go/pull/62">go-version-file</a> input. The new input (<code>go-version-file</code>) provides functionality to specify the path to the file containing Go version with such behaviour:</p>
<ul>
<li>If the file does not exist the action will throw an error.</li>
<li>If you specify both go-version and go-version-file inputs, the action will use value from the go-version input and throw the following warning: Both go-version and go-version-file inputs are specified, only go-version will be used.</li>
<li>For now the action supports .go-version and go.mod files.</li>
</ul>
<pre lang="yaml"><code>steps:
 - uses: actions/checkout@v3
 - uses: actions/setup-go@v3
   with:
     go-version-file: 'path/to/go.mod'
 - run: go version
</code></pre>
<p>Besides, the following pull requests included in this release:</p>
<ul>
<li>Fix condition for GOPATH output <a href="https://github-redirect.dependabot.com/actions/setup-go/pull/221">actions/setup-go#221</a></li>
<li>Added go-version output <a href="https://github-redirect.dependabot.com/actions/setup-go/pull/85">actions/setup-go#85</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/actions/setup-go/commit/b22fbbc2921299758641fab08929b4ac52b32923"><code>b22fbbc</code></a> Implementation of caching functionality for setup-go action (<a href="https://github-redirect.dependabot.com/actions/setup-go/issues/228">#228</a>)</li>
<li><a href="https://github.com/actions/setup-go/commit/fcdc43634adb5f7ae75a9d7a9b9361790f7293e2"><code>fcdc436</code></a> Update <code>@​zeit/ncc</code> to <code>@​vercel/ncc</code> (<a href="https://github-redirect.dependabot.com/actions/setup-go/issues/229">#229</a>)</li>
<li><a href="https://github.com/actions/setup-go/commit/265edc1beb822df98f8606cd052a5af00d64271d"><code>265edc1</code></a> Add go-version-file option (<a href="https://github-redirect.dependabot.com/actions/setup-go/issues/62">#62</a>)</li>
<li><a href="https://github.com/actions/setup-go/commit/193b404f8a1d1dccaf6ed9bf03cdb68d2d02020f"><code>193b404</code></a> Successfully set up (<a href="https://github-redirect.dependabot.com/actions/setup-go/issues/231">#231</a>)</li>
<li><a href="https://github.com/actions/setup-go/commit/56a61c9834b4a4950dbbf4740af0b8a98c73b768"><code>56a61c9</code></a> Create ADR for integrating cache functionality to setup-go action (<a href="https://github-redirect.dependabot.com/actions/setup-go/issues/217">#217</a>)</li>
<li><a href="https://github.com/actions/setup-go/commit/b46db954a1b7f4b0f623637da4f378d230cabfb3"><code>b46db95</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/actions/setup-go/issues/222">#222</a> from vsafonkin/v-vsafonkin/add-readme-note</li>
<li><a href="https://github.com/actions/setup-go/commit/333235845452e808872d02ff54724c813b6735d6"><code>3332358</code></a> Add note about go building</li>
<li><a href="https://github.com/actions/setup-go/commit/46eabca1abc3e7139b3f3fb406a057e316a8360f"><code>46eabca</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/actions/setup-go/issues/221">#221</a> from vsafonkin/v-vsafonkin/fix-gopath-condition</li>
<li><a href="https://github.com/actions/setup-go/commit/07948221bef819e39255ccb730b9ead9f22c5c03"><code>0794822</code></a> Rename CONDUCT.md and change email inside (<a href="https://github-redirect.dependabot.com/actions/setup-go/issues/218">#218</a>)</li>
<li><a href="https://github.com/actions/setup-go/commit/ad70bef2ef3d4a69511a3994c9b65a3584bbe653"><code>ad70bef</code></a> Fix condition for old go versions</li>
<li>Additional commits viewable in <a href="https://github.com/actions/setup-go/compare/v2.1.5...v3.2.0">compare view</a></li>
</ul>
</details>
<br />

#### Link to JIRA Story (if applicable):

No JIRA
