### PR TITLE
Fix module conflict with appstudio-controller caused due to db-migration

### DIFF
--- a/appstudio-controller/go.mod
+++ b/appstudio-controller/go.mod
@@ -130,4 +130,5 @@ replace (
 	github.com/redhat-appstudio/managed-gitops/appstudio-shared => ../appstudio-shared
 	github.com/redhat-appstudio/managed-gitops/backend => ../backend
 	github.com/redhat-appstudio/managed-gitops/backend-shared => ../backend-shared
+	github.com/redhat-appstudio/managed-gitops/utilities/db-migration => ../utilities/db-migration
 )


### PR DESCRIPTION
### Description:
-  Today in the slack discussion @drpaneas found out that we have an indirect dependency conflict with db-migration which was breaking development in Goland. This is a quick fix to resolve that issue.

Issue Snap (in appstudio-controller):

```
-> go list -m -json all
go: [github.com/redhat-appstudio/managed-gitops/utilities/db-migration@v0.0.0](http://github.com/redhat-appstudio/managed-gitops/utilities/db-migration@v0.0.0): invalid version: unknown revision utilities/db-migration/v0.0.0
```


#### Link to JIRA Story (if applicable): NA
