### PR TITLE
Update ci dockerfile to match the kcp requirements (Needed: #GITOPSRVC-187)

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -5,8 +5,10 @@ ENV GOFLAGS=""
 
 SHELL ["/bin/bash", "-c"]
 
-# Install kubectl, postgresql-server
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+# Install yq, kubectl, postgresql-server
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.20.2/yq_linux_amd64 -O /usr/local/bin/yq && \
+    chmod +x /usr/local/bin/yq && yq --version && \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin && \
     yum -y install postgresql-server


### PR DESCRIPTION
#### Description:
- Update the ci Dockerfile to match the kcp requirements, this PR is intended to add commands to install yq package in the ci's Dockerfile which is required by ckcp.

Ref: Check [logs](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/31857/rehearse-31857-pull-ci-redhat-appstudio-managed-gitops-main-managed-gitops-e2e-tests-on-kcp/1565006131774885888#1:build-log.txt%3A37) from the release PR for the above requirement.

#### Link to JIRA Story: [GITOPSRVCE-187](https://issues.redhat.com/browse/GITOPSRVCE-187)
