### PR TITLE
Add short names for the shared APIs

### DIFF
--- a/appstudio-shared/apis/appstudio.redhat.com/v1alpha1/applicationpromotionrun_types.go
+++ b/appstudio-shared/apis/appstudio.redhat.com/v1alpha1/applicationpromotionrun_types.go
@@ -122,6 +122,7 @@ const (
 //+kubebuilder:subresource:status
 
 // ApplicationPromotionRun is the Schema for the applicationpromotionruns API
+// +kubebuilder:resource:path=applicationpromotionruns,shortName=apr;promotion
 type ApplicationPromotionRun struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/appstudio-shared/apis/appstudio.redhat.com/v1alpha1/applicationsnapshot_types.go
+++ b/appstudio-shared/apis/appstudio.redhat.com/v1alpha1/applicationsnapshot_types.go
@@ -74,6 +74,7 @@ type ApplicationSnapshotStatus struct {
 //+kubebuilder:subresource:status
 
 // ApplicationSnapshot is the Schema for the applicationsnapshots API
+// +kubebuilder:resource:path=applicationsnapshots,shortName=as;snapshot
 type ApplicationSnapshot struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/appstudio-shared/apis/appstudio.redhat.com/v1alpha1/applicationsnapshotenvironmentbinding_types.go
+++ b/appstudio-shared/apis/appstudio.redhat.com/v1alpha1/applicationsnapshotenvironmentbinding_types.go
@@ -145,6 +145,7 @@ type BindingStatusGitOpsDeployment struct {
 //+kubebuilder:subresource:status
 
 // ApplicationSnapshotEnvironmentBinding is the Schema for the applicationsnapshotenvironmentbindings API
+// +kubebuilder:resource:path=applicationsnapshotenvironmentbindings,shortName=aseb;binding
 type ApplicationSnapshotEnvironmentBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/appstudio-shared/apis/appstudio.redhat.com/v1alpha1/environment_types.go
+++ b/appstudio-shared/apis/appstudio.redhat.com/v1alpha1/environment_types.go
@@ -119,6 +119,7 @@ type EnvironmentStatus struct {
 //+kubebuilder:subresource:status
 
 // Environment is the Schema for the environments API
+// +kubebuilder:resource:path=environments,shortName=env;environment
 type Environment struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/appstudio-shared/apis/appstudio.redhat.com/v1alpha1/environment_types.go
+++ b/appstudio-shared/apis/appstudio.redhat.com/v1alpha1/environment_types.go
@@ -119,7 +119,7 @@ type EnvironmentStatus struct {
 //+kubebuilder:subresource:status
 
 // Environment is the Schema for the environments API
-// +kubebuilder:resource:path=environments,shortName=env;environment
+// +kubebuilder:resource:path=environments,shortName=env
 type Environment struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/appstudio-shared/config/crd/bases/appstudio.redhat.com_applicationpromotionruns.yaml
+++ b/appstudio-shared/config/crd/bases/appstudio.redhat.com_applicationpromotionruns.yaml
@@ -12,6 +12,9 @@ spec:
     kind: ApplicationPromotionRun
     listKind: ApplicationPromotionRunList
     plural: applicationpromotionruns
+    shortNames:
+    - apr
+    - promotion
     singular: applicationpromotionrun
   scope: Namespaced
   versions:

--- a/appstudio-shared/config/crd/bases/appstudio.redhat.com_applicationsnapshotenvironmentbindings.yaml
+++ b/appstudio-shared/config/crd/bases/appstudio.redhat.com_applicationsnapshotenvironmentbindings.yaml
@@ -12,6 +12,9 @@ spec:
     kind: ApplicationSnapshotEnvironmentBinding
     listKind: ApplicationSnapshotEnvironmentBindingList
     plural: applicationsnapshotenvironmentbindings
+    shortNames:
+    - aseb
+    - binding
     singular: applicationsnapshotenvironmentbinding
   scope: Namespaced
   versions:

--- a/appstudio-shared/config/crd/bases/appstudio.redhat.com_applicationsnapshots.yaml
+++ b/appstudio-shared/config/crd/bases/appstudio.redhat.com_applicationsnapshots.yaml
@@ -12,6 +12,9 @@ spec:
     kind: ApplicationSnapshot
     listKind: ApplicationSnapshotList
     plural: applicationsnapshots
+    shortNames:
+    - as
+    - snapshot
     singular: applicationsnapshot
   scope: Namespaced
   versions:

--- a/appstudio-shared/config/crd/bases/appstudio.redhat.com_environments.yaml
+++ b/appstudio-shared/config/crd/bases/appstudio.redhat.com_environments.yaml
@@ -12,6 +12,9 @@ spec:
     kind: Environment
     listKind: EnvironmentList
     plural: environments
+    shortNames:
+    - env
+    - environment
     singular: environment
   scope: Namespaced
   versions:

--- a/appstudio-shared/config/crd/bases/appstudio.redhat.com_environments.yaml
+++ b/appstudio-shared/config/crd/bases/appstudio.redhat.com_environments.yaml
@@ -14,7 +14,6 @@ spec:
     plural: environments
     shortNames:
     - env
-    - environment
     singular: environment
   scope: Namespaced
   versions:

--- a/appstudio-shared/manifests/appstudio-shared-customresourcedefinitions.yaml
+++ b/appstudio-shared/manifests/appstudio-shared-customresourcedefinitions.yaml
@@ -11,6 +11,9 @@ spec:
     kind: ApplicationPromotionRun
     listKind: ApplicationPromotionRunList
     plural: applicationpromotionruns
+    shortNames:
+    - apr
+    - promotion
     singular: applicationpromotionrun
   scope: Namespaced
   versions:
@@ -152,6 +155,9 @@ spec:
     kind: ApplicationSnapshotEnvironmentBinding
     listKind: ApplicationSnapshotEnvironmentBindingList
     plural: applicationsnapshotenvironmentbindings
+    shortNames:
+    - aseb
+    - binding
     singular: applicationsnapshotenvironmentbinding
   scope: Namespaced
   versions:
@@ -441,6 +447,9 @@ spec:
     kind: ApplicationSnapshot
     listKind: ApplicationSnapshotList
     plural: applicationsnapshots
+    shortNames:
+    - as
+    - snapshot
     singular: applicationsnapshot
   scope: Namespaced
   versions:
@@ -540,6 +549,9 @@ spec:
     kind: Environment
     listKind: EnvironmentList
     plural: environments
+    shortNames:
+    - env
+    - environment
     singular: environment
   scope: Namespaced
   versions:

--- a/appstudio-shared/manifests/appstudio-shared-customresourcedefinitions.yaml
+++ b/appstudio-shared/manifests/appstudio-shared-customresourcedefinitions.yaml
@@ -551,7 +551,6 @@ spec:
     plural: environments
     shortNames:
     - env
-    - environment
     singular: environment
   scope: Namespaced
   versions:


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>


#### Description:
- Very cumbersome to type in the long API names when using CLI
- Adds shortnames for the shared APIs

Here is a summary:
`ApplicationSnapshotEnvironmentBinding` - `aseb`, `binding`
`ApplicationSnapshot` - `as`, `snapshot`
`Environment` - `env`
`ApplicationPromotionRun` - `apr`, `promotion`

#### Link to JIRA Story (if applicable):
N/A
<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->