### PR TITLE
Fix missing CRD in Makefile, update Repository Credentials Role, fix backend time format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,12 @@ deploy-backend-crd: ## Deploy backend related CRDs
 	kubectl create namespace gitops 2> /dev/null || true
 	kubectl -n gitops apply -f  $(MAKEFILE_ROOT)/backend/config/crd/bases/managed-gitops.redhat.com_gitopsdeployments.yaml
 	kubectl -n gitops apply -f  $(MAKEFILE_ROOT)/backend/config/crd/bases/managed-gitops.redhat.com_gitopsdeploymentsyncruns.yaml
+	kubectl -n gitops apply -f  $(MAKEFILE_ROOT)/backend/config/crd/bases/managed-gitops.redhat.com_gitopsdeploymentrepositorycredentials.yaml
 
 undeploy-backend-crd: ## Remove backend related CRDs
 	kubectl -n gitops delete -f  $(MAKEFILE_ROOT)/backend/config/crd/bases/managed-gitops.redhat.com_gitopsdeployments.yaml
 	kubectl -n gitops delete -f  $(MAKEFILE_ROOT)/backend/config/crd/bases/managed-gitops.redhat.com_gitopsdeploymentsyncruns.yaml
+	kubectl -n gitops delete -f  $(MAKEFILE_ROOT)/backend/config/crd/bases/managed-gitops.redhat.com_gitopsdeploymentrepositorycredentials.yaml
 
 deploy-backend-rbac: ## Deploy backend related RBAC resouces
 	kubectl create namespace gitops 2> /dev/null || true

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -57,7 +57,7 @@ build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go --zap-log-level debug 
+	go run ./main.go --zap-log-level debug --zap-time-encoding=rfc3339nano
 # more on controller log level configuration: https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/
 
 ##@ Deployment

--- a/backend/routes/router.go
+++ b/backend/routes/router.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"log"
 	"net/http"
+	"time"
 
 	restful "github.com/emicklei/go-restful/v3"
 
@@ -47,7 +48,7 @@ func RouteInit() *http.Server {
 	wsContainer.Add(webhookR)
 
 	log.Print("Main: the server is up, and listening to port 8090 on your host.")
-	server := &http.Server{Addr: ":8090", Handler: wsContainer}
+	server := &http.Server{Addr: ":8090", Handler: wsContainer, ReadHeaderTimeout: time.Second * 30}
 
 	return server
 }

--- a/manifests/backend-rbac/managed-gitops-backend-manager-role.yaml
+++ b/manifests/backend-rbac/managed-gitops-backend-manager-role.yaml
@@ -6,6 +6,32 @@ metadata:
   name: managed-gitops-backend-manager-role
 rules:
 - apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeploymentrepositorycredentials
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeploymentrepositorycredentials/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeploymentrepositorycredentials/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - ""
   resources:
     - namespaces


### PR DESCRIPTION
#### Description:
- Fix missing CRD in Makefile, which was preventing backend controller from starting
- Update Repository Credentials backend `Role` resource (for now this is only used when deployed to staging cluster)
- Fix backend time format, now that backend controller moved up to the same controller-runtime version as the other components.
- Verified the new PR passes E2E test

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
