### PR TITLE
hack: port-forward postgres db from the workload cluster until kcp supports or we migrate to release testing manner

### DIFF
--- a/kcp/ckcp/setup-ckcp-on-openshift.sh
+++ b/kcp/ckcp/setup-ckcp-on-openshift.sh
@@ -196,6 +196,8 @@ test-gitops-service-e2e-in-kcp-in-ci() {
   printf "The Kubeconfig being used for this is:" $KUBECONFIG
   cd ${SCRIPT_DIR}/../../
   make devenv-k8s-e2e
+  KUBECONFIG="" dbnamespace=$(kubectl get pods --selector=app.kubernetes.io/instance=gitops-postgresql-staging --all-namespaces -o yaml | yq e '.items[0].metadata.namespace')
+  KUBECONFIG="" kubectl port-forward -n $dbnamespace svc/gitops-postgresql-staging 5432:5432 &
   kubectl create ns kube-system || true
   make start-e2e &
   make test-e2e


### PR DESCRIPTION
#### Description:

In openshift-ci, the PostgreSQL database is not reachable for that we need to do port-forward, but kcp doesn't support it yet;
We are using `make devenv-k8s-e2e` for creating a testing environment. The long-term solution is to switch to more production-based testing, which we have opened the story for.
The hack, for now, is to check in the workload cluster where the Postgres is being deployed and port-froward from there, hence this PR is about that.

Logs here:

```
[36m09:21:32        cluster-agent | [mgo: downloading github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd
[36m09:21:32        cluster-agent | [mgo: downloading github.com/go-git/go-billy/v5 v5.0.0
[32m09:21:32              backend | [mgo vet ./...
[36m09:21:34        cluster-agent | [mgo vet ./...
[35m09:22:05 appstudio-controller | [mgo run ./main.go --zap-log-level debug --zap-time-encoding=rfc3339nano
[32m09:22:06              backend | [mgo run ./main.go --zap-log-level debug --zap-time-encoding=rfc3339nano
[32m09:22:09              backend | [m2022-09-08T09:22:09.088446265Z	ERROR	setup	Fatal Error: Unsuccessful Migration	{"error": "unable to connect to DB: dial tcp [::1]:5432: connect: connection refused"}
[32m09:22:09              backend | [mmain.main
[32m09:22:09              backend | [m	/go/src/github.com/redhat-appstudio/managed-gitops/backend/main.go:99
[32m09:22:09              backend | [mruntime.main
[32m09:22:09              backend | [m	/usr/local/go/src/runtime/proc.go:250
[32m09:22:09              backend | [mexit status 1
[32m09:22:09              backend | [mmake[2]: *** [run] Error 1
[32m09:22:09              backend | [mmake[2]: Leaving directory `/go/src/github.com/redhat-appstudio/managed-gitops/backend'
```

PR: https://github.com/openshift/release/pull/31857
Logs:  [PR failed logs](https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/31857/rehearse-31857-pull-ci-redhat-appstudio-managed-gitops-main-managed-gitops-e2e-tests-on-kcp/1567798420242960384/build-log.txt) 



#### Link to JIRA Story (if applicable): Needed [#GITOPSRVC-187](https://issues.redhat.com/browse/GITOPSRVCE-187)