### PR TITLE
Add ArgoCD CLI and use only curl

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -5,10 +5,11 @@ ENV GOFLAGS=""
 
 SHELL ["/bin/bash", "-c"]
 
-# Install yq, kubectl, postgresql-server
-RUN wget https://github.com/mikefarah/yq/releases/download/v4.20.2/yq_linux_amd64 -O /usr/local/bin/yq && \
+# Install yq, kubectl, postgresql-server, argocd cli
+RUN curl -sSL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && \
     chmod +x /usr/local/bin/yq && yq --version && \
     curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin && \
-    yum -y install postgresql-server
+    yum -y install postgresql-server && \
+    curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64 && chmod +x /usr/local/bin/argocd


### PR DESCRIPTION
#### Description:
- Looks like https://github.com/openshift-pipelines/pipeline-service/pull/220 will be merged, so we need to add `argocd` as well.
- Use only `curl` for fetching binaries from the web.

#### Link to JIRA Story (if applicable):

Link to JIRA Story: [GITOPSRVCE-187](https://issues.redhat.com/browse/GITOPSRVCE-187)
