### PR TITLE
Setup service provider and user workspace 

### DIFF
--- a/kcp/utils.sh
+++ b/kcp/utils.sh
@@ -12,6 +12,9 @@ ARGOCD_NAMESPACE="gitops-service-argocd"
 
 
 readKUBECONFIGPath() {
+    if [ "$CPS_KUBECONFIG" != "" ]; then
+      return
+    fi
     read -p "Please enter path to CPS KUBECONFIG: " CPS_KUBECONFIG
     if [ ! -f "$CPS_KUBECONFIG" ]; then
       echo "unable to find KUBECONFIG file at path: $CPS_KUBECONFIG"
@@ -21,7 +24,7 @@ readKUBECONFIGPath() {
 
 createAndEnterWorkspace() {
     WORKSPACE=$1
-    KUBECONFIG="$CPS_KUBECONFIG" kubectl config use-context kcp-stable
+    KUBECONFIG="$CPS_KUBECONFIG" kubectl kcp ws
 
     # Opens a web browser to authenticate to your RH SSO acount
     KUBECONFIG="$CPS_KUBECONFIG" kubectl api-resources
@@ -138,7 +141,7 @@ runGitOpsService() {
     KUBECONFIG="${CPS_KUBECONFIG}" make devenv-docker
 
     echo "Running gitops service controllers"
-    KUBECONFIG="${CPS_KUBECONFIG}" make start-e2e
+    KUBECONFIG="${CPS_KUBECONFIG}" make start-e2e &
 }
 
 registerSyncTarget() {

--- a/kcp/utils.sh
+++ b/kcp/utils.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+set -ex
+
+CPS_KUBECONFIG="${CPS_KUBECONFIG:-$(realpath kcp/cps-kubeconfig)}"
+WORKLOAD_KUBECONFIG="${WORKLOAD_KUBECONFIG:-$HOME/.kube/config}"
+SYNCER_IMAGE="${SYNCER_IMAGE:-ghcr.io/kcp-dev/kcp/syncer:v0.8.2}"
+SYNCER_MANIFESTS=$(mktemp -d)/cps-syncer.yaml
+
+ARGOCD_MANIFEST="$(realpath kcp/install-argocd.yaml)"
+ARGOCD_NAMESPACE="gitops-service-argocd"
+
+
+readKUBECONFIGPath() {
+    read -p "Please enter path to CPS KUBECONFIG: " CPS_KUBECONFIG
+    if [ ! -f "$CPS_KUBECONFIG" ]; then
+      echo "unable to find KUBECONFIG file at path: $CPS_KUBECONFIG"
+      exit 1
+    fi
+}
+
+createAndEnterWorkspace() {
+    WORKSPACE=$1
+    KUBECONFIG="$CPS_KUBECONFIG" kubectl config use-context kcp-stable
+
+    # Opens a web browser to authenticate to your RH SSO acount
+    KUBECONFIG="$CPS_KUBECONFIG" kubectl api-resources
+
+    # Create a new workspace if it doesn't exist
+    if KUBECONFIG="$CPS_KUBECONFIG" kubectl get workspaces "${WORKSPACE}"; then
+        echo "Workspace $WORKSPACE already exists"
+    else 
+        KUBECONFIG="$CPS_KUBECONFIG" kubectl kcp ws create "$WORKSPACE"
+    fi
+
+    KUBECONFIG="$CPS_KUBECONFIG" kubectl kcp ws use "$WORKSPACE"
+    KUBECONFIG="$CPS_KUBECONFIG" kubectl create ns kube-system || true    
+}
+
+create_kubeconfig_secret() {
+    sa_name=$1
+    sa_secret_name=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get sa $sa_name -n $ARGOCD_NAMESPACE -o=jsonpath='{.secrets[0].name}')
+
+    ca=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get secret/$sa_secret_name -n $ARGOCD_NAMESPACE -o jsonpath='{.data.ca\.crt}')
+    token=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get secret/$sa_secret_name -n $ARGOCD_NAMESPACE -o jsonpath='{.data.token}' | base64 --decode)
+    namespace=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get secret/$sa_secret_name -n $ARGOCD_NAMESPACE -o jsonpath='{.data.namespace}' | base64 --decode)
+
+    server=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl config view -o jsonpath='{.clusters[?(@.name == "workspace.kcp.dev/current")].cluster.server}')
+
+    secret_name=$2
+    kubeconfig_secret="
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: ${secret_name}
+  namespace: ${ARGOCD_NAMESPACE}
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - name: default-cluster
+      cluster:
+        certificate-authority-data: ${ca}
+        server: ${server}
+    contexts:
+    - name: default-context
+      context:
+        cluster: default-cluster
+        namespace: ${ARGOCD_NAMESPACE}
+        user: default-user
+    current-context: default-context
+    users:
+    - name: default-user
+      user:
+        token: ${token}
+"
+
+    echo "${kubeconfig_secret}" | KUBECONFIG="${CPS_KUBECONFIG}" kubectl apply -f -
+}
+
+
+installArgoCD() {
+    echo "Installing Argo CD resources in workspace $WORKSPACE and namespace $ARGOCD_NAMESPACE"
+    KUBECONFIG="${CPS_KUBECONFIG}" kubectl create ns $ARGOCD_NAMESPACE || true
+    KUBECONFIG="${CPS_KUBECONFIG}" kubectl apply -f $ARGOCD_MANIFEST -n $ARGOCD_NAMESPACE
+
+    echo "Creating KUBECONFIG secrets for argocd server and argocd application controller service accounts"
+    create_kubeconfig_secret "argocd-server" "kcp-kubeconfig-controller"
+    create_kubeconfig_secret "argocd-application-controller" "kcp-kubeconfig-server"
+
+    echo "Verifying if argocd components are up and running after mounting kubeconfig secrets"
+    KUBECONFIG="${CPS_KUBECONFIG}" kubectl wait --for=condition=available deployments/argocd-server -n $ARGOCD_NAMESPACE --timeout 3m
+    count=0
+    while [ $count -lt 30 ]
+    do
+        count=`expr $count + 1`
+        replicas=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get statefulsets argocd-application-controller -n $ARGOCD_NAMESPACE -o jsonpath='{.spec.replicas}')
+        ready_replicas=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get statefulsets argocd-application-controller -n $ARGOCD_NAMESPACE -o jsonpath='{.status.readyReplicas}')
+        if [ "$replicas" -eq "$ready_replicas" ]; then 
+            break
+        fi
+        if [ $count -eq 30 ]; then 
+            echo "Statefulset argocd-application-controller does not have the required replicas"
+            exit 1
+        fi
+    done
+
+    cat <<EOF | KUBECONFIG="${CPS_KUBECONFIG}" kubectl apply -n $ARGOCD_NAMESPACE -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-cluster-config
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+type: Opaque
+stringData:
+  name: in-cluster
+  namespace: "$ARGOCD_NAMESPACE"
+  server: https://kubernetes.default.svc
+  config: |
+    {
+      "tlsClientConfig": {
+        "insecure": true
+      }
+    }
+EOF
+
+    echo "Argo CD is successfully installed in namespace $ARGOCD_NAMESPACE"
+}
+
+runGitOpsService() {
+    echo "Preparing to run gitops service against KCP"
+    ./stop-dev-env.sh || true
+    ./delete-dev-env.sh || true
+
+    KUBECONFIG="${CPS_KUBECONFIG}" make devenv-docker
+
+    echo "Running gitops service controllers"
+    KUBECONFIG="${CPS_KUBECONFIG}" make start-e2e
+}
+
+registerSyncTarget() {
+    # Extract the Workload Cluster name from the KUBECONFIG
+    WORKLOAD_CLUSTER=$(KUBECONFIG="${WORKLOAD_KUBECONFIG}" kubectl config view --minify -o jsonpath='{.clusters[].name}' | awk -F[:] '{print $1}')
+
+    WORKLOAD_CLUSTER=${WORKLOAD_CLUSTER:22}
+
+    echo "Generating syncer manifests for OCP SyncTarget $WORKLOAD_CLUSTER"
+    KUBECONFIG="$CPS_KUBECONFIG" kubectl kcp workload sync "$WORKLOAD_CLUSTER"  --resources "services,statefulsets.apps,deployments.apps,routes.route.openshift.io" --syncer-image "$SYNCER_IMAGE" --output-file "$SYNCER_MANIFESTS" --namespace kcp-syncer
+
+    # Deploy the syncer to the SyncTarget
+    KUBECONFIG="${WORKLOAD_KUBECONFIG}" kubectl apply -f "$SYNCER_MANIFESTS"
+
+    echo "Waiting for the SyncTarget resource to reach ready state"
+    KUBECONFIG="${CPS_KUBECONFIG}" kubectl wait --for=condition=Ready=true synctarget/"${WORKLOAD_CLUSTER}" --timeout 3m
+}

--- a/kcp/utils.sh
+++ b/kcp/utils.sh
@@ -141,14 +141,14 @@ runGitOpsService() {
     KUBECONFIG="${CPS_KUBECONFIG}" make devenv-docker
 
     echo "Running gitops service controllers"
-    KUBECONFIG="${CPS_KUBECONFIG}" make start &
+    KUBECONFIG="${CPS_KUBECONFIG}" make start
 }
 
 registerSyncTarget() {
     # Extract the Workload Cluster name from the KUBECONFIG
     WORKLOAD_CLUSTER=$(KUBECONFIG="${WORKLOAD_KUBECONFIG}" kubectl config view --minify -o jsonpath='{.clusters[].name}' | awk -F[:] '{print $1}')
 
-    WORKLOAD_CLUSTER=${WORKLOAD_CLUSTER:22}
+    WORKLOAD_CLUSTER=${WORKLOAD_CLUSTER:0:22}
 
     echo "Generating syncer manifests for OCP SyncTarget $WORKLOAD_CLUSTER"
     KUBECONFIG="$CPS_KUBECONFIG" kubectl kcp workload sync "$WORKLOAD_CLUSTER"  --resources "services,statefulsets.apps,deployments.apps,routes.route.openshift.io" --syncer-image "$SYNCER_IMAGE" --output-file "$SYNCER_MANIFESTS" --namespace kcp-syncer

--- a/kcp/utils.sh
+++ b/kcp/utils.sh
@@ -150,6 +150,14 @@ registerSyncTarget() {
 
     WORKLOAD_CLUSTER=${WORKLOAD_CLUSTER:0:22}
 
+    if [ "${WORKLOAD_CLUSTER: -1}" == "-" ]; then
+      WORKLOAD_CLUSTER="${WORKLOAD_CLUSTER%?}"
+    fi
+
+    if [ "${WORKLOAD_CLUSTER:0:1}" == "-" ]; then
+      WORKLOAD_CLUSTER="${WORKLOAD_CLUSTER#?}"
+    fi
+
     echo "Generating syncer manifests for OCP SyncTarget $WORKLOAD_CLUSTER"
     KUBECONFIG="$CPS_KUBECONFIG" kubectl kcp workload sync "$WORKLOAD_CLUSTER"  --resources "services,statefulsets.apps,deployments.apps,routes.route.openshift.io" --syncer-image "$SYNCER_IMAGE" --output-file "$SYNCER_MANIFESTS" --namespace kcp-syncer
 

--- a/kcp/utils.sh
+++ b/kcp/utils.sh
@@ -141,7 +141,7 @@ runGitOpsService() {
     KUBECONFIG="${CPS_KUBECONFIG}" make devenv-docker
 
     echo "Running gitops service controllers"
-    KUBECONFIG="${CPS_KUBECONFIG}" make start-e2e &
+    KUBECONFIG="${CPS_KUBECONFIG}" make start &
 }
 
 registerSyncTarget() {

--- a/kcp/virtual-workspace.sh
+++ b/kcp/virtual-workspace.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -ex
+
+source utils.sh
+
+SERVICE_WS="service-provider-$(echo $RANDOM)"
+USER_WS="user-$(echo $RANDOM)"
+
+export GITOPS_IN_KCP="true"
+
+readKUBECONFIGPath
+
+# Create and initialize server provide namespace
+createAndEnterWorkspace SERVICE_WS
+
+registerSyncTarget
+
+# Install Argo CD and GitOps Service components in service provider workspace
+installArgoCD
+
+KUBECONFIG="${CPS_KUBECONFIG}" make apply-kcp-api-all
+
+runGitOpsService
+
+createAndEnterWorkspace USER_WS
+
+switchToWorkspace() {
+    kubectl config use-context kcp-stable
+    kubectl kcp ws use $1
+}
+
+createAPIBinding() {
+    exportName=$1
+    switchToWorkspace SERVICE_WS
+    url=$(kubectl get workspaces sample -o jsonpath='{.status.URL}')
+    path=$($url\#\#*/)
+
+cat <<EOF | kubectl apply -n -f -
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIBinding
+metadata:
+  name: ${exportName}
+spec:
+  acceptedPermissionClaims:
+  - group: ""
+    resource: "secrets"
+  - group: ""
+    resource: "namespaces"
+  reference:
+    workspace:
+      path: ${path}
+      exportName: ${exportName}
+EOF
+
+}
+
+createAPIBinding gitopsrvc-backend-shared
+createAPIBinding gitopsrvc-appstudio-shared

--- a/kcp/virtual-workspace.sh
+++ b/kcp/virtual-workspace.sh
@@ -33,9 +33,7 @@ identityHash=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get apiexports.apis.kcp.de
 # Create permissions to bind APIExports. We need this workaround until KCP fixes the bug in their admission logic. Ref: https://github.com/kcp-dev/kcp/issues/1939  
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws
 bindingName=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get clusterrolebinding | grep $SERVICE_WS | awk '{print $1}')
-echo $bindingName
 userName=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get clusterrolebindings $bindingName -o jsonpath='{.subjects[0].name}')
-echo $userName
 
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws use $SERVICE_WS
 cat <<EOF | KUBECONFIG="${CPS_KUBECONFIG}" kubectl apply -f -

--- a/kcp/virtual-workspace.sh
+++ b/kcp/virtual-workspace.sh
@@ -10,9 +10,9 @@ USER_WS="user-$(echo $RANDOM)"
 export GITOPS_IN_KCP="true"
 
 cleanup_workspace() {
-    kubectl kcp ws
-    kubectl delete workspace $SERVICE_WS || true
-    kubectl delete workspace $USER_WS || true
+    KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws
+    KUBECONFIG="${CPS_KUBECONFIG}" kubectl delete workspace $SERVICE_WS || true
+    KUBECONFIG="${CPS_KUBECONFIG}" kubectl delete workspace $USER_WS || true
     pkill go
 }
 

--- a/kcp/virtual-workspace.sh
+++ b/kcp/virtual-workspace.sh
@@ -26,6 +26,8 @@ createAndEnterWorkspace "$SERVICE_WS"
 echo "Creating APIExports and APIResourceSchemas in workspace $SERVICE_WS"
 KUBECONFIG="${CPS_KUBECONFIG}" make apply-kcp-api-all
 
+## Add identityHash for the exports
+
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws
 bindingName=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get clusterrolebinding | grep $SERVICE_WS | awk '{print $1}')
 echo $bindingName
@@ -95,6 +97,10 @@ EOF
 echo "Creating APIBindings in workspace $USER_wS"
 createAPIBinding gitopsrvc-backend-shared
 createAPIBinding gitopsrvc-appstudio-shared
+
+# Checking if the bindings are in Ready state
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl wait --for=condition=Ready apibindings/gitopsrvc-appstudio-shared
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl wait --for=condition=Ready apibindings/gitopsrvc-backend-shared
 
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws use $SERVICE_WS


### PR DESCRIPTION
#### Description:
- Create a script to create service provider and user workspaces
- Create APIExports and APISchemas in the service workspace
- Create APIBindings in the user workspace
- Install Argo CD and GitOps Service in the service workspace
- Move the common functions to utils.sh to avoid duplicates.

#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-207

#### How to test:
1. Login to an OCP cluster
2. Login to CPS and set the path to CPS KUBECONFIG and run the script in the root directory
```shell

$ export CPS_KUBECONFIG=<path-to-CPS-kubeconfig>

$ ./kcp/virtual-workspace.sh
```
3.  Verify if the GitOps service controllers are up and running
4. Copy the KUBECONFIG to a different location and open a new tab. We don't want to change the KUBECONFIG that is referenced by the GitOps service running in the service provider workspace.
5. In the newly opened tab, switch to the user workspace and create a sample GitOpsDeployment
```shell
$ export KUBECONFIG=<new-path-kubeconfig-copy>

$ kubectl kcp ws
$ kubectl kcp ws use <user-workspace-name>     -----> user workspace name will be available in the script logs

$ kubectl create ns jane
$ kubectl apply -f examples/m2-demo/jane-deployment.yaml
```
6. Verify if the GitOps service backend controllers in the service workspace reacted to the GitOpsDepl resource created in the user workspace.

```shell
12:25:28              backend | 2022-09-21T12:25:28.597561023+05:30	DEBUG	Task retry loop: task completed 'GitOpsDeployment-gitops-depl-jane-19acc71d-eb6c-464a-ac2f-71d24faa7957'	{"task-retry-name": "event-loop-router-retry-loop", "shouldRetry": false}
```