### PR TITLE
Switch to defaulting to new Kubernetes behaviour for Secret/ServiceAccount

### DIFF
--- a/backend/eventloop/eventloop_test_util/eventloop_test_util.go
+++ b/backend/eventloop/eventloop_test_util/eventloop_test_util.go
@@ -2,72 +2,88 @@ package eventloop_test_util
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	// . "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// StartServiceAccountListenerOnFakeClient waits for an ArgoCD Manager ServiceAccount token to be created,
-// then creates a token secret and adds ito the ServiceAccount.
-// This simulates the default K8s behaviour of ServiceAccount (which, in a unit test, we do not have)
+// StartServiceAccountListenerOnFakeClient simulates the default K8s behaviour of ServiceAccountTokenSecrets on Kubernetes.
+// - Wait for the ServiceAccountToken Secret to be created
+// - Next, add a fake token to the secret
+// - Finally, add a reference to the Secret to the ServiceAccount
 func StartServiceAccountListenerOnFakeClient(ctx context.Context, managedEnvironmentUID string, k8sClient client.Client) {
-	go func() {
 
-		var sa *corev1.ServiceAccount
+	addSecretToServiceAccount := func(secret corev1.Secret) {
 
-		// Wait for a ServiceAccount to be created for the given GitOpsDeploymentManagedEnvironment
-		err := wait.Poll(time.Second*1, time.Hour*1, func() (bool, error) {
-			// Look for ServiceAccounts in kube-system
-			saList := corev1.ServiceAccountList{}
-			err := k8sClient.List(ctx, &saList, &client.ListOptions{Namespace: "kube-system"})
+		// Update the token field of the Secret, to include our simulated token
+		secret.Data = map[string][]byte{
+			"token": ([]byte)("token"),
+		}
+		err := k8sClient.Update(ctx, &secret)
+		Expect(err).To(BeNil())
+
+		// Locate the ServiceAccount that is pointed to by the Secret, and update that ServiceAccount
+		// - Add the Secret to the list of token secrets in the Service account
+		serviceAccountName, exists := secret.Annotations[corev1.ServiceAccountNameKey]
+		Expect(exists).To(BeTrue())
+
+		if exists {
+
+			serviceAccount := corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceAccountName,
+					Namespace: secret.Namespace,
+				},
+			}
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&serviceAccount), &serviceAccount)
 			Expect(err).To(BeNil())
 
-			for idx := range saList.Items {
+			serviceAccount.Secrets = append(serviceAccount.Secrets, corev1.ObjectReference{
+				Name:      secret.Name,
+				Namespace: secret.Namespace,
+			})
 
-				item := saList.Items[idx]
+			err = k8sClient.Update(ctx, &serviceAccount)
+			Expect(err).To(BeNil())
 
-				sa = &item
+		}
+	}
 
-				if strings.HasPrefix(item.Name, sharedutil.ArgoCDManagerServiceAccountPrefix) &&
-					strings.Contains(item.Name, managedEnvironmentUID) {
-					return true, nil
+	go func() {
+
+		// Wait for the ServiceAccountToken Secret to be created
+		// Then:
+		// - add a fake token to the secret
+		// - add a reference to the Secret to the ServiceAccount
+		err := wait.Poll(time.Second*1, time.Hour*1, func() (bool, error) {
+
+			secretList := corev1.SecretList{}
+			err := k8sClient.List(ctx, &secretList, &client.ListOptions{Namespace: "kube-system"})
+			Expect(err).To(BeNil())
+
+			for idx := range secretList.Items {
+
+				secret := secretList.Items[idx]
+
+				if secret.Type == corev1.SecretTypeServiceAccountToken {
+
+					// Only touch secrets that don't already have a token
+					_, tokenDataExists := secret.Data["token"]
+					if !tokenDataExists {
+						addSecretToServiceAccount(secret)
+					}
 				}
+
 			}
 
 			return false, nil
 		})
-		Expect(err).To(BeNil())
-
-		// Once the ServiceAccount was created, create the corresponding Secret and add it to the ServiceAccount
-		tokenSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "token-secret-" + string(uuid.NewUUID()),
-				Namespace: "kube-system",
-				Annotations: map[string]string{
-					corev1.ServiceAccountNameKey: sa.Name,
-				},
-			},
-			Data: map[string][]byte{"token": ([]byte)("token")},
-			Type: corev1.SecretTypeServiceAccountToken,
-		}
-		err = k8sClient.Create(ctx, tokenSecret)
-		Expect(err).To(BeNil())
-
-		sa.Secrets = append(sa.Secrets, corev1.ObjectReference{
-			Name:      tokenSecret.Name,
-			Namespace: tokenSecret.Namespace,
-		})
-
-		err = k8sClient.Update(ctx, sa)
 		Expect(err).To(BeNil())
 
 	}()


### PR DESCRIPTION
#### Description:
- Update the Secret/ServiceAccount creation logic to work with the logic that will work with newer versions of Kubernetes. I've tested it with both OpenShift 4.10 and OpenShift 4.11 (the two versions we support).
- Update the unit test logic which mocks  the ServiceAccount/Secret behaviour
- This removes the failover delay in the previous code (`wait.ErrWaitTimeout`), which would have increased the time to run the E2E test suite when running on OpenShift 4.11 and KCP.

#### Link to JIRA Story (if applicable): [GITOPSRVCE-192](https://issues.redhat.com/browse/GITOPSRVCE-192)
