### PR TITLE
Update argocd installation manifest for CPS

### DIFF
--- a/kcp/install-argocd.yaml
+++ b/kcp/install-argocd.yaml
@@ -9772,6 +9772,7 @@ spec:
         name: redis
         ports:
         - containerPort: 6379
+          protocol: TCP
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/kcp/install-argocd.yaml
+++ b/kcp/install-argocd.yaml
@@ -9697,9 +9697,6 @@ spec:
         - argocd-notifications
         image: quay.io/argoproj/argocd:v2.4.10
         imagePullPolicy: Always
-        livenessProbe:
-          tcpSocket:
-            port: 9001
         name: argocd-notifications-controller
         securityContext:
           allowPrivilegeEscalation: false
@@ -9922,13 +9919,6 @@ spec:
           value: /helm-working-dir
         image: quay.io/argoproj/argocd:v2.4.10
         imagePullPolicy: Always
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /healthz?full=true
-            port: 8084
-          initialDelaySeconds: 30
-          periodSeconds: 5
         name: argocd-repo-server
         ports:
         - containerPort: 8081
@@ -10214,12 +10204,6 @@ spec:
               optional: true
         image: quay.io/argoproj/argocd:v2.4.10
         imagePullPolicy: Always
-        livenessProbe:
-          httpGet:
-            path: /healthz?full=true
-            port: 8080
-          initialDelaySeconds: 3
-          periodSeconds: 30
         name: argocd-server
         ports:
         - containerPort: 8080
@@ -10430,12 +10414,6 @@ spec:
               optional: true
         image: quay.io/argoproj/argocd:v2.4.10
         imagePullPolicy: Always
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8082
-          initialDelaySeconds: 5
-          periodSeconds: 10
         name: argocd-application-controller
         ports:
         - containerPort: 8082

--- a/kcp/setup-kcp-cps.sh
+++ b/kcp/setup-kcp-cps.sh
@@ -5,7 +5,7 @@ set -ex
 CPS_KUBECONFIG="${CPS_KUBECONFIG:-$(realpath kcp/cps-kubeconfig)}"
 WORKLOAD_KUBECONFIG="${WORKLOAD_KUBECONFIG:-$HOME/.kube/config}"
 WORKSPACE="gitops-service-$(echo $RANDOM)"
-SYNCER_IMAGE="${SYNCER_IMAGE:-ghcr.io/kcp-dev/kcp/syncer:v0.7.1}"
+SYNCER_IMAGE="${SYNCER_IMAGE:-ghcr.io/kcp-dev/kcp/syncer:v0.7.8}"
 SYNCER_MANIFESTS=$(mktemp -d)/cps-syncer.yaml
 
 export GITOPS_IN_KCP="true"


### PR DESCRIPTION
#### Description:
Some of the changes that I missed when moving the manifest from my gist to managed-gitops repo in #197
 
- Remove liveness probes for all the components
- Add the missing protocol field
- Update KCP syncer to v0.7.8