### PR TITLE
Improving log statements at INFO level, cleanup log code

### DIFF
--- a/appstudio-controller/Makefile
+++ b/appstudio-controller/Makefile
@@ -103,7 +103,7 @@ build: generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go --zap-log-level debug --zap-time-encoding=rfc3339nano
+	go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
 # more on controller log level configuration: https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/
 
 #.PHONY: docker-build

--- a/argocd.sh
+++ b/argocd.sh
@@ -35,7 +35,7 @@ if [ "$1" = "install" ]; then
     until kubectl -n "$ARGO_CD_NAMESPACE" get secret | grep argocd-initial-admin-secret; do
         ((counter++))
         sleep 1
-        if [ "$counter" -gt 60 ]; then
+        if [ "$counter" -gt 180 ]; then
             echo " --> Error: Cannot find argocd-initial-admin-secret secret."
             exit 1
         fi

--- a/backend-shared/config/db/apicrtodatabasemapping.go
+++ b/backend-shared/config/db/apicrtodatabasemapping.go
@@ -212,5 +212,20 @@ func (dbq *PostgreSQLDatabaseQueries) GetAPICRForDatabaseUID(ctx context.Context
 	*obj = result[0]
 
 	return nil
+}
 
+// GetAsLogKeyValues return a []interface that can be passed to log.Info(...).
+// e.g. log.Info("Creating database resource", obj.GetAsLogKeyValues()...)
+func (obj *APICRToDatabaseMapping) GetAsLogKeyValues() []interface{} {
+	if obj == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{"apiResourceName", obj.APIResourceName,
+		"apiResourceNamespace", obj.APIResourceNamespace,
+		"apiResourceType", obj.APIResourceType,
+		"apiResourceUID", obj.APIResourceUID,
+		"dbRelationKey", obj.DBRelationKey,
+		"dbRelationType", obj.DBRelationType,
+		"namespaceUID", obj.NamespaceUID}
 }

--- a/backend-shared/config/db/application.go
+++ b/backend-shared/config/db/application.go
@@ -338,3 +338,18 @@ func (app *Application) DisposeAppScoped(ctx context.Context, dbq ApplicationSco
 
 	return err
 }
+
+// GetAsLogKeyValues return a []interface that can be passed to log.Info(...).
+// e.g. log.Info("Creating database resource", obj.GetAsLogKeyValues()...)
+func (obj *Application) GetAsLogKeyValues() []interface{} {
+	if obj == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{"applicationID", obj.Application_id,
+		"engineInstanceID", obj.Engine_instance_inst_id,
+		"managedEnvironmentID", obj.Managed_environment_id,
+		"applicationName", obj.Name,
+		"applicationSpecField", obj.Spec_field}
+
+}

--- a/backend-shared/config/db/clusteraccess.go
+++ b/backend-shared/config/db/clusteraccess.go
@@ -151,3 +151,15 @@ func (obj *ClusterAccess) Dispose(ctx context.Context, dbq DatabaseQueries) erro
 	_, err := dbq.DeleteClusterAccessById(ctx, obj.Clusteraccess_user_id, obj.Clusteraccess_managed_environment_id, obj.Clusteraccess_gitops_engine_instance_id)
 	return err
 }
+
+// GetAsLogKeyValues return a []interface that can be passed to log.Info(...).
+// e.g. log.Info("Creating database resource", obj.GetAsLogKeyValues()...)
+func (obj *ClusterAccess) GetAsLogKeyValues() []interface{} {
+	if obj == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{"engineInstance", obj.Clusteraccess_gitops_engine_instance_id,
+		"managedEnvironment", obj.Clusteraccess_managed_environment_id,
+		"userID", obj.Clusteraccess_user_id}
+}

--- a/backend-shared/config/db/clustercredentials.go
+++ b/backend-shared/config/db/clustercredentials.go
@@ -275,3 +275,16 @@ func (obj *ClusterCredentials) Dispose(ctx context.Context, dbq DatabaseQueries)
 	_, err := dbq.DeleteClusterCredentialsById(ctx, obj.Clustercredentials_cred_id)
 	return err
 }
+
+// GetAsLogKeyValues return a []interface that can be passed to log.Info(...).
+// e.g. log.Info("Creating database resource", obj.GetAsLogKeyValues()...)
+func (obj *ClusterCredentials) GetAsLogKeyValues() []interface{} {
+	if obj == nil {
+		return []interface{}{}
+	}
+
+	// We avoid logging the bearer_token or kube_config, as these container sensitive user data.
+	return []interface{}{"host", obj.Host, "kube-config-length", len(obj.Kube_config),
+		"kube-config-context", len(obj.Kube_config_context), "serviceaccount_ns", obj.Serviceaccount_ns,
+		"serviceaccount-bearer-token-length", len(obj.Serviceaccount_bearer_token)}
+}

--- a/backend-shared/config/db/clusteruser.go
+++ b/backend-shared/config/db/clusteruser.go
@@ -195,3 +195,13 @@ func (obj *ClusterUser) Dispose(ctx context.Context, dbq DatabaseQueries) error 
 	_, err := dbq.DeleteClusterUserById(ctx, obj.Clusteruser_id)
 	return err
 }
+
+// GetAsLogKeyValues return a []interface that can be passed to log.Info(...).
+// e.g. log.Info("Creating database resource", obj.GetAsLogKeyValues()...)
+func (obj *ClusterUser) GetAsLogKeyValues() []interface{} {
+	if obj == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{"clusteruser_id", obj.Clusteruser_id, "user_name", obj.User_name}
+}

--- a/backend-shared/config/db/deploymenttoapplicationmapping.go
+++ b/backend-shared/config/db/deploymenttoapplicationmapping.go
@@ -317,3 +317,15 @@ func (obj *DeploymentToApplicationMapping) Dispose(ctx context.Context, dbq Data
 	_, err := dbq.DeleteDeploymentToApplicationMappingByDeplId(ctx, obj.Deploymenttoapplicationmapping_uid_id)
 	return err
 }
+
+// GetAsLogKeyValues return a []interface that can be passed to log.Info(...).
+// e.g. log.Info("Creating database resource", obj.GetAsLogKeyValues()...)
+func (obj *DeploymentToApplicationMapping) GetAsLogKeyValues() []interface{} {
+	if obj == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{"dtamApplicationID", obj.Application_id, "dtamDeploymentName", obj.DeploymentName,
+		"dtamNamespace", obj.DeploymentNamespace, "dtamUID", obj.Deploymenttoapplicationmapping_uid_id,
+		"dtamNamespaceUID", obj.NamespaceUID}
+}

--- a/backend-shared/config/db/gitopsenginecluster.go
+++ b/backend-shared/config/db/gitopsenginecluster.go
@@ -216,3 +216,12 @@ func (obj *GitopsEngineCluster) Dispose(ctx context.Context, dbq DatabaseQueries
 	_, err := dbq.DeleteGitopsEngineClusterById(ctx, obj.Gitopsenginecluster_id)
 	return err
 }
+
+// GetAsLogKeyValues return a []interface that can be passed to log.Info(...).
+// e.g. log.Info("Creating database resource", obj.GetAsLogKeyValues()...)
+func (obj *GitopsEngineCluster) GetAsLogKeyValues() []interface{} {
+	if obj == nil {
+		return []interface{}{}
+	}
+	return []interface{}{"clustercredentials_id", obj.Clustercredentials_id, "gitopsenginecluster_id", obj.Gitopsenginecluster_id}
+}

--- a/backend-shared/config/db/kubernetesresourcetodbresourcemapping.go
+++ b/backend-shared/config/db/kubernetesresourcetodbresourcemapping.go
@@ -127,3 +127,15 @@ func (obj *KubernetesToDBResourceMapping) Dispose(ctx context.Context, dbq Datab
 	_, err := dbq.DeleteKubernetesResourceToDBResourceMapping(ctx, obj)
 	return err
 }
+
+// GetAsLogKeyValues return a []interface that can be passed to log.Info(...).
+// e.g. log.Info("Creating database resource", obj.GetAsLogKeyValues()...)
+func (obj *KubernetesToDBResourceMapping) GetAsLogKeyValues() []interface{} {
+	if obj == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{
+		"k8sResourceType", obj.KubernetesResourceType, "k8sResourceUID", obj.KubernetesResourceUID,
+		"dbRelationType", obj.DBRelationType, "dbRelationKey", obj.DBRelationKey}
+}

--- a/backend-shared/config/db/managedenvironment.go
+++ b/backend-shared/config/db/managedenvironment.go
@@ -233,3 +233,15 @@ func (obj *ManagedEnvironment) Dispose(ctx context.Context, dbq DatabaseQueries)
 	_, err := dbq.DeleteManagedEnvironmentById(ctx, obj.Managedenvironment_id)
 	return err
 }
+
+// GetAsLogKeyValues return a []interface that can be passed to log.Info(...).
+// e.g. log.Info("Creating database resource", obj.GetAsLogKeyValues()...)
+func (obj *ManagedEnvironment) GetAsLogKeyValues() []interface{} {
+	if obj == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{"clusterCredentialsID", obj.Clustercredentials_id,
+		"managedEnvironmentID", obj.Managedenvironment_id,
+		"managedEnvironmentName", obj.Name}
+}

--- a/backend-shared/config/db/queries.go
+++ b/backend-shared/config/db/queries.go
@@ -211,6 +211,8 @@ type ApplicationScopedQueries interface {
 	DeleteDeploymentToApplicationMappingByDeplId(ctx context.Context, id string) (int, error)
 	DeleteDeploymentToApplicationMappingByNamespaceAndName(ctx context.Context, deploymentName string, deploymentNamespace string, namespaceUID string) (int, error)
 
+	// UpdateSyncOperationRemoveApplicationField locates any SyncOperations that reference 'applicationID', and sets the
+	// applicationID field to nil.
 	UpdateSyncOperationRemoveApplicationField(ctx context.Context, applicationId string) (int, error)
 
 	GetApplicationStateById(ctx context.Context, obj *ApplicationState) error

--- a/backend-shared/config/db/syncoperation.go
+++ b/backend-shared/config/db/syncoperation.go
@@ -110,6 +110,8 @@ func (dbq *PostgreSQLDatabaseQueries) DeleteSyncOperationById(ctx context.Contex
 	return deleteResult.RowsAffected(), nil
 }
 
+// UpdateSyncOperationRemoveApplicationField locates any SyncOperations that reference 'applicationID', and sets the
+// applicationID field to nil.
 func (dbq *PostgreSQLDatabaseQueries) UpdateSyncOperationRemoveApplicationField(ctx context.Context, applicationId string) (int, error) {
 
 	if err := validateQueryParamsNoPK(dbq); err != nil {

--- a/backend-shared/config/db/util/util_suite_test.go
+++ b/backend-shared/config/db/util/util_suite_test.go
@@ -5,7 +5,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(zapcore.DebugLevel)))
+})
 
 func TestUtil(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/backend-shared/util/task_retry_loop.go
+++ b/backend-shared/util/task_retry_loop.go
@@ -196,7 +196,7 @@ const (
 func internalTaskRetryLoop(inputChan chan taskRetryLoopMessage, debugName string) {
 
 	ctx := context.Background()
-	log := log.FromContext(ctx).WithValues("task-retry-name", debugName)
+	log := log.FromContext(ctx).WithName("task-retry-loop").WithValues("task-retry-name", debugName)
 
 	// activeTaskMap is the set of tasks currently running in goroutines
 	activeTaskMap := map[string]internalTaskEntry{}
@@ -213,9 +213,12 @@ func internalTaskRetryLoop(inputChan chan taskRetryLoopMessage, debugName string
 
 	for {
 
-		// Every X minutes, report how many tasks are in progress, and how many are waiting
+		// Every X minutes, report how many tasks are in progress, and how many are waiting. This allows us
+		// to identify bottenecks in task retry queues.
 		if time.Now().After(nextReportActiveTasks) {
-			log.Info(fmt.Sprintf("task retry loop status [%v]: waitingTasks: %v, activeTasks: %v ", debugName, len(waitingTaskContainer.waitingTasks), len(activeTaskMap)))
+			log.Info(fmt.Sprintf("task retry loop status [%v]: waitingTasks: %v, activeTasks: %v ", debugName,
+				len(waitingTaskContainer.waitingTasks), len(activeTaskMap)))
+
 			nextReportActiveTasks = time.Now().Add(ReportActiveTasksEveryXMinutes)
 		}
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -57,7 +57,7 @@ build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go --zap-log-level debug --zap-time-encoding=rfc3339nano
+	go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
 # more on controller log level configuration: https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/
 
 ##@ Deployment

--- a/backend/eventloop/application_event_loop/application_event_loop.go
+++ b/backend/eventloop/application_event_loop/application_event_loop.go
@@ -64,7 +64,8 @@ func applicationEventQueueLoop(input chan eventlooptypes.EventLoopMessage, gitop
 
 	ctx := context.Background()
 
-	log := log.FromContext(ctx).WithValues("workspaceID", workspaceID).WithValues("gitOpsDeplID", gitopsDeplID)
+	log := log.FromContext(ctx).WithValues("workspaceID", workspaceID).WithValues("gitOpsDeplID", gitopsDeplID).
+		WithName("application-event-loop")
 
 	log.Info("applicationEventQueueLoop started.")
 	defer log.Info("applicationEventQueueLoop ended.")

--- a/backend/eventloop/application_event_loop/application_event_runner.go
+++ b/backend/eventloop/application_event_loop/application_event_runner.go
@@ -79,7 +79,7 @@ func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent
 	sharedResourceEventLoop *shared_resource_loop.SharedResourceEventLoop, gitopsDeplUID string, namespaceID string, debugContext string) {
 
 	outerContext := context.Background()
-	log := log.FromContext(outerContext)
+	log := log.FromContext(outerContext).WithName("application-event-loop-runner")
 
 	log = log.WithValues("gitopsDeplUID", gitopsDeplUID, "namespaceID", namespaceID, "debugContext", debugContext)
 

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -254,15 +254,12 @@ func (a applicationEventLoopRunner_Action) handleNewGitOpsDeplEvent(ctx context.
 		Spec_field:              specFieldText,
 	}
 
-	a.log.Info("Creating new Application in DB: "+application.Application_id, "appName", appName,
-		"gitopsEngineInstanceID", application.Engine_instance_inst_id, "managedEnvID", application.Managed_environment_id,
-		"spec_field", application.Spec_field)
-
 	if err := dbQueries.CreateApplication(ctx, &application); err != nil {
-		a.log.Error(err, "unable to create application", "application", application, "ownerId", clusterUser.Clusteruser_id)
+		a.log.Error(err, "Unable to create application", application.GetAsLogKeyValues()...)
 
 		return false, nil, nil, deploymentModifiedResult_Failed, err
 	}
+	a.log.Info("Created new Application in DB: "+application.Application_id, application.GetAsLogKeyValues()...)
 
 	requiredDeplToAppMapping := &db.DeploymentToApplicationMapping{
 		Deploymenttoapplicationmapping_uid_id: string(gitopsDeployment.UID),

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -481,14 +481,14 @@ func (a applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplEvent(ctx cont
 		}
 
 		if specFieldResult == application.Spec_field {
-			log.Info("No spec change detected between Application DB entry and GitOpsDeployment CR")
+			log.Info("Processed GitOpsDeployment event: No spec change detected between Application DB entry and GitOpsDeployment CR")
 			// No change required: the application database entry is consistent with the gitopsdepl CR
 		} else {
 
 			shouldUpdateApplication = true
 			application.Spec_field = specFieldResult
 
-			log.Info("Spec change detected between Application DB entry and GitOpsDeployment CR")
+			log.Info("Processed GitOpsDeployment event: Spec change detected between Application DB entry and GitOpsDeployment CR")
 		}
 
 		// If the managed environment changed from what is in the database, we should update the environment
@@ -500,12 +500,11 @@ func (a applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplEvent(ctx cont
 			application.Managed_environment_id = newManagedEnvId
 			shouldUpdateApplication = true
 		}
-
 	}
 
 	// If neither the managed environment, nor the spec field changed, then no need to update the database, so exit.
 	if !shouldUpdateApplication {
-		log.Info("No Application row change detected")
+		log.Info("Processed GitOpsDeployment event: No Application row change detected")
 		return false, application, engineInstance, deploymentModifiedResult_NoChange, nil
 	}
 
@@ -514,12 +513,12 @@ func (a applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplEvent(ctx cont
 
 		return false, nil, nil, deploymentModifiedResult_Failed, err
 	}
-	log.Info("Application updated with ID: " + application.Application_id)
+	log.Info("Processed GitOpsDeployment event: Application updated in database from latest API changes")
 
 	// Create the operation
 	gitopsEngineClient, err := a.getK8sClientForGitOpsEngineInstance(engineInstance)
 	if err != nil {
-		log.Error(err, "unable to retrieve gitopsengineinstance for updated gitopsdepl", "gitopsEngineIstance", engineInstance.EngineCluster_id)
+		log.Error(err, "unable to retrieve gitopsengineinstance for updated gitopsdepl", "gitopsEngineInstance", engineInstance.EngineCluster_id)
 		return false, nil, nil, deploymentModifiedResult_Failed, err
 	}
 
@@ -533,7 +532,7 @@ func (a applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplEvent(ctx cont
 	k8sOperation, dbOperation, err := operations.CreateOperation(ctx, waitForOperation, dbOperationInput, clusterUser.Clusteruser_id,
 		operationNamespace, dbQueries, gitopsEngineClient, log)
 	if err != nil {
-		log.Error(err, "could not create operation", "operation", dbOperation.Operation_id, "namespace", operationNamespace)
+		log.Error(err, "could not create operation")
 		return false, nil, nil, deploymentModifiedResult_Failed, err
 	}
 

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -191,6 +191,8 @@ func (a applicationEventLoopRunner_Action) handleNewGitOpsDeplEvent(ctx context.
 	gitopsDeployment *managedgitopsv1alpha1.GitOpsDeployment, clusterUser *db.ClusterUser, operationNamespace string,
 	dbQueries db.ApplicationScopedQueries) (bool, *db.Application, *db.GitopsEngineInstance, deploymentModifiedResult, error) {
 
+	a.log.Info("Received GitOpsDeployment event for a new GitOpsDeployment resource")
+
 	gitopsDeplNamespace := corev1.Namespace{}
 	if err := a.workspaceClient.Get(ctx, types.NamespacedName{Namespace: gitopsDeployment.ObjectMeta.Namespace,
 		Name: gitopsDeployment.ObjectMeta.Namespace}, &gitopsDeplNamespace); err != nil {
@@ -317,9 +319,11 @@ func (a applicationEventLoopRunner_Action) handleDeleteGitOpsDeplEvent(ctx conte
 		return false, fmt.Errorf("required parameter should not be nil in handleDelete: %v %v", deplToAppMappingList, clusterUser)
 	}
 
-	workspaceNamespace := corev1.Namespace{}
-	if err := a.workspaceClient.Get(ctx, types.NamespacedName{Namespace: a.eventResourceNamespace, Name: a.eventResourceNamespace}, &workspaceNamespace); err != nil {
-		return false, fmt.Errorf("unable to retrieve workspace namespace")
+	a.log.Info("Received GitOpsDeployment event for a GitOpsDeployment resource that no longer exists (or does not exist)")
+
+	apiNamespace := corev1.Namespace{}
+	if err := a.workspaceClient.Get(ctx, types.NamespacedName{Namespace: a.eventResourceNamespace, Name: a.eventResourceNamespace}, &apiNamespace); err != nil {
+		return false, fmt.Errorf("unable to retrieve API namespace")
 	}
 
 	var allErrors error
@@ -332,7 +336,7 @@ func (a applicationEventLoopRunner_Action) handleDeleteGitOpsDeplEvent(ctx conte
 		deplToAppMapping := (*deplToAppMappingList)[idx]
 
 		// Clean up the database entries
-		itemSignalledShutdown, err := a.cleanOldGitOpsDeploymentEntry(ctx, &deplToAppMapping, clusterUser, operationNamespace, workspaceNamespace, dbQueries)
+		itemSignalledShutdown, err := a.cleanOldGitOpsDeploymentEntry(ctx, &deplToAppMapping, clusterUser, operationNamespace, apiNamespace, dbQueries)
 		if err != nil {
 			signalShutdown = false
 
@@ -399,6 +403,8 @@ func (a applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplEvent(ctx cont
 	}
 
 	log := a.log.WithValues("applicationId", deplToAppMapping.Application_id, "gitopsDeplUID", gitopsDeployment.UID)
+
+	a.log.Info("Received GitOpsDeployment event for an existing GitOpsDeployment resource")
 
 	application := &db.Application{Application_id: deplToAppMapping.Application_id}
 	if err := dbQueries.GetApplicationById(ctx, application); err != nil {
@@ -541,8 +547,9 @@ func (a applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplEvent(ctx cont
 
 }
 
-func (a applicationEventLoopRunner_Action) cleanOldGitOpsDeploymentEntry(ctx context.Context, deplToAppMapping *db.DeploymentToApplicationMapping,
-	clusterUser *db.ClusterUser, operationNamespace string, workspaceNamespace corev1.Namespace, dbQueries db.ApplicationScopedQueries) (bool, error) {
+func (a applicationEventLoopRunner_Action) cleanOldGitOpsDeploymentEntry(ctx context.Context,
+	deplToAppMapping *db.DeploymentToApplicationMapping, clusterUser *db.ClusterUser, operationNamespace string,
+	workspaceNamespace corev1.Namespace, dbQueries db.ApplicationScopedQueries) (bool, error) {
 
 	dbApplicationFound := true
 
@@ -562,7 +569,7 @@ func (a applicationEventLoopRunner_Action) cleanOldGitOpsDeploymentEntry(ctx con
 		}
 	}
 
-	log := a.log.WithValues("id", dbApplication.Application_id)
+	log := a.log.WithValues("applicationID", deplToAppMapping.Application_id)
 
 	// Remove the ApplicationState from the database
 	rowsDeleted, err := dbQueries.DeleteApplicationStateById(ctx, deplToAppMapping.Application_id)
@@ -573,9 +580,9 @@ func (a applicationEventLoopRunner_Action) cleanOldGitOpsDeploymentEntry(ctx con
 
 	} else if rowsDeleted == 0 {
 		// Log the warning, but continue
-		log.Info("no application rows deleted for application state", "rowsDeleted", rowsDeleted)
+		log.Info("No ApplicationState rows were found, while cleaning up after deleted GitOpsDeployment", "rowsDeleted", rowsDeleted)
 	} else {
-		log.Info("ApplicationState rows deleted App ID: ", "application_id", deplToAppMapping.Application_id, "rowsDeleted", rowsDeleted)
+		log.Info("ApplicationState rows were successfully deleted, while cleaning up after deleted GitOpsDeployment", "rowsDeleted", rowsDeleted)
 	}
 
 	// Remove DeplToAppMapping
@@ -588,22 +595,23 @@ func (a applicationEventLoopRunner_Action) cleanOldGitOpsDeploymentEntry(ctx con
 		// Log the warning, but continue
 		log.V(sharedutil.LogLevel_Warn).Error(nil, "unexpected number of rows deleted for deplToAppMapping", "rowsDeleted", rowsDeleted)
 	} else {
-		log.Info("Deleted deplToAppMapping by id", "deplToAppMapUid", deplToAppMapping.Deploymenttoapplicationmapping_uid_id)
+		log.Info("While cleaning up after deleted GitOpsDeployment, deleted deplToAppMapping", "deplToAppMapUid", deplToAppMapping.Deploymenttoapplicationmapping_uid_id)
 	}
 
+	// Removed references to Application from all SyncOperations that reference it, to ensure SyncOperation foreign key is nil
 	rowsUpdated, err := dbQueries.UpdateSyncOperationRemoveApplicationField(ctx, deplToAppMapping.Application_id)
 	if err != nil {
-		log.Error(err, "unable to update old sync operations", "applicationId", deplToAppMapping.Application_id)
+		log.Error(err, "unable to update old sync operations")
 		return false, err
 
 	} else if rowsUpdated == 0 {
-		log.Info("no sync operation rows updated, for updating old syncoperations on gitopsdepl deletion")
+		log.Info("no SyncOperation rows updated, for updating old syncoperations on GitOpsDeployment deletion")
 	} else {
-		log.Info("Removed Application Field with ID: " + deplToAppMapping.Application_id)
+		log.Info("Removed references to Application from all SyncOperations that reference it")
 	}
 
 	if !dbApplicationFound {
-		log.Info("While cleaning up old gitopsdepl entries, db application wasn't found, id: " + deplToAppMapping.Application_id)
+		log.Info("While cleaning up old gitopsdepl entries, the Application row wasn't found. No more work to do.")
 		// If the Application CR no longer exists, then our work is done.
 		return true, nil
 	}
@@ -611,19 +619,19 @@ func (a applicationEventLoopRunner_Action) cleanOldGitOpsDeploymentEntry(ctx con
 	// If the Application table entry still exists, finish the cleanup...
 
 	// Remove the Application from the database
-	log.Info("deleting database Application, id: " + deplToAppMapping.Application_id)
+	log.Info("GitOpsDeployment was deleted, so deleting Application row from database")
 	rowsDeleted, err = dbQueries.DeleteApplicationById(ctx, deplToAppMapping.Application_id)
 	if err != nil {
 		// Log the error, but continue
-		log.Error(err, "unable to delete application by id", "appId", deplToAppMapping.Application_id)
+		log.Error(err, "unable to delete application by id")
 	} else if rowsDeleted == 0 {
 		// Log the error, but continue
-		log.V(sharedutil.LogLevel_Warn).Error(nil, "unexpected number of rows deleted for application", "rowsDeleted", rowsDeleted, "appId", deplToAppMapping.Application_id)
+		log.V(sharedutil.LogLevel_Warn).Error(nil, "unexpected number of rows deleted for application", "rowsDeleted", rowsDeleted)
 	}
 
 	gitopsEngineInstance, err := a.sharedResourceEventLoop.GetGitopsEngineInstanceById(ctx, dbApplication.Engine_instance_inst_id, a.workspaceClient, workspaceNamespace, a.log)
 	if err != nil {
-		log := log.WithValues("id", dbApplication.Engine_instance_inst_id)
+		log := log.WithValues("gitopsEngineID", dbApplication.Engine_instance_inst_id)
 
 		if db.IsResultNotFoundError(err) {
 			log.Error(err, "GitOpsEngineInstance could not be retrieved during gitopsdepl deletion handling")

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
@@ -29,7 +29,7 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleSyncRun
 		return false, fmt.Errorf("unable to retrieve namespace '%s': %v", a.eventResourceNamespace, err)
 	}
 
-	clusterUser, _, err := a.sharedResourceEventLoop.GetOrCreateClusterUserByNamespaceUID(ctx, a.workspaceClient, namespace)
+	clusterUser, _, err := a.sharedResourceEventLoop.GetOrCreateClusterUserByNamespaceUID(ctx, a.workspaceClient, namespace, log)
 	if err != nil {
 		return false, fmt.Errorf("unable to retrieve cluster user in handleDeploymentModified, '%s': %v", string(namespace.UID), err)
 	}
@@ -149,7 +149,9 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleSyncRun
 			return false, err
 		}
 
-		if gitopsEngineInstance, err = a.sharedResourceEventLoop.GetGitopsEngineInstanceById(ctx, application.Engine_instance_inst_id, a.workspaceClient, namespace); err != nil {
+		if gitopsEngineInstance, err = a.sharedResourceEventLoop.GetGitopsEngineInstanceById(ctx, application.Engine_instance_inst_id,
+			a.workspaceClient, namespace, a.log); err != nil {
+
 			log.Error(err, "unable to retrieve gitopsengineinstance, on sync run modified", "instanceId", string(application.Engine_instance_inst_id))
 			return false, err
 		}

--- a/backend/eventloop/preprocess_event_loop/preprocess_event_loop.go
+++ b/backend/eventloop/preprocess_event_loop/preprocess_event_loop.go
@@ -26,7 +26,7 @@ import (
 // - detecting cases where the user deletes/creates a resource with the same name, before we have have processed the delete
 // - ensures that 'associatedGitopsDeplUID' field is set for all requests that are processed by the GitOps service.
 //     - if the event is for a GitOpsDeployment, then this field matches the UID of the resource (but for deleted resources, we need to retrieve the uid from the database)
-//     - if the event is for a GitOpsDeploymentSyncRun, then this field matches the UID of the GitOp
+//     - if the event is for a GitOpsDeploymentSyncRun, then this field matches the UID of the GitOpsDeployment that it references
 //
 // Invariants:
 // - The cache should only ever use values from the database. It should be eventually consistent with the database.

--- a/backend/eventloop/preprocess_event_loop/preprocess_event_loop.go
+++ b/backend/eventloop/preprocess_event_loop/preprocess_event_loop.go
@@ -67,7 +67,7 @@ const (
 func preprocessEventLoopRouter(input chan eventlooptypes.EventLoopEvent, nextStep *eventloop.ControllerEventLoop) {
 
 	ctx := context.Background()
-	log := log.FromContext(ctx)
+	log := log.FromContext(ctx).WithName("preprocess-event-loop")
 
 	taskRetryLoop := sharedutil.NewTaskRetryLoop("event-loop-router-retry-loop")
 

--- a/backend/eventloop/preprocess_event_loop/preprocess_event_loop.go
+++ b/backend/eventloop/preprocess_event_loop/preprocess_event_loop.go
@@ -181,7 +181,8 @@ func (task *processEventTask) processEvent(ctx context.Context, newEvent eventlo
 
 		// If the resource we received the event for no longer exists, it has been deleted.
 		// So we will need to use the cache and database values to figure out what resources to clean up.
-		log.Info("CR doesn't exist in namespace, so the resource is likely deleted.", "resource", resource)
+		log.V(sharedutil.LogLevel_Debug).Info("Received event, and CR doesn't exist in namespace, so the resource is likely deleted.",
+			"resource", resource)
 		return processResourceThatDoesntExistInNamespace(ctx, newEvent, nextStep, task.recentUIDCache, task.gitopsDeplSyncRunCache, dbQueries, log)
 	}
 

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -36,7 +36,7 @@ import (
 //   - But this is bad: the database now contains _two different_ managed environment database entries for the same environment A.
 //   - Thus, without mutexes/locking, there is a race condition.
 //   - However, the shared resource event loop prevents this issue, by ensuring that threads are never able to
-//     concurrently create API-namespace database resources at the same time.
+//     concurrently create API-namespace-scoped database resources at the same time.
 type SharedResourceEventLoop struct {
 	inputChannel chan sharedResourceLoopMessage
 }

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -373,11 +373,12 @@ func internalProcessMessage_GetOrCreateClusterUserByNamespaceUID(ctx context.Con
 		if db.IsResultNotFoundError(err) {
 			isNewUser = true
 
-			log.Info("Creating Cluster User with User ID: "+clusterUser.Clusteruser_id, clusterUser.GetAsLogKeyValues()...)
-
 			if err := dbq.CreateClusterUser(ctx, &clusterUser); err != nil {
+				log.Error(err, "Unable to create ClusterUser with User ID: "+clusterUser.Clusteruser_id, clusterUser.GetAsLogKeyValues()...)
 				return nil, false, err
 			}
+			log.Info("Created Cluster User with User ID: "+clusterUser.Clusteruser_id, clusterUser.GetAsLogKeyValues()...)
+
 		} else {
 			return nil, false, err
 		}
@@ -496,12 +497,14 @@ func internalGetOrCreateClusterAccess(ctx context.Context, ca *db.ClusterAccess,
 		return nil, false
 	}
 
-	log.Info(fmt.Sprintf("Creating ClusterAccess for UserID: %s, for ManagedEnvironment: %s", ca.Clusteraccess_user_id,
-		ca.Clusteraccess_managed_environment_id), ca.GetAsLogKeyValues()...)
-
 	if err := dbq.CreateClusterAccess(ctx, ca); err != nil {
+		log.Error(err, fmt.Sprintf("Unable to create ClusterAccess for UserID: %s, for ManagedEnvironment: %s", ca.Clusteraccess_user_id,
+			ca.Clusteraccess_managed_environment_id), ca.GetAsLogKeyValues()...)
+
 		return err, false
 	}
+	log.Info(fmt.Sprintf("Created ClusterAccess for UserID: %s, for ManagedEnvironment: %s", ca.Clusteraccess_user_id,
+		ca.Clusteraccess_managed_environment_id), ca.GetAsLogKeyValues()...)
 
 	return nil, true
 }
@@ -518,11 +521,11 @@ func internalGetOrCreateClusterUserByNamespaceUID(ctx context.Context, namespace
 		if db.IsResultNotFoundError(err) {
 			isNewUser = true
 
-			log.Info("Creating ClusterUser", clusterUser.GetAsLogKeyValues()...)
-
 			if err := dbq.CreateClusterUser(ctx, &clusterUser); err != nil {
+				log.Error(err, "Unable to create ClusterUser", clusterUser.GetAsLogKeyValues()...)
 				return nil, false, err
 			}
+			log.Info("Created ClusterUser", clusterUser.GetAsLogKeyValues()...)
 
 		} else {
 			return nil, false, err

--- a/backend/eventloop/workspace_event_loop.go
+++ b/backend/eventloop/workspace_event_loop.go
@@ -14,7 +14,7 @@ import (
 	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/eventlooptypes"
 	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/shared_resource_loop"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -274,7 +274,7 @@ func handleOrphaned(ctx context.Context, event eventlooptypes.EventLoopMessage, 
 	if event.Event.ReqResource == eventlooptypes.GitOpsDeploymentSyncRunTypeName {
 
 		syncRunCR := &v1alpha1.GitOpsDeploymentSyncRun{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      event.Event.Request.Name,
 				Namespace: event.Event.Request.Namespace,
 			},
@@ -316,7 +316,7 @@ func unorphanResourcesIfPossible(ctx context.Context, event eventlooptypes.Event
 
 		// Retrieve the gitopsdepl
 		gitopsDeplCR := &v1alpha1.GitOpsDeployment{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      event.Event.Request.Name,
 				Namespace: event.Event.Request.Namespace,
 			},

--- a/backend/eventloop/workspace_event_loop.go
+++ b/backend/eventloop/workspace_event_loop.go
@@ -132,7 +132,7 @@ func workspaceEventLoopRouter(input chan workspaceEventLoopMessage, workspaceID 
 
 	ctx := context.Background()
 
-	log := log.FromContext(ctx).WithValues("workspaceID", workspaceID)
+	log := log.FromContext(ctx).WithValues("workspaceID", workspaceID).WithName("workspace-event-loop")
 
 	log.Info("workspaceEventLoopRouter started")
 	defer log.Info("workspaceEventLoopRouter ended.")

--- a/backend/eventloop/workspace_resource_event_loop.go
+++ b/backend/eventloop/workspace_resource_event_loop.go
@@ -259,7 +259,8 @@ func internalProcessWorkspaceResourceMessage(ctx context.Context, msg workspaceR
 		}
 
 		// Ask the shared resource loop to ensure the managed environment is reconciled
-		_, err := sharedResourceLoop.ReconcileSharedManagedEnv(ctx, msg.apiNamespaceClient, *namespace, req.Name, req.Namespace, false, shared_resource_loop.DefaultK8sClientFactory{})
+		_, err := sharedResourceLoop.ReconcileSharedManagedEnv(ctx, msg.apiNamespaceClient, *namespace, req.Name, req.Namespace,
+			false, shared_resource_loop.DefaultK8sClientFactory{}, log)
 		if err != nil {
 			return true, fmt.Errorf("unable to reconcile shared managed env: %v", err)
 		}

--- a/backend/eventloop/workspace_resource_event_loop.go
+++ b/backend/eventloop/workspace_resource_event_loop.go
@@ -20,7 +20,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// workspaceResourceEventLoop is responsible for handling workspace-scoped events, like events for RepositoryCredentials resources.
+// workspaceResourceEventLoop is responsible for handling events for API-namespaced-scoped resources, like events for RepositoryCredentials resources.
+// An api-namespace-scoped resources are resources that can be used by (and reference from) multiple GitOpsDeployments.
+//
+// For example, a ManagedEnvironment could be referenced by 2 separate GitOpsDeployments in a namespace.
+//
 // NOTE: workspaceResourceEventLoop should only be called from workspace_event_loop.go.
 type workspaceResourceEventLoop struct {
 	inputChannel chan workspaceResourceLoopMessage

--- a/cluster-agent/Makefile
+++ b/cluster-agent/Makefile
@@ -96,7 +96,7 @@ build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go --zap-log-level debug --zap-time-encoding=rfc3339nano
+	go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
 # more on controller log level configuration: https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/
 
 # docker-build: test ## Build docker image with the manager.

--- a/cluster-agent/controllers/argoproj.io/namespace_reconciler.go
+++ b/cluster-agent/controllers/argoproj.io/namespace_reconciler.go
@@ -354,9 +354,14 @@ func deleteOrphanedApplications(argoApplications []appv1.Application, processedA
 	})
 
 	// Iterate through all Argo CD applications and delete applications which are not having entry in DB.
-	log.V(sharedutil.LogLevel_Debug).Info("Deleting orphaned Argo CD Aplications")
 	var deletedOrphanedApplications []appv1.Application
 	for _, application := range shuffledList {
+
+		// Skip Applications not created by the GitOps Service
+		if value, exists := application.Labels[controllers.ArgoCDApplicationDatabaseIDLabel]; !exists || value == "" {
+			continue
+		}
+
 		if _, ok := processedApplicationIds[application.Labels["databaseID"]]; !ok {
 			if err := controllers.DeleteArgoCDApplication(ctx, application, client, log); err != nil {
 				log.Error(err, "unable to delete an orphaned Argo CD Application "+application.Name)

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
@@ -220,13 +220,14 @@ func (task *processOperationEventTask) internalPerformTask(taskContext context.C
 
 	// If the operation is in waiting state, update it to in-progress before we start processing it.
 	if dbOperation.State == db.OperationState_Waiting {
-		log.V(sharedutil.LogLevel_Debug).Info("Updating OperationState to InProgress")
 		dbOperation.State = db.OperationState_In_Progress
 
 		if err := dbQueries.UpdateOperation(taskContext, &dbOperation); err != nil {
-			log.Error(err, "unable to update Operation state")
+			log.Error(err, "Unable to update Operation state")
 			return nil, shouldRetryTrue, fmt.Errorf("unable to update Operation, err: %v", err)
 		}
+		log.V(sharedutil.LogLevel_Debug).Info("Updated OperationState to InProgress")
+
 	}
 
 	// 3) Find the Argo CD instance that is targeted by this operation.
@@ -492,10 +493,8 @@ func processOperation_Application(ctx context.Context, dbOperation db.Operation,
 					return true, err
 				}
 			}
-
-			log.Info("Creating Argo CD Application CR")
 			if err := eventClient.Create(ctx, app, &client.CreateOptions{}); err != nil {
-				log.Error(err, "unable to create Argo CD Application CR")
+				log.Error(err, "Unable to create Argo CD Application CR")
 				// This may or may not be salvageable depending on the error; ultimately we should figure out which
 				// error messages mean unsalvageable, and not wait for them.
 				return true, err

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
@@ -183,7 +183,7 @@ func (task *processOperationEventTask) internalPerformTask(taskContext context.C
 	if err := eventClient.Get(taskContext, client.ObjectKeyFromObject(operationCR), operationCR); err != nil {
 		if apierr.IsNotFound(err) {
 			// If the resource doesn't exist, so our job is done.
-			log.V(sharedutil.LogLevel_Debug).Info("Received a request for an operation CR that doesn't exist")
+			log.V(sharedutil.LogLevel_Debug).Info("Received a K8s request for an Operation CR that doesn't exist")
 
 			return nil, shouldRetryFalse, nil
 
@@ -203,7 +203,7 @@ func (task *processOperationEventTask) internalPerformTask(taskContext context.C
 
 		if db.IsResultNotFoundError(err) {
 			// no corresponding db operation, so no work to do
-			log.V(sharedutil.LogLevel_Warn).Info("Received operation requested for operation DB entry that doesn't exist")
+			log.V(sharedutil.LogLevel_Warn).Info("Received a K8 request for an Operation resource, but the referenced DB Operation Row doesn't exist")
 			return nil, shouldRetryFalse, nil
 		} else {
 			// some other generic error

--- a/cluster-agent/controllers/managed-gitops/operation_controller.go
+++ b/cluster-agent/controllers/managed-gitops/operation_controller.go
@@ -57,9 +57,6 @@ type OperationReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile
 func (r *OperationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	contextLog := log.FromContext(ctx)
-
-	contextLog.Info("Operation event seen in reconciler: " + req.NamespacedName.String())
 
 	r.ControllerEventLoop.EventReceived(req, r.Client)
 

--- a/cluster-agent/controllers/util.go
+++ b/cluster-agent/controllers/util.go
@@ -48,11 +48,11 @@ func DeleteArgoCDApplication(ctx context.Context, appFromList appv1.Application,
 	if err := eventClient.Get(ctx, client.ObjectKeyFromObject(app), app); err != nil {
 
 		if apierr.IsNotFound(err) {
-			log.Info("unable to locate application which previously existed")
+			// The Application no longer exists: no work to do.
 			return nil
 		}
 
-		log.Error(err, "unable to retrieve application which previously existed")
+		log.Error(err, "Unable to retrieve Argo CD Application which we are attempting to delete")
 		return err
 	}
 


### PR DESCRIPTION
#### Description:
- This general idea behind this PR is that I have been looking at the log statements that are being output as the GitOps Service runs, and making sure that the INFO-level log statements are outputing the actions that are taking place, and why.
    - Previously, the INFO log statments did not contain enough information/context, or they did not exist at all.
    - Now we should have INFO level log statements for database entry creation/modification/deletion, and resource creation/modification/deletion.
    - It's not (yet) perfect, but it's definitely a major improvement.

- Other log statement refeactoring: 
    - Switch log output to default to INFO, rather than DEBUG
    - Add more INFO statements to better explain what's going on
    - Shift some INFO statements to DEBUG
    - Improve INFO log statement text: make it more obvious why an action is occurring
    - Reduce the number of key/value pairs used on log statements, by shifting those key value pairs into the function itself

#### Link to JIRA Story (if applicable): Part of work for [GITOPSRVCE-67](https://issues.redhat.com/browse/GITOPSRVCE-67)
