### PR TITLE
Refactoring the kube-auto make target  (pt: 5/n)

### DIFF
--- a/create-dev-env.sh
+++ b/create-dev-env.sh
@@ -147,8 +147,7 @@ if [ "$1" = "kube-auto" ]; then
   echo " * Postgres secret has been created."
 
   # Wait until postgres pod is running
-  if [[ $OPENSHIFT_CI == "" ]] || [[ $GITOPS_IN_KCP != "true" ]]
-  then
+  if [ "$GITOPS_IN_KCP" != "true" ]; then
     echo " * Wait until Postgres pod is running"
     counter=0
     until kubectl -n gitops get pods | grep postgres | grep '1/1' | grep 'Running' &> /dev/null
@@ -205,7 +204,6 @@ if [ "$1" = "kube-auto" ]; then
     # Do not stop port-forwarding
     echo "Port-forwarding is active. You can stop it with 'kill $KUBE_PID'"
     echo "Or you can find the process with typing: 'sudo lsof -i:5432'"
-    exit 0
   else
     # This else scenario mainly focus on running e2e test with kcp on Openshift CI or in local KCP/CKCP/CPS setups
     # Decode the password from the secret
@@ -214,6 +212,7 @@ if [ "$1" = "kube-auto" ]; then
     echo "Port-forwarding is yet not supported in kcp, skipping ..."
     echo "The pods under this scenario will be running on your workload end, hence 'pods' as a resource is not available with current kubeconfig, skipping ..."
   fi
+  exit 0
 fi
 
 # Binary requirements

--- a/kcp/ckcp/setup-ckcp-on-openshift.sh
+++ b/kcp/ckcp/setup-ckcp-on-openshift.sh
@@ -15,8 +15,8 @@ ARGOCD_MANIFEST="$SCRIPT_DIR/../install-argocd.yaml"
 ARGOCD_NAMESPACE="gitops-service-argocd"
 
 cleanup() {
-  pkill goreman
-  pkill kubectl
+  killall goreman
+  killall kubectl
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
#### Description:
- Remove the OPENSHIFT_CI constraint and only kept it kcp specific
- correct the exit endpoint in kube-auto target

#### Link to JIRA Story (if applicable): Needed [#GITOPSRVC-187](https://issues.redhat.com/browse/GITOPSRVCE-187)

