### PR TITLE
Use go-pg's shared connection pool logic and update GitOps Service k8s manifests

### DIFF
--- a/backend-shared/config/db/queries.go
+++ b/backend-shared/config/db/queries.go
@@ -255,10 +255,11 @@ const (
 	sharedDBPoolMapKey_verbose  = "verbose"
 )
 
+// internalSharedDBConnectionPool maintains a list of DatabaseQueries, at present, one for verbose log output, and one for non-verbose log output
 type internalSharedDBConnectionPool struct {
 	mutex sync.Mutex
 
-	// At present, we maintain two separate pools: one for verbose output, and one for non-verbose output
+	// At present, we maintain two separate pools: one for verbose log output, and one for non-verbose log output
 	// key is 'sharedDBPoolMapKey_*'
 	pools map[string]DatabaseQueries
 }
@@ -270,15 +271,15 @@ func NewSharedProductionPostgresDBQueries(verbose bool) (DatabaseQueries, error)
 	internalSharedDBEntity.mutex.Lock()
 	defer internalSharedDBEntity.mutex.Unlock()
 
+	if internalSharedDBEntity.pools == nil {
+		// Ensure the pools map is intialized
+		internalSharedDBEntity.pools = map[string]DatabaseQueries{}
+	}
+
 	// At present, we maintain two pools: one for verbose output, and one for non-verbose output
 	mapKey := sharedDBPoolMapKey_standard
 	if verbose {
 		mapKey = sharedDBPoolMapKey_verbose
-	}
-
-	if internalSharedDBEntity.pools == nil {
-		// Ensure the pools map is intialized
-		internalSharedDBEntity.pools = map[string]DatabaseQueries{}
 	}
 
 	dbQueries, exists := internalSharedDBEntity.pools[mapKey]

--- a/backend-shared/config/db/queries_test.go
+++ b/backend-shared/config/db/queries_test.go
@@ -1,0 +1,108 @@
+package db
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+)
+
+var _ = Describe("Database Query interface tests", func() {
+
+	Context("Test Shared Connection Pool Logic", func() {
+
+		const sharedConnectionPoolUserName = "test-shared-pool-user-name"
+
+		// cleanupDatabase deletes the test user created to verify the connection
+		cleanupDatabase := func() {
+			var err error
+
+			// Ensure the created ClusterUser is deleted
+			conn, err := NewSharedProductionPostgresDBQueries(false)
+			if err != nil {
+				GinkgoWriter.Println(err)
+				return
+			}
+
+			createdClusterUser := ClusterUser{
+				User_name: sharedConnectionPoolUserName,
+			}
+
+			err = conn.GetClusterUserByUsername(context.Background(), &createdClusterUser)
+			if err != nil && !apierr.IsNotFound(err) {
+				GinkgoWriter.Println(err)
+				return
+			}
+
+			_, err = conn.DeleteClusterUserById(context.Background(), createdClusterUser.Clusteruser_id)
+			if err != nil && !apierr.IsNotFound(err) {
+				GinkgoWriter.Println(err)
+				return
+			}
+		}
+
+		BeforeEach(func() {
+			cleanupDatabase()
+		})
+
+		AfterEach(func() {
+			cleanupDatabase()
+		})
+
+		It("Should maintain only two shared connection pools: verbose and non-verbose", func() {
+
+			By("verifying that verbose and non-verbose parameters return different pools")
+			firstNonVerbose, err := NewSharedProductionPostgresDBQueries(false)
+			Expect(err).To(BeNil())
+			firstVerbose, err := NewSharedProductionPostgresDBQueries(true)
+			Expect(err).To(BeNil())
+			Expect(firstNonVerbose).ToNot(Equal(firstVerbose))
+
+			By("verifying that each subsequent call returns the existing connection object, which confirms the connections are shared in the pool.")
+			for count := 0; count < 10; count++ {
+				nextVerbose, err := NewSharedProductionPostgresDBQueries(true)
+				Expect(err).To(BeNil())
+				nextNonVerbose, err := NewSharedProductionPostgresDBQueries(false)
+				Expect(err).To(BeNil())
+
+				Expect(nextVerbose).To(Equal(firstVerbose))
+				Expect(nextNonVerbose).To(Equal(firstNonVerbose))
+			}
+		})
+
+		verifyValidConnection := func(conn DatabaseQueries) {
+			By("creating and geting a cluster user to verify the database connection works")
+			var err error
+			createdClusterUser := ClusterUser{
+				User_name: sharedConnectionPoolUserName,
+			}
+			err = conn.CreateClusterUser(context.Background(), &createdClusterUser)
+			Expect(err).To(BeNil())
+
+			retrievedClusterUser := ClusterUser{
+				Clusteruser_id: createdClusterUser.Clusteruser_id,
+			}
+			err = conn.GetClusterUserById(context.Background(), &retrievedClusterUser)
+			Expect(err).To(BeNil())
+		}
+
+		It("Should verify the non-verbose shared connection pools can be connected to", func() {
+
+			conn, err := NewSharedProductionPostgresDBQueries(false)
+			Expect(err).To(BeNil())
+
+			verifyValidConnection(conn)
+		})
+
+		It("Should verify the verbose shared connection pools can be connected to", func() {
+
+			conn, err := NewSharedProductionPostgresDBQueries(true)
+			Expect(err).To(BeNil())
+
+			verifyValidConnection(conn)
+		})
+
+	})
+
+})

--- a/backend-shared/config/db/util/application_info_cache.go
+++ b/backend-shared/config/db/util/application_info_cache.go
@@ -190,7 +190,7 @@ func applicationInfoCacheLoop(inputChan chan applicationInfoCacheRequest) {
 	cacheAppState := map[string]applicationStateCacheEntry{}
 	cacheApp := map[string]applicationCacheEntry{}
 
-	dbQueries, err := db.NewProductionPostgresDBQueries(false)
+	dbQueries, err := db.NewSharedProductionPostgresDBQueries(false)
 	if err != nil {
 		log.Error(err, "SEVERE: unexpected error in calling dbQueries")
 		return

--- a/backend/eventloop/application_event_loop/application_event_runner.go
+++ b/backend/eventloop/application_event_loop/application_event_runner.go
@@ -133,7 +133,7 @@ func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent
 
 				var err error
 
-				dbQueriesUnscoped, err := db.NewProductionPostgresDBQueries(false)
+				dbQueriesUnscoped, err := db.NewSharedProductionPostgresDBQueries(false)
 				if err != nil {
 					return fmt.Errorf("unable to access database in workspaceEventLoopRunner: %v", err)
 				}

--- a/backend/eventloop/preprocess_event_loop/preprocess_event_loop.go
+++ b/backend/eventloop/preprocess_event_loop/preprocess_event_loop.go
@@ -71,7 +71,7 @@ func preprocessEventLoopRouter(input chan eventlooptypes.EventLoopEvent, nextSte
 
 	taskRetryLoop := sharedutil.NewTaskRetryLoop("event-loop-router-retry-loop")
 
-	dbQueries, err := db.NewProductionPostgresDBQueries(false)
+	dbQueries, err := db.NewSharedProductionPostgresDBQueries(false)
 	if err != nil {
 		log.Error(err, "SEVERE: preProcessEventLoopRouter exiting before startup")
 		os.Exit(1)

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -247,7 +247,7 @@ func internalSharedResourceEventLoop(inputChan chan sharedResourceLoopMessage) {
 
 	ctx := context.Background()
 	log := log.FromContext(ctx)
-	dbQueries, err := db.NewProductionPostgresDBQueries(false)
+	dbQueries, err := db.NewSharedProductionPostgresDBQueries(false)
 	if err != nil {
 		log.Error(err, "SEVERE: internalSharedResourceEventLoop exiting before startup")
 		return

--- a/backend/eventloop/workspace_resource_event_loop.go
+++ b/backend/eventloop/workspace_resource_event_loop.go
@@ -87,7 +87,7 @@ func internalWorkspaceResourceEventLoop(inputChan chan workspaceResourceLoopMess
 	ctx := context.Background()
 	log := log.FromContext(ctx).WithValues("component", "workspace_resource_event_loop")
 
-	dbQueries, err := db.NewProductionPostgresDBQueries(false)
+	dbQueries, err := db.NewSharedProductionPostgresDBQueries(false)
 	if err != nil {
 		log.Error(err, "SEVERE: internalSharedResourceEventLoop exiting before startup")
 		return

--- a/backend/main.go
+++ b/backend/main.go
@@ -194,7 +194,7 @@ func createPrimaryGitOpsEngineInstance(k8sclient client.Client, log logr.Logger)
 
 	ctx := context.Background()
 
-	dbQueries, err := db.NewProductionPostgresDBQueries(true)
+	dbQueries, err := db.NewSharedProductionPostgresDBQueries(false)
 	if err != nil {
 		return err
 	}

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
@@ -112,7 +112,7 @@ type processOperationEventTask struct {
 // NOTE: 'error' value does not affect whether the task will be retried, this error is only used for
 // error reporting.
 func (task *processOperationEventTask) PerformTask(taskContext context.Context) (bool, error) {
-	dbQueries, err := db.NewProductionPostgresDBQueries(true)
+	dbQueries, err := db.NewSharedProductionPostgresDBQueries(false)
 	if err != nil {
 		return true, fmt.Errorf("unable to instantiate database in operation controller loop: %v", err)
 	}

--- a/cluster-agent/main.go
+++ b/cluster-agent/main.go
@@ -94,7 +94,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	dbQueries, err := db.NewProductionPostgresDBQueries(true)
+	dbQueries, err := db.NewSharedProductionPostgresDBQueries(false)
 	if err != nil {
 		setupLog.Error(err, "never able to connect to database")
 		os.Exit(1)

--- a/manifests/managed-gitops-appstudio-controller-deployment.yaml
+++ b/manifests/managed-gitops-appstudio-controller-deployment.yaml
@@ -22,20 +22,13 @@ spec:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
-        - --v=0
+        - --v=10
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
           name: https
           protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 256Mi
-          requests:
-            cpu: 100m
-            memory: 64Mi
       - args:
         - --health-probe-bind-address=:8085
         - --metrics-bind-address=127.0.0.1:8080
@@ -60,10 +53,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 512Mi
           requests:
-            cpu: 10m
-            memory: 64Mi
+            cpu: 50m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:

--- a/manifests/managed-gitops-backend-deployment.yaml
+++ b/manifests/managed-gitops-backend-deployment.yaml
@@ -65,7 +65,7 @@ spec:
             memory: 512Mi
           requests:
             cpu: 200m
-            memory: 60Mi
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:

--- a/manifests/staging-cluster-resources/argo-cd.yaml
+++ b/manifests/staging-cluster-resources/argo-cd.yaml
@@ -19,7 +19,7 @@ spec:
     resources:
       limits:
         cpu: "1"
-        memory: 1Gi
+        memory: 3Gi
       requests:
         cpu: 250m
         memory: 256Mi

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -68,7 +68,7 @@ var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 			err = k8sClient.List(context.Background(), &secretList, &client.ListOptions{Namespace: dbutil.DefaultGitOpsEngineSingleInstanceNamespace})
 			Expect(err).To(BeNil())
 
-			dbQueries, err := db.NewProductionPostgresDBQueries(false)
+			dbQueries, err := db.NewSharedProductionPostgresDBQueries(false)
 			Expect(err).To(BeNil())
 			defer dbQueries.CloseDatabase()
 


### PR DESCRIPTION
#### Description:
- Fixing some issues seen on the AppStudio staging cluster:
    - A 'too many connections' errors from PostgreSQL: fortunately we can use go-pg in-built connection sharing to solve this
    - Appstudio-controller is OOM-ing, so we can increase the memory limits
    - During stress unit tests, Argo CD is OOMing, so increase the memory limit of that
- Switch to using go-pg's existing connection pooling logic: one connection pool for 'verbose' logging, and one for without verbose logging
- Unit tests for above.
- Increase memory limits of appstudio-controller `Deployment` resource

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-194

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
