### PR TITLE
:recycle: Use any instead of interface{}

### DIFF
--- a/backend-shared/apis/managed-gitops/v1alpha1/mocks/cr-client.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/mocks/cr-client.go
@@ -41,7 +41,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 // Create mocks base method.
 func (m *MockClient) Create(arg0 context.Context, arg1 client.Object, arg2 ...client.CreateOption) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -51,16 +51,16 @@ func (m *MockClient) Create(arg0 context.Context, arg1 client.Object, arg2 ...cl
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockClientMockRecorder) Create(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Create(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockClient)(nil).Create), varargs...)
 }
 
 // Delete mocks base method.
 func (m *MockClient) Delete(arg0 context.Context, arg1 client.Object, arg2 ...client.DeleteOption) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -70,16 +70,16 @@ func (m *MockClient) Delete(arg0 context.Context, arg1 client.Object, arg2 ...cl
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockClientMockRecorder) Delete(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Delete(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClient)(nil).Delete), varargs...)
 }
 
 // DeleteAllOf mocks base method.
 func (m *MockClient) DeleteAllOf(arg0 context.Context, arg1 client.Object, arg2 ...client.DeleteAllOfOption) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -89,9 +89,9 @@ func (m *MockClient) DeleteAllOf(arg0 context.Context, arg1 client.Object, arg2 
 }
 
 // DeleteAllOf indicates an expected call of DeleteAllOf.
-func (mr *MockClientMockRecorder) DeleteAllOf(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) DeleteAllOf(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllOf", reflect.TypeOf((*MockClient)(nil).DeleteAllOf), varargs...)
 }
 
@@ -104,7 +104,7 @@ func (m *MockClient) Get(arg0 context.Context, arg1 types.NamespacedName, arg2 c
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockClientMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Get(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get), arg0, arg1, arg2)
 }
@@ -112,7 +112,7 @@ func (mr *MockClientMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call
 // List mocks base method.
 func (m *MockClient) List(arg0 context.Context, arg1 client.ObjectList, arg2 ...client.ListOption) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -122,16 +122,16 @@ func (m *MockClient) List(arg0 context.Context, arg1 client.ObjectList, arg2 ...
 }
 
 // List indicates an expected call of List.
-func (mr *MockClientMockRecorder) List(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) List(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockClient)(nil).List), varargs...)
 }
 
 // Patch mocks base method.
 func (m *MockClient) Patch(arg0 context.Context, arg1 client.Object, arg2 client.Patch, arg3 ...client.PatchOption) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1, arg2}
+	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
@@ -141,9 +141,9 @@ func (m *MockClient) Patch(arg0 context.Context, arg1 client.Object, arg2 client
 }
 
 // Patch indicates an expected call of Patch.
-func (mr *MockClientMockRecorder) Patch(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Patch(arg0, arg1, arg2 any, arg3 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Patch", reflect.TypeOf((*MockClient)(nil).Patch), varargs...)
 }
 
@@ -192,7 +192,7 @@ func (mr *MockClientMockRecorder) Status() *gomock.Call {
 // Update mocks base method.
 func (m *MockClient) Update(arg0 context.Context, arg1 client.Object, arg2 ...client.UpdateOption) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -202,8 +202,8 @@ func (m *MockClient) Update(arg0 context.Context, arg1 client.Object, arg2 ...cl
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockClientMockRecorder) Update(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Update(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockClient)(nil).Update), varargs...)
 }

--- a/backend-shared/apis/managed-gitops/v1alpha1/mocks/status-writer.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/mocks/status-writer.go
@@ -38,7 +38,7 @@ func (m *MockStatusWriter) EXPECT() *MockStatusWriterMockRecorder {
 // Patch mocks base method.
 func (m *MockStatusWriter) Patch(arg0 context.Context, arg1 client.Object, arg2 client.Patch, arg3 ...client.PatchOption) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1, arg2}
+	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
@@ -48,16 +48,16 @@ func (m *MockStatusWriter) Patch(arg0 context.Context, arg1 client.Object, arg2 
 }
 
 // Patch indicates an expected call of Patch.
-func (mr *MockStatusWriterMockRecorder) Patch(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+func (mr *MockStatusWriterMockRecorder) Patch(arg0, arg1, arg2 any, arg3 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Patch", reflect.TypeOf((*MockStatusWriter)(nil).Patch), varargs...)
 }
 
 // Update mocks base method.
 func (m *MockStatusWriter) Update(arg0 context.Context, arg1 client.Object, arg2 ...client.UpdateOption) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
+	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
@@ -67,8 +67,8 @@ func (m *MockStatusWriter) Update(arg0 context.Context, arg1 client.Object, arg2
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockStatusWriterMockRecorder) Update(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockStatusWriterMockRecorder) Update(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockStatusWriter)(nil).Update), varargs...)
 }

--- a/backend-shared/apis/managed-gitops/v1alpha1/mocks/structs/gitopsdeployment.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/mocks/structs/gitopsdeployment.go
@@ -61,7 +61,7 @@ func NewGitopsDeploymentMatcher() *GitOpsDeploymentMatcher {
 	}
 }
 
-func (m *GitOpsDeploymentMatcher) Matches(x interface{}) bool {
+func (m *GitOpsDeploymentMatcher) Matches(x any) bool {
 	ref, isCorrectType := x.(*api.GitOpsDeployment)
 	if !isCorrectType {
 		m.FailReason = fmt.Sprintf("Unexpected type passed: want '%T', got '%T'", api.GitOpsDeployment{}, x)

--- a/backend-shared/config/db/utils.go
+++ b/backend-shared/config/db/utils.go
@@ -20,7 +20,7 @@ import (
 // the amount of boilerplate code.
 //
 // See functions that are calling this one for examples.
-func isEmptyValues(callLocation string, params ...interface{}) error {
+func isEmptyValues(callLocation string, params ...any) error {
 
 	if len(params)%2 == 1 {
 		return fmt.Errorf("invalid number of parameters, expected an even number: %v", len(params))
@@ -91,7 +91,7 @@ func validateUnsafeQueryParams(entityId string, dbq *PostgreSQLDatabaseQueries) 
 }
 
 // validateQueryParams is common, simple validation logic shared by most entities
-func validateQueryParamsEntity(entity interface{}, dbq *PostgreSQLDatabaseQueries) error {
+func validateQueryParamsEntity(entity any, dbq *PostgreSQLDatabaseQueries) error {
 	if dbq.dbConnection == nil {
 		return fmt.Errorf("database connection is nil")
 	}
@@ -191,7 +191,7 @@ func ConvertSnakeCaseToCamelCase(fieldName string) string {
 
 // A generic function to validate length of string values in input provided by users.
 // The max length of string is checked using constant variables defined for each type and field in db_field_constants.go
-func validateFieldLength(obj interface{}) error {
+func validateFieldLength(obj any) error {
 	valuesOfObject := reflect.ValueOf(obj).Elem()
 	typeOfObject := reflect.TypeOf(obj).Elem().Name()
 
@@ -339,7 +339,7 @@ func SetupForTestingDBGinkgo() error {
 
 	// Create a list of gitops engine instance uids that were created by test cases; we
 	// will later use this to delete old Operations rows, that reference these instances.
-	gitopsEngineInstanceUIDsToDelete := map[string]interface{}{}
+	gitopsEngineInstanceUIDsToDelete := map[string]any{}
 	{
 		var engineInstances []GitopsEngineInstance
 		err = dbq.UnsafeListAllGitopsEngineInstances(ctx, &engineInstances)

--- a/backend-shared/config/db/utils_test.go
+++ b/backend-shared/config/db/utils_test.go
@@ -16,68 +16,68 @@ func TestIsEmptyValues(t *testing.T) {
 	for _, c := range []struct {
 		// name is human-readable test name
 		name          string
-		params        []interface{}
+		params        []any
 		expectedError bool
 	}{
 		{
 			name:          "valid",
-			params:        []interface{}{"key", "value"},
+			params:        []any{"key", "value"},
 			expectedError: false,
 		},
 		{
 			name:          "empty key w/ string value",
-			params:        []interface{}{"", "value"},
+			params:        []any{"", "value"},
 			expectedError: true,
 		},
 		{
 			name:          "empty value w/ string key",
-			params:        []interface{}{"key", ""},
+			params:        []any{"key", ""},
 			expectedError: true,
 		},
 		{
 			name:          "empty string value, w/ string key",
-			params:        []interface{}{"key", ""},
+			params:        []any{"key", ""},
 			expectedError: true,
 		},
 		{
 			name:          "empty interface value, w/ string key",
-			params:        []interface{}{"key", nil},
+			params:        []any{"key", nil},
 			expectedError: true,
 		},
 		{
 			name:          "empty interface key, w/ string value",
-			params:        []interface{}{nil, ""},
+			params:        []any{nil, ""},
 			expectedError: true,
 		},
 		{
 			name:          "multiple valid string values",
-			params:        []interface{}{"key", "value", "key2", "value2"},
+			params:        []any{"key", "value", "key2", "value2"},
 			expectedError: false,
 		},
 		{
 			name:          "multiple string values, one invalid",
-			params:        []interface{}{"key", "value", "key2", ""},
+			params:        []any{"key", "value", "key2", ""},
 			expectedError: true,
 		},
 		{
 			name:          "multiple mixed values, one invalid",
-			params:        []interface{}{"key", nil, "key2", ""},
+			params:        []any{"key", nil, "key2", ""},
 			expectedError: true,
 		},
 		{
 			name:          "multiple mixed values, one invalid, different order",
-			params:        []interface{}{"key", "hi", "key2", nil},
+			params:        []any{"key", "hi", "key2", nil},
 			expectedError: true,
 		},
 
 		{
 			name:          "invalid number of params",
-			params:        []interface{}{"key", "value", "key2"},
+			params:        []any{"key", "value", "key2"},
 			expectedError: true,
 		},
 		{
 			name:          "no params",
-			params:        []interface{}{},
+			params:        []any{},
 			expectedError: true,
 		},
 	} {

--- a/backend-shared/util/log.go
+++ b/backend-shared/util/log.go
@@ -24,7 +24,7 @@ const (
 	ResourceDeleted  ResourceChangeType = "Deleted"
 )
 
-func LogAPIResourceChangeEvent(resourceNamespace string, resourceName string, resource interface{}, resourceChangeType ResourceChangeType, log logr.Logger) {
+func LogAPIResourceChangeEvent(resourceNamespace string, resourceName string, resource any, resourceChangeType ResourceChangeType, log logr.Logger) {
 	log = log.WithValues("audit", "true")
 
 	if resource == nil {

--- a/backend-shared/util/task_retry_loop.go
+++ b/backend-shared/util/task_retry_loop.go
@@ -116,7 +116,7 @@ const (
 
 type taskRetryLoopMessage struct {
 	msgType taskRetryMessageType
-	payload interface{}
+	payload any
 }
 
 type taskRetryMessage_addTask struct {
@@ -160,7 +160,7 @@ func NewTaskRetryLoop(debugName string) (loop *TaskRetryLoop) {
 }
 
 type waitingTaskContainer struct {
-	waitingTasksByName map[string]interface{}
+	waitingTasksByName map[string]any
 	waitingTasks       []waitingTaskEntry
 }
 
@@ -203,7 +203,7 @@ func internalTaskRetryLoop(inputChan chan taskRetryLoopMessage, debugName string
 
 	// tasks that are waiting to run. We ensure there are no duplicates in either list.
 	waitingTaskContainer := waitingTaskContainer{
-		waitingTasksByName: map[string]interface{}{},
+		waitingTasksByName: map[string]any{},
 		waitingTasks:       []waitingTaskEntry{},
 	}
 

--- a/backend-shared/util/test_task_retry_loop_test.go
+++ b/backend-shared/util/test_task_retry_loop_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Task Retry Loop Unit Tests", func() {
 		It("ensures that calling startTask removes the task from 'waitingTasksByName'", func() {
 
 			waitingTaskContainer := waitingTaskContainer{
-				waitingTasksByName: make(map[string]interface{}),
+				waitingTasksByName: make(map[string]any),
 				waitingTasks:       []waitingTaskEntry{},
 			}
 

--- a/backend/condition/mocks/conditions.go
+++ b/backend/condition/mocks/conditions.go
@@ -44,7 +44,7 @@ func (m *MockConditions) FindCondition(conditions *[]v1alpha1.GitOpsDeploymentCo
 }
 
 // FindCondition indicates an expected call of FindCondition.
-func (mr *MockConditionsMockRecorder) FindCondition(conditions, conditionType interface{}) *gomock.Call {
+func (mr *MockConditionsMockRecorder) FindCondition(conditions, conditionType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindCondition", reflect.TypeOf((*MockConditions)(nil).FindCondition), conditions, conditionType)
 }
@@ -58,7 +58,7 @@ func (m *MockConditions) HasCondition(conditions *[]v1alpha1.GitOpsDeploymentCon
 }
 
 // HasCondition indicates an expected call of HasCondition.
-func (mr *MockConditionsMockRecorder) HasCondition(conditions, conditionType interface{}) *gomock.Call {
+func (mr *MockConditionsMockRecorder) HasCondition(conditions, conditionType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasCondition", reflect.TypeOf((*MockConditions)(nil).HasCondition), conditions, conditionType)
 }
@@ -70,7 +70,7 @@ func (m *MockConditions) SetCondition(conditions *[]v1alpha1.GitOpsDeploymentCon
 }
 
 // SetCondition indicates an expected call of SetCondition.
-func (mr *MockConditionsMockRecorder) SetCondition(conditions, conditionType, status, reason, message interface{}) *gomock.Call {
+func (mr *MockConditionsMockRecorder) SetCondition(conditions, conditionType, status, reason, message any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCondition", reflect.TypeOf((*MockConditions)(nil).SetCondition), conditions, conditionType, status, reason, message)
 }

--- a/backend/eventloop/workspace_event_loop.go
+++ b/backend/eventloop/workspace_event_loop.go
@@ -80,7 +80,7 @@ const (
 
 type workspaceEventLoopMessage struct {
 	messageType workspaceEventLoopMessageType
-	payload     interface{}
+	payload     any
 }
 
 // internalStartWorkspaceEventLoopRouter has the primary goal of catching panics from the workspaceEventLoopRouter, and

--- a/backend/eventloop/workspace_resource_event_loop.go
+++ b/backend/eventloop/workspace_resource_event_loop.go
@@ -32,7 +32,7 @@ type workspaceResourceLoopMessage struct {
 	messageType workspaceResourceLoopMessageType
 
 	// optional payload
-	payload interface{}
+	payload any
 }
 
 type workspaceResourceLoopMessageType string

--- a/backend/main.go
+++ b/backend/main.go
@@ -186,7 +186,7 @@ func initializeRoutes() {
 
 }
 
-//nolint
+// nolint
 // createPrimaryGitOpsEngineInstance create placeholder values, for development purposes. This should not be used in production.
 func createPrimaryGitOpsEngineInstance(k8sclient client.Client, log logr.Logger) error {
 

--- a/backend/util/createHook.go
+++ b/backend/util/createHook.go
@@ -20,11 +20,12 @@ func (t *TokenSource) Token() (*oauth2.Token, error) {
 }
 
 // Parameters:
-// 	personalAccessToken : This points to the personal access token (PAT) assigned from the GitHub with the repo access atleast
-// 	authorUsername 		: The author git username (a/c to the PAT)
-// 	authorName 			: The author full name registered (a/c to the PAT)
-// 	repoName 			: The repository name on which the hook will be defined
-// 	hookURL 			: This points to the payloadURL on which github will POST request
+//
+//	personalAccessToken : This points to the personal access token (PAT) assigned from the GitHub with the repo access atleast
+//	authorUsername 		: The author git username (a/c to the PAT)
+//	authorName 			: The author full name registered (a/c to the PAT)
+//	repoName 			: The repository name on which the hook will be defined
+//	hookURL 			: This points to the payloadURL on which github will POST request
 func CreateWebHook(personalAccessToken string, authorUsername string, authorName string, repoName string, hookURL string) error {
 	// OAuth Authentication
 	tokenSource := &TokenSource{
@@ -44,7 +45,7 @@ func CreateWebHook(personalAccessToken string, authorUsername string, authorName
 		// The webhook name in the parameter is by default set to "web"
 		Name: github.String("web"),
 		URL:  github.String(hookURL),
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"url":          hookURL,
 			"content_type": "json",
 		},

--- a/cluster-agent/controllers/argoproj.io/namespace_reconciler.go
+++ b/cluster-agent/controllers/argoproj.io/namespace_reconciler.go
@@ -59,7 +59,7 @@ func runNamespaceReconcile(ctx context.Context, dbQueries db.DatabaseQueries, cl
 
 	// Fetch list of ArgoCD applications to be used later
 	// map: applications IDs seen (string) -> (map value not used)
-	processedApplicationIds := make(map[string]interface{})
+	processedApplicationIds := make(map[string]any)
 
 	argoApplicationList := appv1.ApplicationList{}
 	if err := client.List(ctx, &argoApplicationList); err != nil {
@@ -338,7 +338,7 @@ func cleanK8sOperations(ctx context.Context, dbq db.DatabaseQueries, client clie
 	log.V(sharedutil.LogLevel_Debug).Info("Cleaned all Operations created by Namespace Reconciler.")
 }
 
-func deleteOrphanedApplications(argoApplications []appv1.Application, processedApplicationIds map[string]interface{},
+func deleteOrphanedApplications(argoApplications []appv1.Application, processedApplicationIds map[string]any,
 	ctx context.Context, client client.Client, log logr.Logger) []appv1.Application {
 
 	if len(argoApplications) == 0 {

--- a/cluster-agent/controllers/argoproj.io/namespace_reconciler_test.go
+++ b/cluster-agent/controllers/argoproj.io/namespace_reconciler_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Namespace Reconciler Tests.", func() {
 				{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"databaseID": "test-my-application-5"}}},
 			}
 
-			processedApplicationIds := map[string]interface{}{"test-my-application-3": false, "test-my-application-5": false}
+			processedApplicationIds := map[string]any{"test-my-application-3": false, "test-my-application-5": false}
 
 			deletedArgoApplications := deleteOrphanedApplications(argoApplications, processedApplicationIds, ctx, reconciler.Client, log)
 

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
@@ -32,16 +32,15 @@ import (
 // Next, these resource changes (events) are then processed within a task retry loop.
 // - Operations are how the backend informs the cluster-agent of database changes.
 // - For example:
-//     - The user updated a field in a GitOpsDeployment in the user's namespace
-//     - The managed-gitops backend updated corresponding field in the Application database row
-//     - Next: an Operation was created to inform the cluster-agent component of the Application row changed
-//     - We are here: now the Operation controller of cluster-agent has been informed of the Operation.
-//     - We need to: Look at the Operation, determine what database entry changed, and ensure that Argo CD
-//                   is reconciled to the contents of the database entry.
+//   - The user updated a field in a GitOpsDeployment in the user's namespace
+//   - The managed-gitops backend updated corresponding field in the Application database row
+//   - Next: an Operation was created to inform the cluster-agent component of the Application row changed
+//   - We are here: now the Operation controller of cluster-agent has been informed of the Operation.
+//   - We need to: Look at the Operation, determine what database entry changed, and ensure that Argo CD
+//     is reconciled to the contents of the database entry.
 //
 // The overall workflow of Operations can be found in the architecture doc:
 // https://docs.google.com/document/d/1e1UwCbwK-Ew5ODWedqp_jZmhiZzYWaxEvIL-tqebMzo/edit#heading=h.9vyguee8vhow
-//
 type OperationEventLoop struct {
 	eventLoopInputChannel chan operationEventLoopEvent
 }

--- a/cluster-agent/controllers/managed-gitops/eventloop/repocred.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/repocred.go
@@ -320,7 +320,9 @@ func addSecretRepoCredMetadata(secret *corev1.Secret, secretType string) {
 // secretToRepoCred converts a Secret to a RepositoryCredentials
 // This is the reverse of convertRepoCredToSecret and it's needed because by default the values of the secret are in bytes
 // e.g. Secret.name: [116 101 115 116 45 102 97 107 101 45 115 101 99 114 101 116 45 111 98 106]
-//		Secret password: [116 101 115 116 45 102 97 107 101 45 97 117 116 104 45 112 97 115 115 119 111 114 100]
+//
+//	Secret password: [116 101 115 116 45 102 97 107 101 45 97 117 116 104 45 112 97 115 115 119 111 114 100]
+//
 // that is why we need this function. To typecast the bytes to string.
 func secretToRepoCred(secret *corev1.Secret) (repoCred *db.RepositoryCredentials) {
 	return &db.RepositoryCredentials{

--- a/cluster-agent/utils/argocd_login_credentials.go
+++ b/cluster-agent/utils/argocd_login_credentials.go
@@ -78,9 +78,9 @@ func (dcg *defaultClientGenerator) generateClientForServerAddress(server string,
 // NewCredentialService is used to create a new instance of the Credential service.
 //
 // Parameters:
-// - acdClientGenerator: used to specify a custom interface, used to create connections to the Argo CD GRPC client
+//   - acdClientGenerator: used to specify a custom interface, used to create connections to the Argo CD GRPC client
 //     (optional: should usually be 'nil', unless a custom implementation is needed, for example, for mocking)
-// - skipTLSTest: whether to test the GRPC endpoint for TLS, before attempting to use it.
+//   - skipTLSTest: whether to test the GRPC endpoint for TLS, before attempting to use it.
 //     (should be true, unless running within automated tests, which do not simulate TLS)
 func NewCredentialService(acdClientGenerator clientGenerator, skipTLSTest bool) *CredentialService {
 

--- a/cluster-agent/utils/mocks/ApplicationServiceClient.go
+++ b/cluster-agent/utils/mocks/ApplicationServiceClient.go
@@ -24,11 +24,11 @@ type ApplicationServiceClient struct {
 
 // Create provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) Create(ctx context.Context, in *application.ApplicationCreateRequest, opts ...grpc.CallOption) (*v1alpha1.Application, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -54,11 +54,11 @@ func (_m *ApplicationServiceClient) Create(ctx context.Context, in *application.
 
 // Delete provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) Delete(ctx context.Context, in *application.ApplicationDeleteRequest, opts ...grpc.CallOption) (*application.ApplicationResponse, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -84,11 +84,11 @@ func (_m *ApplicationServiceClient) Delete(ctx context.Context, in *application.
 
 // DeleteResource provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) DeleteResource(ctx context.Context, in *application.ApplicationResourceDeleteRequest, opts ...grpc.CallOption) (*application.ApplicationResponse, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -114,11 +114,11 @@ func (_m *ApplicationServiceClient) DeleteResource(ctx context.Context, in *appl
 
 // Get provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) Get(ctx context.Context, in *application.ApplicationQuery, opts ...grpc.CallOption) (*v1alpha1.Application, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -144,11 +144,11 @@ func (_m *ApplicationServiceClient) Get(ctx context.Context, in *application.App
 
 // GetApplicationSyncWindows provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) GetApplicationSyncWindows(ctx context.Context, in *application.ApplicationSyncWindowsQuery, opts ...grpc.CallOption) (*application.ApplicationSyncWindowsResponse, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -174,11 +174,11 @@ func (_m *ApplicationServiceClient) GetApplicationSyncWindows(ctx context.Contex
 
 // GetManifests provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) GetManifests(ctx context.Context, in *application.ApplicationManifestQuery, opts ...grpc.CallOption) (*apiclient.ManifestResponse, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -204,11 +204,11 @@ func (_m *ApplicationServiceClient) GetManifests(ctx context.Context, in *applic
 
 // GetResource provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) GetResource(ctx context.Context, in *application.ApplicationResourceRequest, opts ...grpc.CallOption) (*application.ApplicationResourceResponse, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -234,11 +234,11 @@ func (_m *ApplicationServiceClient) GetResource(ctx context.Context, in *applica
 
 // List provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) List(ctx context.Context, in *application.ApplicationQuery, opts ...grpc.CallOption) (*v1alpha1.ApplicationList, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -264,11 +264,11 @@ func (_m *ApplicationServiceClient) List(ctx context.Context, in *application.Ap
 
 // ListResourceActions provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) ListResourceActions(ctx context.Context, in *application.ApplicationResourceRequest, opts ...grpc.CallOption) (*application.ResourceActionsListResponse, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -294,11 +294,11 @@ func (_m *ApplicationServiceClient) ListResourceActions(ctx context.Context, in 
 
 // ListResourceEvents provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) ListResourceEvents(ctx context.Context, in *application.ApplicationResourceEventsQuery, opts ...grpc.CallOption) (*v1.EventList, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -324,11 +324,11 @@ func (_m *ApplicationServiceClient) ListResourceEvents(ctx context.Context, in *
 
 // ManagedResources provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) ManagedResources(ctx context.Context, in *application.ResourcesQuery, opts ...grpc.CallOption) (*application.ManagedResourcesResponse, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -354,11 +354,11 @@ func (_m *ApplicationServiceClient) ManagedResources(ctx context.Context, in *ap
 
 // Patch provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) Patch(ctx context.Context, in *application.ApplicationPatchRequest, opts ...grpc.CallOption) (*v1alpha1.Application, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -384,11 +384,11 @@ func (_m *ApplicationServiceClient) Patch(ctx context.Context, in *application.A
 
 // PatchResource provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) PatchResource(ctx context.Context, in *application.ApplicationResourcePatchRequest, opts ...grpc.CallOption) (*application.ApplicationResourceResponse, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -414,11 +414,11 @@ func (_m *ApplicationServiceClient) PatchResource(ctx context.Context, in *appli
 
 // PodLogs provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) PodLogs(ctx context.Context, in *application.ApplicationPodLogsQuery, opts ...grpc.CallOption) (application.ApplicationService_PodLogsClient, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -444,11 +444,11 @@ func (_m *ApplicationServiceClient) PodLogs(ctx context.Context, in *application
 
 // ResourceTree provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) ResourceTree(ctx context.Context, in *application.ResourcesQuery, opts ...grpc.CallOption) (*v1alpha1.ApplicationTree, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -474,11 +474,11 @@ func (_m *ApplicationServiceClient) ResourceTree(ctx context.Context, in *applic
 
 // RevisionMetadata provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) RevisionMetadata(ctx context.Context, in *application.RevisionMetadataQuery, opts ...grpc.CallOption) (*v1alpha1.RevisionMetadata, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -504,11 +504,11 @@ func (_m *ApplicationServiceClient) RevisionMetadata(ctx context.Context, in *ap
 
 // Rollback provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) Rollback(ctx context.Context, in *application.ApplicationRollbackRequest, opts ...grpc.CallOption) (*v1alpha1.Application, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -534,11 +534,11 @@ func (_m *ApplicationServiceClient) Rollback(ctx context.Context, in *applicatio
 
 // RunResourceAction provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) RunResourceAction(ctx context.Context, in *application.ResourceActionRunRequest, opts ...grpc.CallOption) (*application.ApplicationResponse, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -564,11 +564,11 @@ func (_m *ApplicationServiceClient) RunResourceAction(ctx context.Context, in *a
 
 // Sync provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) Sync(ctx context.Context, in *application.ApplicationSyncRequest, opts ...grpc.CallOption) (*v1alpha1.Application, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -594,11 +594,11 @@ func (_m *ApplicationServiceClient) Sync(ctx context.Context, in *application.Ap
 
 // TerminateOperation provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) TerminateOperation(ctx context.Context, in *application.OperationTerminateRequest, opts ...grpc.CallOption) (*application.OperationTerminateResponse, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -624,11 +624,11 @@ func (_m *ApplicationServiceClient) TerminateOperation(ctx context.Context, in *
 
 // Update provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) Update(ctx context.Context, in *application.ApplicationUpdateRequest, opts ...grpc.CallOption) (*v1alpha1.Application, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -654,11 +654,11 @@ func (_m *ApplicationServiceClient) Update(ctx context.Context, in *application.
 
 // UpdateSpec provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) UpdateSpec(ctx context.Context, in *application.ApplicationUpdateSpecRequest, opts ...grpc.CallOption) (*v1alpha1.ApplicationSpec, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -684,11 +684,11 @@ func (_m *ApplicationServiceClient) UpdateSpec(ctx context.Context, in *applicat
 
 // Watch provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) Watch(ctx context.Context, in *application.ApplicationQuery, opts ...grpc.CallOption) (application.ApplicationService_WatchClient, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -714,11 +714,11 @@ func (_m *ApplicationServiceClient) Watch(ctx context.Context, in *application.A
 
 // WatchResourceTree provides a mock function with given fields: ctx, in, opts
 func (_m *ApplicationServiceClient) WatchResourceTree(ctx context.Context, in *application.ResourcesQuery, opts ...grpc.CallOption) (application.ApplicationService_WatchResourceTreeClient, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)

--- a/cluster-agent/utils/mocks/SessionServiceClient.go
+++ b/cluster-agent/utils/mocks/SessionServiceClient.go
@@ -19,11 +19,11 @@ type SessionServiceClient struct {
 
 // Create provides a mock function with given fields: ctx, in, opts
 func (_m *SessionServiceClient) Create(ctx context.Context, in *session.SessionCreateRequest, opts ...grpc.CallOption) (*session.SessionResponse, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -49,11 +49,11 @@ func (_m *SessionServiceClient) Create(ctx context.Context, in *session.SessionC
 
 // Delete provides a mock function with given fields: ctx, in, opts
 func (_m *SessionServiceClient) Delete(ctx context.Context, in *session.SessionDeleteRequest, opts ...grpc.CallOption) (*session.SessionResponse, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -79,11 +79,11 @@ func (_m *SessionServiceClient) Delete(ctx context.Context, in *session.SessionD
 
 // GetUserInfo provides a mock function with given fields: ctx, in, opts
 func (_m *SessionServiceClient) GetUserInfo(ctx context.Context, in *session.GetUserInfoRequest, opts ...grpc.CallOption) (*session.GetUserInfoResponse, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)

--- a/cluster-agent/utils/mocks/SettingsServiceClient.go
+++ b/cluster-agent/utils/mocks/SettingsServiceClient.go
@@ -19,11 +19,11 @@ type SettingsServiceClient struct {
 
 // Get provides a mock function with given fields: ctx, in, opts
 func (_m *SettingsServiceClient) Get(ctx context.Context, in *settings.SettingsQuery, opts ...grpc.CallOption) (*settings.Settings, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)

--- a/cluster-agent/utils/mocks/VersionServiceClient.go
+++ b/cluster-agent/utils/mocks/VersionServiceClient.go
@@ -20,11 +20,11 @@ type VersionServiceClient struct {
 
 // Version provides a mock function with given fields: ctx, in, opts
 func (_m *VersionServiceClient) Version(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*version.VersionMessage, error) {
-	_va := make([]interface{}, len(opts))
+	_va := make([]any, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, in)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)


### PR DESCRIPTION
#### Description:

This is a cosmetic change to match the idiomatic way of writing Go >= 1.18 (thus it's breaking if you try to compile with previous versions). Generics aside, if the existing code uses `interface{}`, we can now replace it with `any` throughout, just as the **Go standard library has done**. So, what this PR is doing is something like this:

```go
func Print(args ...interface{}) {
```

can now be refactored very straightforwardly to:

```go
func Print(args ...any) {
```

_NOTE_: This doesn't mean the function is now turned into a generic, nor it has any other effect on it at all. The `any` shortcut it simply a **type alias** for `interface{}`, so Gophers can (and they should IMHO) to use the shorter name anywhere.

In brief, the new name for `interface{}` is `any`.

#### Link to JIRA Story (if applicable):

None
