### PR TITLE
Generate controller-gen manifests for appstudio-shared

### DIFF
--- a/appstudio-shared/config/crd/bases/appstudio.redhat.com_environments.yaml
+++ b/appstudio-shared/config/crd/bases/appstudio.redhat.com_environments.yaml
@@ -91,7 +91,7 @@ spec:
                     description: "KubernetesClusterCredentials allows you to specify
                       cluster credentials for stanadard K8s cluster (e.g. non-KCP
                       workspace). \n See this temporary URL for details on what values
-                      to provide for the APIURL and Secret: https://github.com/jgwest/managed-gitops/tree/managed-environment-87-june-2022/examples/m6-demo#gitopsdeploymentmanagedenvironment-resource"
+                      to provide for the APIURL and Secret: https://github.com/redhat-appstudio/managed-gitops/tree/main/examples/m6-demo#gitopsdeploymentmanagedenvironment-resource"
                     properties:
                       apiURL:
                         description: APIURL is a reference to a cluster API url defined
@@ -102,7 +102,7 @@ spec:
                           name of k8s Secret, defined within the same namespace as
                           the Environment resource, that contains a kubeconfig. The
                           Secret must be of type 'managed-gitops.redhat.com/managed-environment'
-                          \n See this temporary URL for details: https://github.com/jgwest/managed-gitops/tree/managed-environment-87-june-2022/examples/m6-demo#gitopsdeploymentmanagedenvironment-resource"
+                          \n See this temporary URL for details: https://github.com/redhat-appstudio/managed-gitops/tree/main/examples/m6-demo#gitopsdeploymentmanagedenvironment-resource"
                         type: string
                       targetNamespace:
                         description: TargetNamespace is the default destination target

--- a/appstudio-shared/manifests/appstudio-shared-customresourcedefinitions.yaml
+++ b/appstudio-shared/manifests/appstudio-shared-customresourcedefinitions.yaml
@@ -619,7 +619,7 @@ spec:
                     description: "KubernetesClusterCredentials allows you to specify
                       cluster credentials for stanadard K8s cluster (e.g. non-KCP
                       workspace). \n See this temporary URL for details on what values
-                      to provide for the APIURL and Secret: https://github.com/jgwest/managed-gitops/tree/managed-environment-87-june-2022/examples/m6-demo#gitopsdeploymentmanagedenvironment-resource"
+                      to provide for the APIURL and Secret: https://github.com/redhat-appstudio/managed-gitops/tree/main/examples/m6-demo#gitopsdeploymentmanagedenvironment-resource"
                     properties:
                       apiURL:
                         description: APIURL is a reference to a cluster API url defined
@@ -630,7 +630,7 @@ spec:
                           name of k8s Secret, defined within the same namespace as
                           the Environment resource, that contains a kubeconfig. The
                           Secret must be of type 'managed-gitops.redhat.com/managed-environment'
-                          \n See this temporary URL for details: https://github.com/jgwest/managed-gitops/tree/managed-environment-87-june-2022/examples/m6-demo#gitopsdeploymentmanagedenvironment-resource"
+                          \n See this temporary URL for details: https://github.com/redhat-appstudio/managed-gitops/tree/main/examples/m6-demo#gitopsdeploymentmanagedenvironment-resource"
                         type: string
                       targetNamespace:
                         description: TargetNamespace is the default destination target


### PR DESCRIPTION
#### Description:

Generate controller-gen manifests without which the step `Ensure that manifests are up-to-date` fails in the CI
