### PR TITLE
Move application info cache to cluster-agent, and cleanup code. Update DeleteArgoCDApplication logic to avoid Error log

### DIFF
--- a/backend-shared/config/db/applicationstates.go
+++ b/backend-shared/config/db/applicationstates.go
@@ -6,6 +6,10 @@ import (
 	"fmt"
 )
 
+const (
+	ErrorUnexpectedNumberOfRowsAffected = "unexpected number of rows affected"
+)
+
 func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllApplicationStates(ctx context.Context, applicationStates *[]ApplicationState) error {
 
 	if err := validateUnsafeQueryParamsNoPK(dbq); err != nil {
@@ -61,7 +65,7 @@ func (dbq *PostgreSQLDatabaseQueries) CreateApplicationState(ctx context.Context
 	noOfBytesInObj := binary.Size(obj.Resources)
 	maxSize := DbFieldMap["ApplicationStateResourcesLength"]
 	if noOfBytesInObj > maxSize {
-		return fmt.Errorf("Resources value exceeds maximum size: max: %d, actual: %d", maxSize, noOfBytesInObj)
+		return fmt.Errorf("resources value exceeds maximum size: max: %d, actual: %d", maxSize, noOfBytesInObj)
 	}
 
 	// Inserting ApplicationState object
@@ -100,7 +104,7 @@ func (dbq *PostgreSQLDatabaseQueries) UpdateApplicationState(ctx context.Context
 	noOfBytesInObj := binary.Size(obj.Resources)
 	maxSize := DbFieldMap["ApplicationStateResourcesLength"]
 	if noOfBytesInObj > maxSize {
-		return fmt.Errorf("Resources value exceeds maximum size: max: %d, actual: %d", maxSize, noOfBytesInObj)
+		return fmt.Errorf("resources value exceeds maximum size: max: %d, actual: %d", maxSize, noOfBytesInObj)
 	}
 
 	result, err := dbq.dbConnection.Model(obj).Context(ctx).
@@ -110,7 +114,7 @@ func (dbq *PostgreSQLDatabaseQueries) UpdateApplicationState(ctx context.Context
 	}
 
 	if result.RowsAffected() != 1 {
-		return fmt.Errorf("unexpected number of rows affected: %d", result.RowsAffected())
+		return fmt.Errorf("%s: %d", ErrorUnexpectedNumberOfRowsAffected, result.RowsAffected())
 	}
 
 	return nil

--- a/backend-shared/config/db/clusteruser.go
+++ b/backend-shared/config/db/clusteruser.go
@@ -168,7 +168,7 @@ func (dbq *PostgreSQLDatabaseQueries) GetOrCreateSpecialClusterUser(ctx context.
 	}
 
 	if len(dbResults) >= 2 {
-		return fmt.Errorf("Multiple users are found is GetOrCreateSpecialClusterUser.")
+		return fmt.Errorf("multiple users are found is GetOrCreateSpecialClusterUser")
 	}
 
 	// If user already exists then return it, else create new.

--- a/cluster-agent/controllers/argoproj.io/application_controller_test.go
+++ b/cluster-agent/controllers/argoproj.io/application_controller_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/operations"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/tests"
 	"github.com/redhat-appstudio/managed-gitops/cluster-agent/controllers"
+	"github.com/redhat-appstudio/managed-gitops/cluster-agent/controllers/argoproj.io/application_info_cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -18,7 +19,6 @@ import (
 
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
-	dbutil "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db/util"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -104,11 +104,11 @@ var _ = Describe("Application Controller", func() {
 			}
 
 			reconciler = ApplicationReconciler{
-				Client:        k8sClient,
-				Scheme:        scheme,
-				DB:            dbQueries,
-				TaskRetryLoop: sharedutil.NewTaskRetryLoop("application-reconciler"),
-				Cache:         dbutil.NewApplicationInfoCache(),
+				Client:                k8sClient,
+				Scheme:                scheme,
+				DB:                    dbQueries,
+				DeletionTaskRetryLoop: sharedutil.NewTaskRetryLoop("application-reconciler"),
+				Cache:                 application_info_cache.NewApplicationInfoCache(),
 			}
 		})
 
@@ -516,7 +516,7 @@ var _ = Describe("Namespace Reconciler Tests.", func() {
 			reconciler = ApplicationReconciler{
 				Client: k8sClient,
 				DB:     dbQueries,
-				Cache:  dbutil.NewApplicationInfoCache(),
+				Cache:  application_info_cache.NewApplicationInfoCache(),
 			}
 
 			err = reconciler.Create(ctx, &argoCdApp)

--- a/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache.go
+++ b/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache.go
@@ -21,7 +21,7 @@ import (
 //
 // The cache:
 // - will always return the most recent ApplicationState value from the database
-// - in constrast, the cache will return a value for Application that is at most 60 seconds old
+// - in contrast, the cache will return a value for an Application that is at most 60 seconds old
 //   (the Application in the cache state will be eventually consistent with the database)
 //     - since it is eventually consistent, the calling code needs to be aware of this in its logic.
 

--- a/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache.go
+++ b/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache.go
@@ -1,4 +1,4 @@
-package util
+package application_info_cache
 
 import (
 	"context"
@@ -10,6 +10,20 @@ import (
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+// The cache exists because we do want to overwhelm the controller (or the database) with various operations frequently: most
+// of the time these reconciliations are changes that might not be useful for us.
+//
+// To avoid unnecessary read/write to the database, the cache is being implemented in backend-shared which will be used
+// by cluster-agent's Application contrller reconciliation.
+//
+// The cache should only be used by 'application_controller.go'.
+//
+// The cache:
+// - will always return the most recent ApplicationState value from the database
+// - in constrast, the cache will return a value for Application that is at most 60 seconds old
+//   (the Application in the cache state will be eventually consistent with the database)
+//     - since it is eventually consistent, the calling code needs to be aware of this in its logic.
 
 // A wrapper over the ApplicationStateCache entries of the database
 // Note: This should only be used by cluster-agent's application controller.

--- a/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache.go
+++ b/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// The cache exists because we do want to overwhelm the controller (or the database) with various operations frequently: most
+// The cache exists because we do not want to overwhelm the controller (or the database) with various operations frequently: most
 // of the time these reconciliations are changes that might not be useful for us.
 //
 // To avoid unnecessary read/write to the database, the cache is being implemented in backend-shared which will be used

--- a/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache_test.go
+++ b/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache_test.go
@@ -1,4 +1,4 @@
-package util_test
+package application_info_cache
 
 import (
 	"context"
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	db "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
-	util "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db/util"
 )
 
 var _ = Describe("application_info_cache Test", func() {
@@ -18,7 +17,7 @@ var _ = Describe("application_info_cache Test", func() {
 			Expect(err).To(BeNil())
 
 			ctx := context.Background()
-			asc := util.NewApplicationInfoCache()
+			asc := NewApplicationInfoCache()
 			defer asc.DebugOnly_Shutdown(ctx)
 
 			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
@@ -87,7 +86,7 @@ var _ = Describe("application_info_cache Test", func() {
 			Expect(err).To(BeNil())
 
 			ctx := context.Background()
-			asc := util.NewApplicationInfoCache()
+			asc := NewApplicationInfoCache()
 			defer asc.DebugOnly_Shutdown(ctx)
 
 			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
@@ -152,7 +151,7 @@ var _ = Describe("application_info_cache Test", func() {
 			Expect(err).To(BeNil())
 
 			ctx := context.Background()
-			asc := util.NewApplicationInfoCache()
+			asc := NewApplicationInfoCache()
 			defer asc.DebugOnly_Shutdown(ctx)
 
 			dbq, err := db.NewUnsafePostgresDBQueries(true, true)

--- a/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache_test.go
+++ b/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache_test.go
@@ -17,8 +17,8 @@ var _ = Describe("application_info_cache Test", func() {
 			Expect(err).To(BeNil())
 
 			ctx := context.Background()
-			asc := NewApplicationInfoCache()
-			defer asc.DebugOnly_Shutdown(ctx)
+			aic := NewApplicationInfoCache()
+			defer aic.DebugOnly_Shutdown(ctx)
 
 			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
 
@@ -45,7 +45,7 @@ var _ = Describe("application_info_cache Test", func() {
 				Health:                          "Healthy",
 				Sync_Status:                     "Synced",
 			}
-			errCreate := asc.CreateApplicationState(ctx, testAppState)
+			errCreate := aic.CreateApplicationState(ctx, testAppState)
 			Expect(errCreate).To(BeNil())
 
 			dbAppStateObj := db.ApplicationState{
@@ -55,15 +55,15 @@ var _ = Describe("application_info_cache Test", func() {
 			Expect(errGet).To(BeNil())
 			Expect(testAppState).To(Equal(dbAppStateObj))
 
-			_, fromCache, err := asc.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
+			_, fromCache, err := aic.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
 			Expect(err).To(BeNil())
 			Expect(fromCache).To(BeTrue())
 
 			testAppState.Health = "Unhealthy"
-			errUpdate := asc.UpdateApplicationState(ctx, testAppState)
+			errUpdate := aic.UpdateApplicationState(ctx, testAppState)
 			Expect(errUpdate).To(BeNil())
 
-			appState, isFromCache, errGet := asc.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
+			appState, isFromCache, errGet := aic.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
 			Expect(errGet).To(BeNil())
 			Expect(isFromCache).To(BeTrue())
 			Expect(testAppState).To(Equal(appState))
@@ -72,7 +72,7 @@ var _ = Describe("application_info_cache Test", func() {
 				Applicationstate_application_id: testAppState.Applicationstate_application_id,
 			}
 
-			rowsAffected, errDelete := asc.DeleteApplicationStateById(ctx, testDeleteAppState.Applicationstate_application_id)
+			rowsAffected, errDelete := aic.DeleteApplicationStateById(ctx, testDeleteAppState.Applicationstate_application_id)
 			Expect(errDelete).To(BeNil())
 			Expect(rowsAffected).Should(Equal(1))
 
@@ -86,8 +86,8 @@ var _ = Describe("application_info_cache Test", func() {
 			Expect(err).To(BeNil())
 
 			ctx := context.Background()
-			asc := NewApplicationInfoCache()
-			defer asc.DebugOnly_Shutdown(ctx)
+			aic := NewApplicationInfoCache()
+			defer aic.DebugOnly_Shutdown(ctx)
 
 			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
 
@@ -98,7 +98,7 @@ var _ = Describe("application_info_cache Test", func() {
 			testId := "test-get-appState"
 
 			//testId doesn't exist, the test should report an error
-			appState, isFromCache, errGet := asc.GetApplicationStateById(ctx, testId)
+			appState, isFromCache, errGet := aic.GetApplicationStateById(ctx, testId)
 			Expect(errGet).ToNot(BeNil())
 			// since no entry in the valuefromcache should be false, appState should be empty
 			Expect(isFromCache).To(BeFalse())
@@ -128,7 +128,7 @@ var _ = Describe("application_info_cache Test", func() {
 			err = dbq.CreateApplicationState(ctx, &testAppState)
 			Expect(err).To(BeNil())
 
-			getAppState, isFromCache, errGet := asc.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
+			getAppState, isFromCache, errGet := aic.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
 			// ideally the appState should now report an ApplicationState obj
 			// isFromCache should be false since initially the value will be coming from db
 			Expect(errGet).To(BeNil())
@@ -136,7 +136,7 @@ var _ = Describe("application_info_cache Test", func() {
 			Expect(testAppState).To(Equal(getAppState))
 
 			//calling the same GetApplicationStateById again should come from cache, hence isFromCache should be True
-			_, isFromCache, errGet = asc.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
+			_, isFromCache, errGet = aic.GetApplicationStateById(ctx, testAppState.Applicationstate_application_id)
 			Expect(errGet).To(BeNil())
 			Expect(isFromCache).To(BeTrue())
 
@@ -151,8 +151,8 @@ var _ = Describe("application_info_cache Test", func() {
 			Expect(err).To(BeNil())
 
 			ctx := context.Background()
-			asc := NewApplicationInfoCache()
-			defer asc.DebugOnly_Shutdown(ctx)
+			aic := NewApplicationInfoCache()
+			defer aic.DebugOnly_Shutdown(ctx)
 
 			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
 
@@ -163,7 +163,7 @@ var _ = Describe("application_info_cache Test", func() {
 			testId := "test-get-appState"
 
 			//testId doesn't exist, the test should report an error
-			app, valuefromCache, errGet := asc.GetApplicationById(ctx, testId)
+			app, valuefromCache, errGet := aic.GetApplicationById(ctx, testId)
 			Expect(errGet).ToNot(BeNil())
 			// since no entry in the valuefromcache should be false, appState should be empty
 			Expect(valuefromCache).To(BeFalse())
@@ -183,14 +183,14 @@ var _ = Describe("application_info_cache Test", func() {
 			err = dbq.CreateApplication(ctx, &testapplication)
 			Expect(err).To(BeNil())
 
-			getApp, isFromCache, errGet := asc.GetApplicationById(ctx, testapplication.Application_id)
+			getApp, isFromCache, errGet := aic.GetApplicationById(ctx, testapplication.Application_id)
 			// ideally the appState should now report an Application obj
 			Expect(errGet).To(BeNil())
 			Expect(isFromCache).To(BeFalse())
 			Expect(getApp).To(Equal(testapplication))
 
 			//calling the same GetApplicationById again should come from cache, hence ifFromCache should be True
-			_, isFromCache, errGet = asc.GetApplicationById(ctx, testapplication.Application_id)
+			_, isFromCache, errGet = aic.GetApplicationById(ctx, testapplication.Application_id)
 			Expect(errGet).To(BeNil())
 			Expect(isFromCache).To(BeTrue())
 

--- a/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache_types.go
+++ b/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache_types.go
@@ -1,4 +1,4 @@
-package util
+package application_info_cache
 
 import (
 	"context"

--- a/cluster-agent/controllers/argoproj.io/namespace_reconciler_test.go
+++ b/cluster-agent/controllers/argoproj.io/namespace_reconciler_test.go
@@ -11,6 +11,7 @@ import (
 	dbutil "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db/util"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/operations"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/tests"
+	"github.com/redhat-appstudio/managed-gitops/cluster-agent/controllers/argoproj.io/application_info_cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -199,7 +200,7 @@ var _ = Describe("Namespace Reconciler Tests.", func() {
 			reconciler = ApplicationReconciler{
 				Client: k8sClient,
 				DB:     dbQueries,
-				Cache:  dbutil.NewApplicationInfoCache(),
+				Cache:  application_info_cache.NewApplicationInfoCache(),
 			}
 
 			err = reconciler.Create(ctx, &argoCdApp)

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
@@ -424,7 +424,7 @@ func processOperation_Application(ctx context.Context, dbOperation db.Operation,
 
 				log := log.WithValues("argoCDApplicationName", item.Name, "argoCDApplicationNmespace", item.Namespace)
 
-				log.Info("Deleting Argo CD Application that is missing a DB Entry")
+				log.Info("Deleting Argo CD Application that is no longer (or not) defined in the Application table.")
 
 				// Delete all Argo CD applications with the corresponding database label (but, there should be only one)
 				err := controllers.DeleteArgoCDApplication(ctx, item, eventClient, log)

--- a/cluster-agent/main.go
+++ b/cluster-agent/main.go
@@ -26,7 +26,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
-	dbutil "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db/util"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -38,6 +37,7 @@ import (
 	appv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	argoprojiocontrollers "github.com/redhat-appstudio/managed-gitops/cluster-agent/controllers/argoproj.io"
+	"github.com/redhat-appstudio/managed-gitops/cluster-agent/controllers/argoproj.io/application_info_cache"
 	controllers "github.com/redhat-appstudio/managed-gitops/cluster-agent/controllers/managed-gitops"
 	"github.com/redhat-appstudio/managed-gitops/cluster-agent/controllers/managed-gitops/eventloop"
 	//+kubebuilder:scaffold:imports
@@ -113,11 +113,11 @@ func main() {
 	operationsGC.StartGarbageCollector()
 
 	if err = (&argoprojiocontrollers.ApplicationReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		DB:            dbQueries,
-		TaskRetryLoop: sharedutil.NewTaskRetryLoop("application-reconciler"),
-		Cache:         dbutil.NewApplicationInfoCache(),
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		DB:                    dbQueries,
+		DeletionTaskRetryLoop: sharedutil.NewTaskRetryLoop("application-reconciler"),
+		Cache:                 application_info_cache.NewApplicationInfoCache(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Application")
 		os.Exit(1)


### PR DESCRIPTION
#### Description:
- Update Argo CD Application resource deletion logic to wait 2 minutes from the _current time_ for the application to delete, rather than from the deletion timestamp.
- Move application info cache to cluster-agent, and cleanup code
- Update DeleteArgoCDApplication logic to avoid Warning log

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-67

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
