### PR TITLE
Add create-db target to use it with openshift-ci setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ docker-push: ## Push docker image - note: you have to change the USERNAME var. O
 
 test: test-backend test-backend-shared test-cluster-agent test-appstudio-controller ## Run tests for all components
 
-setup-e2e-openshift: install-argocd-openshift devenv-k8s reset-db ## Setup steps for E2E tests to run with Openshift CI
+setup-e2e-openshift: install-argocd-openshift devenv-k8s create-db ## Setup steps for E2E tests to run with Openshift CI
 
 setup-e2e-local: install-argocd-openshift devenv-docker reset-db ## Setup steps for E2E tests to run with Local Openshift Cluster
 
@@ -196,6 +196,9 @@ download-deps: ## Download goreman to ~/go/bin
 reset-db: ## Erase the current database, and reset it scratch; useful during development if you want a clean slate.
 	$(MAKEFILE_ROOT)/delete-dev-env.sh
 	$(MAKEFILE_ROOT)/create-dev-env.sh
+
+create-db: ## Create a new development database in Kubernetes
+	$(MAKEFILE_ROOT)/create-dev-env.sh kube
 
 vendor: ## Clone locally the dependencies - off-line
 	cd $(MAKEFILE_ROOT)/appstudio-shared && go mod vendor


### PR DESCRIPTION
Hello folks :hugs:,

#### Description:
- Add create-db target to use it with openshift-ci setup (required by openshift-ci)!

Why?

```
-setup-e2e-openshift: install-argocd-openshift devenv-k8s reset-db ## Setup steps for E2E tests to run with Openshift CI
+setup-e2e-openshift: install-argocd-openshift devenv-k8s create-db ## Setup steps for E2E tests to run with Openshift CI
 
 setup-e2e-local: install-argocd-openshift devenv-docker reset-db ## Setup steps for E2E tests to run with Local Openshift Cluster
 
@@ -193,6 +193,9 @@ test-backend-shared: ## Run test for backend-shared only
 download-deps: ## Download goreman to ~/go/bin
        go install github.com/mattn/goreman@latest
 
+create-db: ## Create dev enviroment; useful during development
+       $(MAKEFILE_ROOT)/create-dev-env.sh
+
 reset-db: ## Erase the current database, and reset it scratch; useful during development if you want a clean slate.
        $(MAKEFILE_ROOT)/delete-dev-env.sh
        $(MAKEFILE_ROOT)/create-dev-env.sh
```
        
So, before it was using reset-db, and which was executing the delete-dev-env.sh which in turns docker rm -rf command. While running  openshift ci everytime which initiates a new cluster each time it starts; it doesn't make sense to check for delete-dev-env.sh script and hence, I changed the target to use create-db which just uses create-dev-env.sh
While in the case of  setup-e2e-local where we are setting up e2e on local openshift cluster we can keep reset-db


#### Link to JIRA Story (if applicable): [GITOPSRVCE-161](https://issues.redhat.com/browse/GITOPSRVCE-161)
