### PR TITLE
Setup make targets for E2E testing on KCP virtual workspaces (Solves: #GITOPSRVC-212)

### DIFF
--- a/kcp/kcp-e2e/setup-ws-e2e.sh
+++ b/kcp/kcp-e2e/setup-ws-e2e.sh
@@ -2,20 +2,22 @@
 
 set -ex
 
-source ./kcp/utils.sh
+SCRIPTPATH="$(
+  cd -- "$(dirname "$0")" >/dev/null 2>&1 || exit
+  pwd -P
+)"
 
+source "${SCRIPTPATH}/../utils.sh"
+
+PARENT_E2E_WS="gitops-service-e2e-test"
 SERVICE_WS="gitops-service-provider"
 USER_WS="user-workspace"
 
-# After setting up the ws, the kubeconfigs for respective ws will be saved here
-SERVICE_WS_CONFIG="/tmp/service-provider-workspace.yaml"
-USER_WS_CONFIG="/tmp/user-provider-workspace.yaml"
-
 # Topology for the virtual workspace:
-# - user root
-#   - gitops-service-e2e-test
-#     - gitops-service-provider
-#     - user-workspace
+# - user root ex: root:fs:fsfs:redhat-sso-samyak   <---------------- workload
+#   - gitops-service-e2e-test  <---------------- workload
+#     - gitops-service-provider  <---------------- workload
+#     - user-workspace  <---------------- workload
 
 echo "-- Setup KCP virtual workspace for e2e testing initialised --"
 
@@ -26,34 +28,36 @@ echo "Entering the home workspace"
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace
 
 echo "Initializing gitops-service-e2e-test workspace"
-createAndEnterWorkspace "gitops-service-e2e-test"
+createAndEnterWorkspace "${PARENT_E2E_WS}"
 
 echo "Initializing service provider workspace"
 # switching to parent workspace will ensure the childrens are created properly
-kubectl kcp workspace use "gitops-service-e2e-test"
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace use "${PARENT_E2E_WS}"
 createAndEnterWorkspace "${SERVICE_WS}"
-cp $KUBECONFIG $SERVICE_WS_CONFIG
+
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workload sync "service-ws-test-cluster" --resources "services,statefulsets.apps,deployments.apps,routes.route.openshift.io" --syncer-image ghcr.io/kcp-dev/kcp/syncer:v0.9.0 --output-file ./syncer-servicews.yaml --namespace kcp-syncer
+kubectl apply -f ./syncer-servicews.yaml
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl wait --for=condition=Ready=true synctarget/service-ws-test-cluster --timeout 3m
+rm ./syncer-servicews.yaml
+
+# echo "Creating APIExports and APIResourceSchemas in workspace ${SERVICE_WS}"
+KUBECONFIG="${CPS_KUBECONFIG}" make apply-kcp-api-all
+
+permissionToBindAPIExport "${PARENT_E2E_WS}"
 
 # Installing ArgoCD in service-provider workspace
 installArgoCD
 
-echo "Creating APIExports and APIResourceSchemas in workspace ${SERVICE_WS}"
-KUBECONFIG="${CPS_KUBECONFIG}" make apply-kcp-api-all
-
-# Copy the identity hash from the backend APIExport in the service workspace so we can reference it later in the appstudio APIBinding
-identityHash=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get apiexports.apis.kcp.dev gitopsrvc-backend-shared -o jsonpath='{.status.identityHash}')
-
-permissionToBindAPIExport
-
 echo "Initializing user workspace"
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace
-KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace use "gitops-service-e2e-test"
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace use "${PARENT_E2E_WS}"
 createAndEnterWorkspace "${USER_WS}"
-cp $KUBECONFIG $USER_WS_CONFIG
+
 
 echo "Creating APIBindings in workspace ${USER_WS}"
-createAPIBinding gitopsrvc-backend-shared
-createAPIBinding gitopsrvc-appstudio-shared
+createAPIBinding gitopsrvc-backend-shared "${PARENT_E2E_WS}" "${SERVICE_WS}"
+createAPIBinding gitopsrvc-appstudio-shared "${PARENT_E2E_WS}" "${SERVICE_WS}"
 
 # Checking if the bindings are in Ready state
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl wait --for=condition=Ready apibindings/gitopsrvc-appstudio-shared --timeout 2m &> /dev/null

--- a/kcp/kcp-e2e/setup-ws-e2e.sh
+++ b/kcp/kcp-e2e/setup-ws-e2e.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -ex
+
+source ./kcp/utils.sh
+
+SERVICE_WS="gitops-service-provider"
+USER_WS="user-workspace"
+
+# Topology for the virtual workspace:
+# - user root
+#   - gitops-service-e2e-test
+#     - gitops-service-provider
+#     - user-workspace
+
+echo "-- Setup KCP virtual workspace for e2e testing initialised --"
+
+# Read the CPS KUBECONFIG path if it's not set already
+readKUBECONFIGPath
+
+echo "Entering the home workspace"
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace
+
+echo "Initializing gitops-service-e2e-test workspace"
+createAndEnterWorkspace "gitops-service-e2e-test"
+
+echo "Initializing service provider workspace"
+# switching to parent workspace will ensure the childrens are created properly
+kubectl kcp workspace use "gitops-service-e2e-test"
+createAndEnterWorkspace "${SERVICE_WS}"
+cp $KUBECONFIG /tmp/service-provider-workspace.yaml
+
+# Installing ArgoCD in service-provider workspace
+installArgoCD
+
+echo "Creating APIExports and APIResourceSchemas in workspace ${SERVICE_WS}"
+KUBECONFIG="${CPS_KUBECONFIG}" make apply-kcp-api-all
+
+# Copy the identity hash from the backend APIExport in the service workspace so we can reference it later in the appstudio APIBinding
+identityHash=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get apiexports.apis.kcp.dev gitopsrvc-backend-shared -o jsonpath='{.status.identityHash}')
+
+permissionToBindAPIExport
+
+echo "Initializing user workspace"
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace use "gitops-service-e2e-test"
+createAndEnterWorkspace "${USER_WS}"
+cp $KUBECONFIG /tmp/user-provider-workspace.yaml
+
+echo "Creating APIBindings in workspace ${USER_WS}"
+createAPIBinding gitopsrvc-backend-shared
+createAPIBinding gitopsrvc-appstudio-shared
+
+# Checking if the bindings are in Ready state
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl wait --for=condition=Ready apibindings/gitopsrvc-appstudio-shared
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl wait --for=condition=Ready apibindings/gitopsrvc-backend-shared
+
+echo "-- Setup KCP virtual workspace for e2e testing successful --"

--- a/kcp/kcp-e2e/start-ws-e2e.sh
+++ b/kcp/kcp-e2e/start-ws-e2e.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -ex
+
+source ./kcp/utils.sh
+
+SERVICE_WS="gitops-service-provider"
+
+# Read the CPS KUBECONFIG path if it's not set already
+readKUBECONFIGPath
+
+echo "-- Running GitOps Service in service provider KCP virtual workspace --"
+
+echo "Entering the home workspace"
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace use "gitops-service-e2e-test"
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace use ${SERVICE_WS}
+
+# Running GitOps Service components in service provider workspace
+runGitOpsService

--- a/kcp/kcp-e2e/start-ws-e2e.sh
+++ b/kcp/kcp-e2e/start-ws-e2e.sh
@@ -2,7 +2,14 @@
 
 set -ex
 
-source ./kcp/utils.sh
+SCRIPTPATH="$(
+  cd -- "$(dirname "$0")" >/dev/null 2>&1 || exit
+  pwd -P
+)"
+
+REPO_ROOT="$SCRIPTPATH/.."
+echo "$SCRIPTPATH"
+source "${REPO_ROOT}/../kcp/utils.sh"
 
 SERVICE_WS="gitops-service-provider"
 

--- a/kcp/utils.sh
+++ b/kcp/utils.sh
@@ -167,3 +167,80 @@ registerSyncTarget() {
     echo "Waiting for the SyncTarget resource to reach ready state"
     KUBECONFIG="${CPS_KUBECONFIG}" kubectl wait --for=condition=Ready=true synctarget/"${WORKLOAD_CLUSTER}" --timeout 3m
 }
+
+createAPIBinding() {
+    exportName=$1
+    KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws
+    url=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get workspace $SERVICE_WS -o jsonpath='{.status.URL}')
+    path=$(basename $url)
+    KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws use $USER_WS
+
+    permissionClaims='
+  permissionClaims:
+  - group: ""
+    resource: "secrets"
+    state: "Accepted"
+  - group: ""
+    resource: "namespaces"
+    state: "Accepted"'
+
+  if [ exportName == "gitopsrvc-appstudio-shared" ]; then
+    permissionClaims="${acceptedPermissionClaims}
+  - group: \"managed-gitops.redhat.com\"
+    resource: \"gitopsdeployments\"
+    state: \"Accepted\"
+    identityHash: ${identityHash}"
+  fi
+
+cat <<EOF | KUBECONFIG="${CPS_KUBECONFIG}" kubectl apply -f -
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIBinding
+metadata:
+  name: ${exportName}
+spec:
+${permissionClaims}
+  reference:
+    workspace:
+      path: ${path}
+      exportName: ${exportName}
+EOF
+}
+
+permissionToBindAPIExport() {
+  # Create permissions to bind APIExports. We need this workaround until KCP fixes the bug in their admission logic. Ref: https://github.com/kcp-dev/kcp/issues/1939  
+  KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws
+  bindingName=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get clusterrolebinding | grep $SERVICE_WS | awk '{print $1}')
+  userName=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get clusterrolebindings $bindingName -o jsonpath='{.subjects[0].name}')
+
+  KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws use $SERVICE_WS
+
+cat <<EOF | KUBECONFIG="${CPS_KUBECONFIG}" kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bind-apiexport
+rules:
+- apiGroups:
+  - apis.kcp.dev
+  resourceNames:
+  - gitopsrvc-backend-shared
+  - gitopsrvc-appstudio-shared
+  resources:
+  - apiexports
+  verbs:
+  - bind
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: bind-apiexport
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: bind-apiexport
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: "$userName"
+EOF
+}

--- a/kcp/virtual-workspace.sh
+++ b/kcp/virtual-workspace.sh
@@ -27,9 +27,6 @@ createAndEnterWorkspace "$SERVICE_WS"
 echo "Creating APIExports and APIResourceSchemas in workspace $SERVICE_WS"
 KUBECONFIG="${CPS_KUBECONFIG}" make apply-kcp-api-all
 
-# Copy the identity hash from the backend APIExport in the service workspace so we can reference it later in the appstudio APIBinding
-identityHash=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get apiexports.apis.kcp.dev gitopsrvc-backend-shared -o jsonpath='{.status.identityHash}')
-
 permissionToBindAPIExport 
 
 echo "Initializing user workspace"

--- a/kcp/virtual-workspace.sh
+++ b/kcp/virtual-workspace.sh
@@ -30,84 +30,12 @@ KUBECONFIG="${CPS_KUBECONFIG}" make apply-kcp-api-all
 # Copy the identity hash from the backend APIExport in the service workspace so we can reference it later in the appstudio APIBinding
 identityHash=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get apiexports.apis.kcp.dev gitopsrvc-backend-shared -o jsonpath='{.status.identityHash}')
 
-# Create permissions to bind APIExports. We need this workaround until KCP fixes the bug in their admission logic. Ref: https://github.com/kcp-dev/kcp/issues/1939  
-KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws
-bindingName=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get clusterrolebinding | grep $SERVICE_WS | awk '{print $1}')
-userName=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get clusterrolebindings $bindingName -o jsonpath='{.subjects[0].name}')
-
-KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws use $SERVICE_WS
-cat <<EOF | KUBECONFIG="${CPS_KUBECONFIG}" kubectl apply -f -
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: bind-apiexport
-rules:
-- apiGroups:
-  - apis.kcp.dev
-  resourceNames:
-  - gitopsrvc-backend-shared
-  - gitopsrvc-appstudio-shared
-  resources:
-  - apiexports
-  verbs:
-  - bind
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: bind-apiexport
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: bind-apiexport
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: "$userName"
-EOF
+permissionToBindAPIExport 
 
 echo "Initializing user workspace"
 createAndEnterWorkspace "$USER_WS"
 
-createAPIBinding() {
-    exportName=$1
-    KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws
-    url=$(KUBECONFIG="${CPS_KUBECONFIG}" kubectl get workspace $SERVICE_WS -o jsonpath='{.status.URL}')
-    path=$(basename $url)
-    KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws use $USER_WS
-
-    permissionClaims='
-  permissionClaims:
-  - group: ""
-    resource: "secrets"
-    state: "Accepted"
-  - group: ""
-    resource: "namespaces"
-    state: "Accepted"'
-
-  if [ exportName == "gitopsrvc-appstudio-shared" ]; then
-    permissionClaims="${acceptedPermissionClaims}
-  - group: \"managed-gitops.redhat.com\"
-    resource: \"gitopsdeployments\"
-    state: \"Accepted\"
-    identityHash: ${identityHash}"
-  fi
-
-cat <<EOF | KUBECONFIG="${CPS_KUBECONFIG}" kubectl apply -f -
-apiVersion: apis.kcp.dev/v1alpha1
-kind: APIBinding
-metadata:
-  name: ${exportName}
-spec:
-${permissionClaims}
-  reference:
-    workspace:
-      path: ${path}
-      exportName: ${exportName}
-EOF
-}
-
-echo "Creating APIBindings in workspace $USER_wS"
+echo "Creating APIBindings in workspace $USER_WS"
 createAPIBinding gitopsrvc-backend-shared
 createAPIBinding gitopsrvc-appstudio-shared
 

--- a/utilities/yamllint.yaml
+++ b/utilities/yamllint.yaml
@@ -1,0 +1,31 @@
+---
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+rules:
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments:
+    require-starting-space: true
+    ignore-shebangs: true
+    min-spaces-from-content: 1
+  comments-indentation: enable
+  document-end: disable
+  document-start: enable
+  empty-lines: enable
+  empty-values: disable
+  float-values: disable
+  hyphens: enable
+  indentation: enable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file: enable
+  new-lines: enable
+  octal-values: disable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy:
+    check-keys: false

--- a/utilities/yamllint.yaml
+++ b/utilities/yamllint.yaml
@@ -18,7 +18,7 @@ rules:
   empty-values: disable
   float-values: disable
   hyphens: enable
-  indentation: enable
+  indentation: disable
   key-duplicates: enable
   key-ordering: disable
   line-length: disable


### PR DESCRIPTION
#### Description:
-  The GitOps Service E2E tests assume that the GitOps Service, Argo CD, and User APIs, are running on the same cluster (in the same Kubernetes API server/config/context). This is because we were supporting the deployment topology of the app studio staging cluster/our local dev environments.
- However, that is not the case with KCP virtual workspaces. When running with KCP virtual workspaces, there will actually be two separate KCP workspaces: The service provider workspace (where gitops and argocd will be installed and running) and the user workspace (where the user will create an APIBinding for accessing the service)
- This PR extends the work done in 207 by setting up scripts to add make targets for E2E testing on KCP v ws.

#### Link to JIRA Story (if applicable): [GITOPSRVCE-212](https://issues.redhat.com/browse/GITOPSRVCE-212)
