### PR TITLE
Update ckcp setup local script to reflect new changes from the repo (pt: 4/n)

### DIFF
--- a/create-dev-env.sh
+++ b/create-dev-env.sh
@@ -147,7 +147,7 @@ if [ "$1" = "kube-auto" ]; then
   echo " * Postgres secret has been created."
 
   # Wait until postgres pod is running
-  if [[ $OPENSHIFT_CI != "true" ]] || [[ $GITOPS_IN_KCP != "true" ]]
+  if [[ $OPENSHIFT_CI == "" ]] || [[ $GITOPS_IN_KCP != "true" ]]
   then
     echo " * Wait until Postgres pod is running"
     counter=0
@@ -211,8 +211,6 @@ if [ "$1" = "kube-auto" ]; then
     # Decode the password from the secret
     POSTGRES_PASSWORD=$(kubectl get -n gitops secret gitops-postgresql-staging -o jsonpath="{.data.postgresql-password}" | base64 --decode)
 
-    # Call the migration binary to migrate the database to the latest version
-    make db-migrate
     echo "Port-forwarding is yet not supported in kcp, skipping ..."
     echo "The pods under this scenario will be running on your workload end, hence 'pods' as a resource is not available with current kubeconfig, skipping ..."
   fi

--- a/kcp/ckcp/config.yaml
+++ b/kcp/ckcp/config.yaml
@@ -1,0 +1,25 @@
+---
+# This YAML file allows openshift_dev_setup.sh to fetch values of certain variables.
+# Usage - to be used for overwriting defaults
+
+# CLUSTER_TYPE can only be "openshift" for now.
+CLUSTER_TYPE: openshift
+
+# GIT_URL refers to a git repo to be considered as the source of truth for Argo CD applications.
+GIT_URL: https://github.com/openshift-pipelines/pipeline-service.git
+
+# GIT_REF refers to the git repo's ref to be considered as the source of truth for Argo CD applications.
+GIT_REF: main
+
+# CR_TO_SYNC is a list of the CRs which need to be synced.
+CR_TO_SYNC:
+  - deployments.apps
+  - services
+  - ingresses.networking.k8s.io
+  - networkpolicies.networking.k8s.io
+  - statefulsets.apps
+  - routes.route.openshift.io
+
+# Applications to be deployed on the cluster
+APPS:
+  - pipeline_service # pipeline_service sets up Pipeline Service on the cluster.

--- a/kcp/ckcp/setup-ckcp-on-openshift.sh
+++ b/kcp/ckcp/setup-ckcp-on-openshift.sh
@@ -15,7 +15,8 @@ ARGOCD_MANIFEST="$SCRIPT_DIR/../install-argocd.yaml"
 ARGOCD_NAMESPACE="gitops-service-argocd"
 
 cleanup() {
-  pkill go
+  pkill goreman
+  pkill kubectl
 }
 
 trap cleanup EXIT
@@ -63,6 +64,7 @@ clone-and-setup-ckcp() {
     git clone https://github.com/openshift-pipelines/pipeline-service.git
     pushd pipeline-service
     cp ${SCRIPT_DIR}/openshift_dev_setup.sh ./ckcp/openshift_dev_setup.sh
+    cp ${SCRIPT_DIR}/config.yaml ./ckcp/config.yaml
 
     sed -i 's/\--resources deployments.apps,services,ingresses.networking.k8s.io,pipelines.tekton.dev,pipelineruns.tekton.dev,tasks.tekton.dev,runs.tekton.dev,networkpolicies.networking.k8s.io/\--resources deployments.apps,services,ingresses.networking.k8s.io,networkpolicies.networking.k8s.io,statefulsets.apps,routes.route.openshift.io/' ./images/kcp-registrar/register.sh
     printf "\nUpdated the resources to sync as needed for gitops-service and ckcp to run...\n\n"
@@ -197,6 +199,8 @@ test-gitops-service-e2e-in-kcp-in-ci() {
   make start-e2e &
   make test-e2e
 }
+
+OPENSHIFT_CI="${OPENSHIFT_CI:-false}"
 
 if [[ $OPENSHIFT_CI != "" ]]
 then

--- a/kcp/ckcp/setup-ckcp-on-openshift.sh
+++ b/kcp/ckcp/setup-ckcp-on-openshift.sh
@@ -63,6 +63,7 @@ clone-and-setup-ckcp() {
     pushd "${TMP_DIR}"
     git clone https://github.com/openshift-pipelines/pipeline-service.git
     pushd pipeline-service
+    git checkout edacf0348b2ae693eeb62b940dd618c05b34df62
     cp ${SCRIPT_DIR}/openshift_dev_setup.sh ./ckcp/openshift_dev_setup.sh
     cp ${SCRIPT_DIR}/config.yaml ./ckcp/config.yaml
 


### PR DESCRIPTION
#### Description:

- Pulled out the latest changes from ckcp, integrated with the changes required for managed-gitops in `openshift-dev-env.sh` carefully, and tried maintaining the uniformity as much as possible
- Added a stable commit hash which is tested on clusterbot cluster which focuses on release-0.7; with every new release we need to update the script accordingly on ci as well as in our managed-gitops repo
- Added a better way for the cleanup function

To test the changes just run the `make kcp-test-local-e2e` target against a clusterbot cluster (v4.10/v4.11)

#### Link to JIRA Story (if applicable): Needed [#GITOPSRVC-187](https://issues.redhat.com/browse/GITOPSRVCE-187)
