### PR TITLE
Kustomize overlay with GitOps Service KCP Manifests (Solves: #GITOPSRVC-209)

### DIFF
--- a/manifests/kcp-resources/argocd-cluster-config.yaml
+++ b/manifests/kcp-resources/argocd-cluster-config.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-cluster-config
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+type: Opaque
+stringData:
+  name: in-cluster
+  namespace: "$ARGOCD_NAMESPACE"
+  server: https://kubernetes.default.svc
+  config: |
+    {
+      "tlsClientConfig": {
+        "insecure": true
+      }
+    }

--- a/manifests/kcp-resources/kube-system-namespace.yaml
+++ b/manifests/kcp-resources/kube-system-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-system

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -1,0 +1,77 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+
+# APIExport(s)
+- ../appstudio-shared/config/kcp/apiexport_gitopsrvc_appstudioshared.yaml
+- ../backend-shared/config/kcp/apiexport_gitopsrvc_backendshared.yaml
+
+# APIResourceSchema(s)
+- ../backend-shared/config/kcp/apiresourceschema_gitopsrvc_backendshared.yaml
+- ../appstudio-shared/config/kcp/apiresourceschema_gitopsrvc_appstudioshared.yaml
+
+# AppStudio-controller RBAC
+- appstudio-controller-rbac/appstudio-controller-rbac.yaml
+
+# Backend RBAC
+- backend-rbac/managed-gitops-backend-controller-manager-metrics-service.yaml
+- backend-rbac/managed-gitops-backend-controller-manager_serviceaccount.yaml
+- backend-rbac/managed-gitops-backend-leader-election-rolebinding.yaml
+- backend-rbac/managed-gitops-backend-leader-election-role.yaml
+- backend-rbac/managed-gitops-backend-manager-config.yaml
+- backend-rbac/managed-gitops-backend-manager-rolebinding.yaml
+- backend-rbac/managed-gitops-backend-manager-role.yaml
+- backend-rbac/managed-gitops-backend-metrics-leader.yaml
+- backend-rbac/managed-gitops-backend-proxy-rolebinding.yaml
+- backend-rbac/managed-gitops-backend-proxy-role.yaml
+
+# Cluster-agent RBAC
+- cluster-agent-rbac/managed-gitops-clusteragent-controller-manager-metrics-service.yaml
+- cluster-agent-rbac/managed-gitops-clusteragent-controller-manager_serviceaccount.yaml
+- cluster-agent-rbac/managed-gitops-clusteragent-leader-election-rolebinding.yaml
+- cluster-agent-rbac/managed-gitops-clusteragent-leader-election-role.yaml
+- cluster-agent-rbac/managed-gitops-clusteragent-manager-config.yaml
+- cluster-agent-rbac/managed-gitops-clusteragent-manager-rolebinding.yaml
+- cluster-agent-rbac/managed-gitops-clusteragent-manager-role.yaml
+- cluster-agent-rbac/managed-gitops-clusteragent-metrics-leader.yaml
+- cluster-agent-rbac/managed-gitops-clusteragent-proxy-rolebinding.yaml
+- cluster-agent-rbac/managed-gitops-clusteragent-proxy-role.yaml
+
+# Workloads
+- managed-gitops-appstudio-controller-deployment.yaml
+- managed-gitops-backend-deployment.yaml
+- managed-gitops-clusteragent-deployment.yaml
+- postgresql-staging/postgresql-staging.yaml
+
+# Route(s)
+- routes.yaml
+
+# 'gitops-service-argocd' Namespace
+- staging-cluster-resources/argo-cd-namespace.yaml
+
+
+# Replace ${ARGO_CD_NAMESPACE}
+patches:
+- target:
+    kind: Secret
+    name: argocd-cluster-config
+  patch: |-
+    - op: replace
+      path: /stringData/namespace
+      value: gitops-service-argocd
+- target:
+    kind: Deployment
+    name: managed-gitops-backend-service
+    namespace: gitops
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/1/env/0/value
+      value: gitops-service-argocd
+- target:
+    kind: Deployment
+    name: managed-gitops-clusteragent-service
+    namespace: gitops
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/1/env/0/value
+      value: gitops-service-argocd


### PR DESCRIPTION
#### Description:
- a kustomize YAML file that points to all the manifests in our repository that are responsible for deploying to KCP
- For now, the kustomisation contains, APIExoorts, APIResourceSchema, Namespace creation for `kube-system`, `gitops-service-argocd`, RBAC's, Workloads, Routes, and a hack for `in-cluster-config` secret mount.
- We have scripts ready for testing against local kcp (ckcp) or using kcp service (CPS), both of the scripts were using some hacks in order to work ArgoCD with sync targets. One of which is included in the kustomisation file which is mounting a secret for `argocd-cluster-config`, located [here](https://github.com/samyak-jn/managed-gitops/blob/kustomize-kcp-manifests-for-gitops/manifests/kcp-resources/argocd-cluster-config.yaml). For another [workaround](https://github.com/samyak-jn/managed-gitops/blob/kustomize-kcp-manifests-for-gitops/kcp/setup-kcp-cps.sh#L67-117) where we were mounting KCP kubeconfig to argocd-server and argocd-controller, we still need to check what's a better way to do this in such scenarios.

- Note: This is the first initial draft, which hasn't been tested yet in production or testing. There are some ToDo(s) within the file that needs to be taken care of. Also, PR #226 needs to go in before this^


#### Link to JIRA Story (if applicable): [GITOPSRVCE-209](https://issues.redhat.com/browse/GITOPSRVCE-209)