### PR TITLE
Add local ckcp script for testing gitops service on kcp (Solves: #Gitopsrvc-158)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,3 +280,5 @@ gen-kcp-api-backend-shared: ## Runs utilities/generate-kcp-api-backend-shared.sh
 gen-kcp-api-appstudio-shared: ## Runs utilities/generate-kcp-api-appstudio-shared.sh to generate kcp api resource schema and export
 	cd $(MAKEFILE_ROOT)/utilities && ./generate-kcp-api-appstudio-shared.sh
 
+kcp-test-local-e2e: ## Initiates a ckcp within openshift cluster and runs e2e test
+	cd $(MAKEFILE_ROOT)/kcp/ckcp && ./setup-ckcp-on-openshift.sh

--- a/Makefile
+++ b/Makefile
@@ -281,4 +281,4 @@ gen-kcp-api-appstudio-shared: ## Runs utilities/generate-kcp-api-appstudio-share
 	cd $(MAKEFILE_ROOT)/utilities && ./generate-kcp-api-appstudio-shared.sh
 
 kcp-test-local-e2e: ## Initiates a ckcp within openshift cluster and runs e2e test
-	cd $(MAKEFILE_ROOT)/kcp/ckcp && ./setup-ckcp-on-openshift.sh
+	cd $(MAKEFILE_ROOT)/kcp && ./ckcp/setup-ckcp-on-openshift.sh

--- a/kcp/ckcp/openshift_dev_setup.sh
+++ b/kcp/ckcp/openshift_dev_setup.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+
+#quit if exit status of any cmd is a non-zero value
+set -euo pipefail
+
+SCRIPT_DIR="$(
+  cd "$(dirname "$0")" >/dev/null
+  pwd
+)"
+
+GITOPS_DIR="$(dirname "$SCRIPT_DIR")/gitops"
+CKCP_DIR="$(dirname "$SCRIPT_DIR")/ckcp"
+KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config}
+CR_TO_SYNC=(
+            deployments.apps
+            services
+            ingresses.networking.k8s.io
+            networkpolicies.networking.k8s.io
+            statefulsets.apps
+            routes.route.openshift.io
+          )
+
+usage() {
+  TMPDIR=$(dirname "$(mktemp -u)")
+  echo "
+Usage:
+    ${0##*/} [options]
+
+Setup GitOps Service on a cluster running on KCP.
+
+Optional arguments:
+    -w, --work-dir
+        Directory in which to create the gitops file structure.
+        If the directory already exists, all content will be removed.
+        By default a temporary directory will be created in $TMPDIR.
+    -d, --debug
+        Activate tracing/debug mode.
+    -h, --help
+        Display this message.
+
+Example:
+    ${0##*/}
+" >&2
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+    -w | --work-dir)
+      shift
+      WORK_DIR="$1"
+      mkdir -p "$WORK_DIR"
+      WORK_DIR="$(cd "$1" >/dev/null; pwd)"
+      ;;
+    -d | --debug)
+      set -x
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      # End of arguments
+      break
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      usage
+      exit 1
+      ;;
+    esac
+    shift
+  done
+}
+
+init() {
+  APP_LIST="openshift-gitops compute ckcp register-compute"
+  cluster_type="openshift"
+
+  # Create SRE repository folder
+  WORK_DIR="${WORK_DIR:-}"
+  if [[ -z "$WORK_DIR" ]]; then
+    WORK_DIR=$(mktemp -d)
+    echo "Working directory: $WORK_DIR"
+  fi
+  if [[ -d "$WORK_DIR" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+  cp -rf "$GITOPS_DIR/sre" "$WORK_DIR"
+  for dir in kcp compute; do
+    mkdir -p "$WORK_DIR/credentials/kubeconfig/$dir"
+  done
+  cp "$KUBECONFIG" "$WORK_DIR/credentials/kubeconfig/compute/compute.kubeconfig.base"
+
+  KUBECONFIG_KCP="$WORK_DIR/credentials/kubeconfig/kcp/admin.kubeconfig.base"
+  KUBECONFIG="$WORK_DIR/credentials/kubeconfig/compute/compute.kubeconfig.base"
+  KUBECONFIG_MERGED="merged-config.kubeconfig:$KUBECONFIG:$KUBECONFIG_KCP"
+  export KUBECONFIG
+  kcp_org="root:default"
+  kcp_workspace="managed-gitops-compute"
+  kcp_version="$(yq '.images[] | select(.name == "kcp") | .newTag' "$SCRIPT_DIR/openshift/overlays/dev/kustomization.yaml")"
+}
+
+# To ensure that dependencies are satisfied
+precheck() {
+  if [ "$(kubectl plugin list | grep -c 'kubectl-kcp')" -eq 0 ]; then
+    printf "kcp plugin could not be found\n"
+    exit 1
+  fi
+}
+
+check_cluster_role() {
+  if [ "$(kubectl auth can-i '*' '*' --all-namespaces)" != "yes" ]; then
+    echo
+    echo "[ERROR] User '$(oc whoami)' does not have the required 'cluster-admin' role." 1>&2
+    echo "Log into the cluster with a user with the required privileges (e.g. kubeadmin) and retry."
+    exit 1
+  fi
+}
+
+install_openshift_gitops() {
+  APP="openshift-gitops"
+
+  local ns="$APP"
+
+  #############################################################################
+  # Install the gitops operator
+  #############################################################################
+  echo -n "  - OpenShift-GitOps: "
+  kubectl apply -k "$CKCP_DIR/openshift-operators/$APP" >/dev/null 2>&1
+  echo "OK"
+
+  #############################################################################
+  # Wait for the URL to be available
+  #############################################################################
+  echo -n "  - ArgoCD dashboard: "
+  test_cmd="kubectl get route/openshift-gitops-server --ignore-not-found -n $ns -o jsonpath={.spec.host}"
+  ARGOCD_HOSTNAME="$(${test_cmd})"
+  until curl --fail --insecure --output /dev/null --silent "https://$ARGOCD_HOSTNAME"; do
+    echo -n "."
+    sleep 2
+    ARGOCD_HOSTNAME="$(${test_cmd})"
+  done
+  echo "OK"
+  echo "  - ArgoCD URL: https://$ARGOCD_HOSTNAME"
+
+  #############################################################################
+  # Post install
+  #############################################################################
+  # Log into ArgoCD
+  echo -n "  - ArgoCD Login: "
+  local argocd_password
+  argocd_password="$(kubectl get secret openshift-gitops-cluster -n $ns -o jsonpath="{.data.admin\.password}" | base64 --decode)"
+  argocd login "$ARGOCD_HOSTNAME" --grpc-web --insecure --username admin --password "$argocd_password" >/dev/null 2>&1
+  echo "OK"
+
+  # Register the host cluster as pipeline-cluster
+  local cluster_name="plnsvc"
+  echo -n "  - Register host cluster to ArgoCD as '$cluster_name': "
+  if ! KUBECONFIG="$KUBECONFIG_MERGED" argocd cluster get "$cluster_name" >/dev/null 2>&1; then
+    argocd cluster add "$(yq e ".current-context" <"$KUBECONFIG")" --name="$cluster_name" --upsert --yes >/dev/null 2>&1
+  fi
+  echo "OK"
+}
+
+check_cert_manager() {
+  # perform a dry-run create of a cert-manager
+  # Certificate resource in order to verify that CRDs are installed and all the
+  # required webhooks are reachable by the K8S API server.
+  echo -n "  - openshift-cert-manager-operator: "
+  until kubectl create -f "$CKCP_DIR/openshift/base/certs.yaml" --dry-run=client >/dev/null 2>&1; do
+    echo -n "."
+    sleep 5
+  done
+  echo "OK"
+}
+
+install_ckcp() {
+  # Install cert manager operator
+  check_cert_manager
+
+  APP="ckcp"
+
+  local ns="$APP"
+
+  # #############################################################################
+  # # Deploy KCP
+  # #############################################################################
+  local ckcp_manifest_dir=$CKCP_DIR/$cluster_type
+  local ckcp_dev_dir=$ckcp_manifest_dir/overlays/dev
+  local ckcp_temp_dir=$ckcp_manifest_dir/overlays/temp
+
+  # To ensure kustomization.yaml file under overlays/temp won't be changed, remove the directory overlays/temp if it exists
+  if [ -d "$ckcp_temp_dir" ]; then
+    rm -rf "$ckcp_temp_dir"
+  fi
+  cp -rf "$ckcp_dev_dir" "$ckcp_temp_dir"
+
+  local ckcp_route
+  domain_name="$(kubectl get ingresses.config/cluster -o jsonpath='{.spec.domain}')"
+  ckcp_route="ckcp-ckcp.$domain_name"
+  echo "
+patches:
+  - target:
+      kind: Ingress
+      name: ckcp
+    patch: |-
+      - op: add
+        path: /spec/rules/0/host
+        description: An ingress host needs to be defined which has the routing suffix of your cluster.
+        value: $ckcp_route
+  - target:
+      kind: Deployment
+      name: ckcp
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/env/0/value
+        description: This value refers to the hostAddress defined in the Route.
+        value: $ckcp_route
+  - target:
+      kind: Certificate
+      name: kcp
+    patch: |-
+      - op: add
+        path: /spec/dnsNames/-
+        description: This value refers to the hostAddress defined in the Route.
+        value: $ckcp_route " >>"$ckcp_temp_dir/kustomization.yaml"
+
+  echo -n "  - kcp $kcp_version: "
+  kubectl apply -k "$ckcp_temp_dir" >/dev/null 2>&1
+  # Check if ckcp pod status is Ready
+  kubectl wait --for=condition=Ready -n $ns pod -l=app=kcp-in-a-pod --timeout=90s >/dev/null 2>&1
+  # Clean up kustomize temp dir
+  rm -rf "$ckcp_temp_dir"
+
+  #############################################################################
+  # Post install
+  #############################################################################
+  # Copy the kubeconfig of kcp from inside the pod onto the local filesystem
+  podname="$(kubectl get pods --ignore-not-found -n "$ns" -l=app=kcp-in-a-pod -o jsonpath='{.items[0].metadata.name}')"
+  mkdir -p "$(dirname "$KUBECONFIG_KCP")"
+  # Wait until admin.kubeconfig file is generated inside ckcp pod
+  while [[ $(kubectl exec -n $ns "$podname" -- ls /etc/kcp/config/admin.kubeconfig >/dev/null 2>&1; echo $?) -ne 0 ]]; do
+    echo -n "."
+    sleep 5
+  done
+  kubectl cp "$ns/$podname:/etc/kcp/config/admin.kubeconfig" "$KUBECONFIG_KCP" >/dev/null 2>&1
+  echo "OK"
+
+  # Check if external ip is assigned and replace kcp's external IP in the kubeconfig file
+  echo -n "  - Route: "
+  if grep -q "ckcp-ckcp.apps.domain.org" "$KUBECONFIG_KCP"; then
+    yq e -i "(.clusters[].cluster.server) |= sub(\"ckcp-ckcp.apps.domain.org:6443\", \"$ckcp_route:443\")" "$KUBECONFIG_KCP"
+  fi
+  echo "OK"
+
+  # Workaround to prevent the creation of a new workspace until KCP is ready.
+  # This fixes `error: creating a workspace under a Universal type workspace is not supported`.
+  ws_name=$(echo "$kcp_org" | cut -d: -f2)
+  while ! KUBECONFIG="$KUBECONFIG_KCP" kubectl kcp workspace create "$ws_name" --type root:organization --ignore-existing >/dev/null; do
+    sleep 5
+  done
+  KUBECONFIG="$KUBECONFIG_KCP" kubectl kcp workspace use "$ws_name"
+
+  echo "  - Setup kcp access:"
+  "$SCRIPT_DIR/../images/access-setup/content/bin/setup_kcp.sh" \
+    --kubeconfig "$KUBECONFIG_KCP" \
+    --kcp-org "$kcp_org" \
+    --kcp-workspace "$kcp_workspace" \
+    --work-dir "$WORK_DIR"
+  KUBECONFIG_KCP="$WORK_DIR/credentials/kubeconfig/kcp/ckcp-ckcp.${ws_name}.${kcp_workspace}.kubeconfig"
+  cp $WORK_DIR/credentials/kubeconfig/kcp/ckcp-ckcp.${ws_name}.${kcp_workspace}.kubeconfig ${TMP_DIR}
+}
+
+install_compute() {
+  echo "  - Setup compute access:"
+  "$SCRIPT_DIR/../images/access-setup/content/bin/setup_compute.sh" \
+    --kubeconfig "$KUBECONFIG" \
+    --work-dir "$WORK_DIR"
+
+  echo "  - Deploy compute:"
+  "$SCRIPT_DIR/../images/cluster-setup/install.sh" --workspace-dir "$WORK_DIR"
+
+  echo "  - Install Pipelines as Code:"
+  # Passing dummy values to the parameters of the pac/setup.sh script
+  # because we only want to install the runner side of resources.
+  GITOPS_REPO="https://example.git.com/my/repo" GIT_TOKEN="placeholder_token" \
+    WEBHOOK_SECRET="placeholder_webhook" \
+    "$GITOPS_DIR/pac/setup.sh"
+
+}
+
+install_register_compute() {
+  echo "  - Register compute to KCP"
+  "$(dirname "$SCRIPT_DIR")/images/kcp-registrar/register.sh" \
+    --kcp-org "root:default" \
+    --kcp-workspace "$kcp_workspace" \
+    --kcp-sync-tag "$kcp_version" \
+    --workspace-dir "$WORK_DIR"
+
+  check_cr_sync
+}
+
+check_cr_sync() {
+  # Wait until CRDs are synced to KCP
+  echo -n "  - Sync CRDs to KCP: "
+  local cr_regexp
+  cr_regexp="$(
+    IFS=\|
+    echo "${CR_TO_SYNC[*]}"
+  )"
+  local wait_period=0
+  while [[ "$(KUBECONFIG="$KUBECONFIG_KCP" kubectl api-resources -o name 2>&1 | grep -Ewc "$cr_regexp")" -ne ${#CR_TO_SYNC[@]} ]]; do
+    wait_period=$((wait_period + 10))
+    #when timeout, print out the CR resoures that is not synced to KCP
+    if [ $wait_period -gt 300 ]; then
+      echo "Failed to sync following resources to KCP: "
+      cr_synced=$(KUBECONFIG="$KUBECONFIG_KCP" kubectl api-resources -o name)
+      for cr in "${CR_TO_SYNC[@]}"; do
+        if [ "$(echo "$cr_synced" | grep -wc "$cr")" -eq 0 ]; then
+          echo "    * $cr"
+        fi
+      done
+      exit 1
+    fi
+    echo -n "."
+    sleep 10
+  done
+  echo "OK"
+}
+
+main() {
+  parse_args "$@"
+  init
+  precheck
+  check_cluster_role
+  for APP in $APP_LIST; do
+    echo "[$APP]"
+    install_"$(echo "$APP" | tr '-' '_')"
+    echo
+  done
+}
+
+if [ "${BASH_SOURCE[0]}" == "$0" ]; then
+  main "$@"
+fi

--- a/kcp/ckcp/setup-ckcp-on-openshift.sh
+++ b/kcp/ckcp/setup-ckcp-on-openshift.sh
@@ -8,6 +8,8 @@ SCRIPT_DIR="$(
   pwd
 )"
 
+export GITOPS_IN_KCP="true"
+
 ARGOCD_MANIFEST="https://gist.githubusercontent.com/chetan-rns/91d0b56af152f3ebb7c10df8e82b459d/raw/99429ff5ac68cb78a4fc70f1ac2d673ad7ba192a/install-argocd.yaml"
 ARGOCD_NAMESPACE="gitops-service-argocd"
 
@@ -54,7 +56,7 @@ clone-and-setup-ckcp() {
     pushd "${TMP_DIR}"
     git clone https://github.com/openshift-pipelines/pipeline-service.git
     pushd pipeline-service
-    cp ${SCRIPT_DIR}/kcp/ckcp/openshift_dev_setup.sh ./ckcp/openshift_dev_setup.sh
+    cp ${SCRIPT_DIR}/openshift_dev_setup.sh ./ckcp/openshift_dev_setup.sh
 
     sed -i 's/\--resources deployments.apps,services,ingresses.networking.k8s.io,pipelines.tekton.dev,pipelineruns.tekton.dev,tasks.tekton.dev,runs.tekton.dev,networkpolicies.networking.k8s.io/\--resources deployments.apps,services,ingresses.networking.k8s.io,networkpolicies.networking.k8s.io,statefulsets.apps,routes.route.openshift.io/' ./images/kcp-registrar/register.sh
     printf "\nUpdated the resources to sync as needed for gitops-service and ckcp to run...\n\n"
@@ -170,14 +172,14 @@ test-gitops-service-e2e-in-kcp() {
   
   export KUBECONFIG=${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig
   printf "The Kubeconfig being used for this is:" $KUBECONFIG
+  cd ${SCRIPT_DIR}/../../
   ./delete-dev-env.sh
   make devenv-docker
   make start-e2e &
   make test-e2e
 }
 
-kubectl port-forward --namespace gitops svc/gitops-postgresql-staging 5432:5432 &
-test-gitops-service-e2e-in-kcp ${TMP_DIR}
+test-gitops-service-e2e-in-kcp ${TMP_DIR} ${SCRIPT_DIR}
 
 cleanup() {
   pkill go

--- a/kcp/ckcp/setup-ckcp-on-openshift.sh
+++ b/kcp/ckcp/setup-ckcp-on-openshift.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+SCRIPT_DIR="$(
+  cd "$(dirname "$0")" >/dev/null
+  pwd
+)"
+
+ARGOCD_MANIFEST="https://gist.githubusercontent.com/chetan-rns/91d0b56af152f3ebb7c10df8e82b459d/raw/99429ff5ac68cb78a4fc70f1ac2d673ad7ba192a/install-argocd.yaml"
+ARGOCD_NAMESPACE="gitops-service-argocd"
+
+
+# Checks if a binary is present on the local system
+exit_if_binary_not_installed() {
+  for binary in "$@"; do
+    command -v "$binary" >/dev/null 2>&1 || {
+      echo >&2 "Script requires '$binary' command-line utility to be installed on your local machine. Aborting..."
+      exit 1
+    }
+  done
+}
+
+# Checks if the version is compatible by checking greater than or equal to in the passed arguments
+version_compatibility() { 
+    test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" != "$1";
+}
+
+
+# Checks if the go binary exists, and if the go version is suitable to setup KCP env
+check_if_go_v_compatibility() {
+    exit_if_binary_not_installed "go"
+    compatible_v="1.18.0"
+    go_version="$(go version | cut -d " " -f3 | cut -d "o" -f2)"
+    echo "For the KCP local build and setup we need go version equal or greater than: $compatible_v."
+    if version_compatibility $go_version $compatible_v; then
+        echo "$go_version >= $compatible_v, compatibility check success ..."
+    else
+        echo "$go_version is lesser than $compatible_v, exiting ..."
+        exit 1
+    fi
+}
+
+check_if_go_v_compatibility
+
+TMP_DIR="$(mktemp -d -t kcp-gitops-service.XXXXXXXXX)"
+printf "Temporary directory created: %s\n" "${TMP_DIR}"
+export TMP_DIR=${TMP_DIR}
+
+clone-and-setup-ckcp() {
+    echo $SCRIPT_DIR
+    exit_if_binary_not_installed "git"
+    pushd "${TMP_DIR}"
+    git clone https://github.com/openshift-pipelines/pipeline-service.git
+    pushd pipeline-service
+    cp ${SCRIPT_DIR}/kcp/ckcp/openshift_dev_setup.sh ./ckcp/openshift_dev_setup.sh
+
+    sed -i 's/\--resources deployments.apps,services,ingresses.networking.k8s.io,pipelines.tekton.dev,pipelineruns.tekton.dev,tasks.tekton.dev,runs.tekton.dev,networkpolicies.networking.k8s.io/\--resources deployments.apps,services,ingresses.networking.k8s.io,networkpolicies.networking.k8s.io,statefulsets.apps,routes.route.openshift.io/' ./images/kcp-registrar/register.sh
+    printf "\nUpdated the resources to sync as needed for gitops-service and ckcp to run...\n\n"
+    
+    printf "Setting up ckcp in the cluster"
+    ./ckcp/openshift_dev_setup.sh
+    popd
+    popd
+
+    printf "\nThe pipeline-service repo consisting of ckcp is cloned and setup, ckcp is ready for use...\n\n"
+}
+
+clone-and-setup-ckcp $TMP_DIR
+# delete openshift-gitops ns to clear out the resources
+kubectl delete ns openshift-gitops
+
+WORKSPACE="gitops-service-compute"
+
+create_kubeconfig_secret() {
+    sa_name=$1
+    sa_secret_name=$(KUBECONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig" kubectl get sa $sa_name -n $ARGOCD_NAMESPACE -o=jsonpath='{.secrets[0].name}')
+
+    ca=$(KUBECONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig" kubectl get secret/$sa_secret_name -n $ARGOCD_NAMESPACE -o jsonpath='{.data.ca\.crt}')
+    token=$(KUBECONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig" kubectl get secret/$sa_secret_name -n $ARGOCD_NAMESPACE -o jsonpath='{.data.token}' | base64 --decode)
+    namespace=$(KUBECONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig" kubectl get secret/$sa_secret_name -n $ARGOCD_NAMESPACE -o jsonpath='{.data.namespace}' | base64 --decode)
+
+    server=$(KUBECONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig" kubectl config view -o jsonpath='{.clusters[?(@.name == "workspace.kcp.dev/current")].cluster.server}')
+
+    secret_name=$2
+    kubeconfig_secret="
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: ${secret_name}
+  namespace: ${ARGOCD_NAMESPACE}
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - name: default-cluster
+      cluster:
+        certificate-authority-data: ${ca}
+        server: ${server}
+    contexts:
+    - name: default-context
+      context:
+        cluster: default-cluster
+        namespace: ${ARGOCD_NAMESPACE}
+        user: default-user
+    current-context: default-context
+    users:
+    - name: default-user
+      user:
+        token: ${token}
+"
+
+    echo "${kubeconfig_secret}" | KUBECONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig" kubectl apply -f -
+}
+
+echo "Installing Argo CD resources in workspace $WORKSPACE and namespace $ARGOCD_NAMESPACE"
+KUBECONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig" kubectl create ns $ARGOCD_NAMESPACE || true
+
+KUBECONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig" kubectl apply -f $ARGOCD_MANIFEST -n $ARGOCD_NAMESPACE
+
+echo "Creating KUBECONFIG secrets for argocd server and argocd application controller service accounts"
+create_kubeconfig_secret "argocd-server" "kcp-kubeconfig-controller"
+create_kubeconfig_secret "argocd-application-controller" "kcp-kubeconfig-server"
+
+echo "Verifying if argocd components are up and running after mounting kubeconfig secrets"
+KUBECONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig" kubectl wait --for=condition=available deployments/argocd-server -n $ARGOCD_NAMESPACE
+count=0
+while [ $count -lt 30 ]
+do
+    count=`expr $count + 1`
+    replicas=$(KUBECONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig" kubectl get statefulsets argocd-application-controller -n $ARGOCD_NAMESPACE -o jsonpath='{.spec.replicas}')
+    ready_replicas=$(KUBECONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig" kubectl get statefulsets argocd-application-controller -n $ARGOCD_NAMESPACE -o jsonpath='{.status.readyReplicas}')
+    if [ "$replicas" -eq "$ready_replicas" ]; then 
+        break
+    fi
+    if [ $count -eq 30 ]; then 
+        echo "Statefulset argocd-application-controller does not have the required replicas"
+        exit 1
+    fi
+done
+
+cat <<EOF | KUBECONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig" kubectl apply -n $ARGOCD_NAMESPACE -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-cluster-config
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+type: Opaque
+stringData:
+  name: in-cluster
+  namespace: "$ARGOCD_NAMESPACE"
+  server: https://kubernetes.default.svc
+  config: |
+    {
+      "tlsClientConfig": {
+        "insecure": true
+      }
+    }
+EOF
+
+echo "Argo CD is successfully installed in namespace $ARGOCD_NAMESPACE"
+
+KUBECONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig" kubectl get all -n $ARGOCD_NAMESPACE
+
+test-gitops-service-e2e-in-kcp() {
+  
+  export KUBECONFIG=${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig
+  printf "The Kubeconfig being used for this is:" $KUBECONFIG
+  ./delete-dev-env.sh
+  make devenv-docker
+  make start-e2e &
+  make test-e2e
+}
+
+kubectl port-forward --namespace gitops svc/gitops-postgresql-staging 5432:5432 &
+test-gitops-service-e2e-in-kcp ${TMP_DIR}
+
+cleanup() {
+  pkill go
+  rm -rf ${TMP_DIR}
+}
+
+cleanup ${TMP_DIR}

--- a/kcp/ckcp/setup-ckcp-on-openshift.sh
+++ b/kcp/ckcp/setup-ckcp-on-openshift.sh
@@ -106,7 +106,7 @@ stringData:
     clusters:
     - name: default-cluster
       cluster:
-        certificate-authority-data: ${ca}
+        insecure-skip-tls-verify: true
         server: ${server}
     contexts:
     - name: default-context

--- a/kcp/ckcp/setup-ckcp-on-openshift.sh
+++ b/kcp/ckcp/setup-ckcp-on-openshift.sh
@@ -9,6 +9,7 @@ SCRIPT_DIR="$(
 )"
 
 export GITOPS_IN_KCP="true"
+export DISABLE_KCP_VIRTUAL_WORKSPACE="true"
 
 ARGOCD_MANIFEST="$SCRIPT_DIR/../install-argocd.yaml"
 ARGOCD_NAMESPACE="gitops-service-argocd"
@@ -140,6 +141,7 @@ do
     count=`expr $count + 1`
     replicas=$(KUBECONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig" kubectl get statefulsets argocd-application-controller -n $ARGOCD_NAMESPACE -o jsonpath='{.spec.replicas}')
     ready_replicas=$(KUBECONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig" kubectl get statefulsets argocd-application-controller -n $ARGOCD_NAMESPACE -o jsonpath='{.status.readyReplicas}')
+
     if [ "$replicas" -eq "$ready_replicas" ]; then 
         break
     fi
@@ -180,6 +182,7 @@ test-gitops-service-e2e-in-kcp() {
   cd ${SCRIPT_DIR}/../../
   ./delete-dev-env.sh
   make devenv-docker
+  kubectl create ns kube-system || true
   make start-e2e &
   make test-e2e
 }
@@ -189,5 +192,5 @@ test-gitops-service-e2e-in-kcp ${TMP_DIR} ${SCRIPT_DIR}
 
 # clean the tmp directory created for the local setup
 rm -rf ${TMP_DIR}
-
+cleanup
 

--- a/kcp/install-argocd.yaml
+++ b/kcp/install-argocd.yaml
@@ -9773,14 +9773,6 @@ spec:
         ports:
         - containerPort: 6379
           protocol: TCP
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - all
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 999
       serviceAccountName: argocd-redis
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Signed-off-by: Samyak Jain <samyak.jn11@gmail.com>


#### Description:
- This is continued work on setting up a local script that consumes the openshift cluster as a workload to KCP as well as KCP running within the same cluster. This concept was being followed by the pipeline service team as ckcp, and hence, in this script, we are an end user of ckcp to set up our local dev env and run e2e on it.
- The blocker from ckcp side: Release on 0.7 PR for the same is up here: https://github.com/openshift-pipelines/pipeline-service/pull/192.
- The PR https://github.com/redhat-appstudio/managed-gitops/pull/170 opened previously can be tweaked to work with local clusters such as kind k2d etc but we can't run our e2e test because it explicitly needs an openshift cluster.

#### Link to JIRA Story (if applicable):  [GITOPSRVCE-158](https://issues.redhat.com/browse/GITOPSRVCE-158)
