### PR TITLE
Add omitempty back to Environment to maintain compatibility with older resources

### DIFF
--- a/backend/apis/managed-gitops/v1alpha1/gitopsdeployment_types.go
+++ b/backend/apis/managed-gitops/v1alpha1/gitopsdeployment_types.go
@@ -53,7 +53,7 @@ type ApplicationSource struct {
 
 // ApplicationDestination holds information about the application's destination
 type ApplicationDestination struct {
-	Environment string `json:"environment"`
+	Environment string `json:"environment,omitempty"`
 
 	// The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
 	Namespace string `json:"namespace,omitempty"`

--- a/backend/config/crd/bases/managed-gitops.redhat.com_gitopsdeployments.yaml
+++ b/backend/config/crd/bases/managed-gitops.redhat.com_gitopsdeployments.yaml
@@ -48,8 +48,6 @@ spec:
                     description: The namespace will only be set for namespace-scoped
                       resources that have not set a value for .metadata.namespace
                     type: string
-                required:
-                - environment
                 type: object
               source:
                 description: ApplicationSource contains all required information about


### PR DESCRIPTION

#### Description:
- Update the GitOpsDeployment Go struct and CR to accept empty environment field (for now)

#### Link to JIRA Story (if applicable): N/A