### PR TITLE
Update make targets to use k8s configurations instead of docker while setting up on openshift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,9 @@ docker-push: ## Push docker image - note: you have to change the USERNAME var. O
 
 test: test-backend test-backend-shared test-cluster-agent test-appstudio-controller ## Run tests for all components
 
-setup-e2e-openshift: install-argocd-openshift devenv-docker reset-db ## Setup steps for E2E tests
+setup-e2e-openshift: install-argocd-openshift devenv-k8s reset-db ## Setup steps for E2E tests to run with Openshift CI
+
+setup-e2e-local: install-argocd-openshift devenv-docker reset-db ## Setup steps for E2E tests to run with Local Openshift Cluster
 
 start-e2e: start ## Start the managed gitops processes for E2E tests. At the moment this is just a wrapper over 'start' target
 

--- a/tests-e2e/core/gitops_deployment_status_test.go
+++ b/tests-e2e/core/gitops_deployment_status_test.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend/apis/managed-gitops/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"

--- a/tests-e2e/go.mod
+++ b/tests-e2e/go.mod
@@ -170,7 +170,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
-	go.uber.org/zap v1.21.0 // indirect
+	go.uber.org/zap v1.21.0
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
 	golang.org/x/mod v0.5.1 // indirect
 	golang.org/x/net v0.0.0-20220420153159-1850ba15e1be // indirect


### PR DESCRIPTION
Hello folks :hugs:,

#### Description:
- Update make targets to use k8s configurations instead of docker while setting up on openshift (required by openshift-ci)!

#### Link to JIRA Story (if applicable): [GITOPSRVCE-161](https://issues.redhat.com/browse/GITOPSRVCE-161)
