### PR TITLE
Implement GitOpsDeploymentRepositoryCredential API CR in GitOps Service

### DIFF
--- a/backend-shared/config/db/gitopsengineinstance.go
+++ b/backend-shared/config/db/gitopsengineinstance.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"github.com/go-pg/pg/v10"
 )
 
 func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllGitopsEngineInstances(ctx context.Context, gitopsEngineInstances *[]GitopsEngineInstance) error {
@@ -205,7 +206,8 @@ func (dbq *PostgreSQLDatabaseQueries) internalDeleteGitopsEngineInstanceById(ctx
 
 	deleteResult, err := dbq.dbConnection.Model(result).WherePK().Context(ctx).Delete()
 	if err != nil {
-		return 0, fmt.Errorf("error on deleting operation: %v", err)
+		pgErr := err.(pg.Error)
+		return 0, fmt.Errorf("error on deleting operation: %v\nPGError:%v\n", err, pgErr)
 	}
 
 	return deleteResult.RowsAffected(), nil

--- a/backend-shared/config/db/repo_cred.go
+++ b/backend-shared/config/db/repo_cred.go
@@ -15,12 +15,23 @@ var (
 )
 
 func (dbq *PostgreSQLDatabaseQueries) CreateRepositoryCredentials(ctx context.Context, obj *RepositoryCredentials) error {
-	if err := validateQueryParamsEntity(obj, dbq); err != nil {
+
+	if dbq.allowTestUuids {
+		if IsEmpty(obj.RepositoryCredentialsID) {
+			obj.RepositoryCredentialsID = generateUuid()
+		}
+	} else {
+		if !IsEmpty(obj.RepositoryCredentialsID) {
+			return fmt.Errorf("primary key should be empty")
+		}
+
+		obj.RepositoryCredentialsID = generateUuid()
+	}
+
+	if err := obj.hasEmptyValues("RepositoryCredentialsID"); err != nil {
 		return err
 	}
-	if err := obj.hasEmptyValues(); err != nil {
-		return err
-	}
+
 	result, err := dbq.dbConnection.Model(obj).Context(ctx).Insert()
 	if err != nil {
 		return fmt.Errorf("%v: %w", errCreateRepositoryCredentials, err)

--- a/backend-shared/config/db/repo_cred.go
+++ b/backend-shared/config/db/repo_cred.go
@@ -15,47 +15,29 @@ var (
 )
 
 func (dbq *PostgreSQLDatabaseQueries) CreateRepositoryCredentials(ctx context.Context, obj *RepositoryCredentials) error {
-
-	fmt.Println("DEBUG: CreateRepositoryCredentials")
-	fmt.Println("-----------------------------")
-	fmt.Println("obj.RepositoryCredentialsID: ", obj.RepositoryCredentialsID)
-	fmt.Println("&obj.RepositoryCredentialsID: ", &obj.RepositoryCredentialsID)
-	fmt.Println("dbq.allowTestUuids: ", dbq.allowTestUuids)
-
 	if dbq.allowTestUuids {
 		if IsEmpty(obj.RepositoryCredentialsID) {
 			obj.RepositoryCredentialsID = "test-" + generateUuid()
 		}
 	} else {
 		if !IsEmpty(obj.RepositoryCredentialsID) {
-			fmt.Println("ERROR: obj.RepositoryCredentialsID is not empty")
 			return fmt.Errorf("primary key should be empty")
 		}
 
 		obj.RepositoryCredentialsID = generateUuid()
-		fmt.Println("obj.RepositoryCredentialsID: ", obj.RepositoryCredentialsID)
-
 	}
 
-	fmt.Println("Checking for empty values")
 	if err := obj.hasEmptyValues("RepositoryCredentialsID"); err != nil {
-		fmt.Println("ERROR: obj.hasEmptyValues")
 		return err
 	}
-	fmt.Println("No empty values")
 
-	fmt.Println("Inserting into database")
 	result, err := dbq.dbConnection.Model(obj).Context(ctx).Insert()
 	if err != nil {
-		fmt.Println("ERROR: dbq.dbConnection.Model(obj).Context(ctx).Insert()")
-		fmt.Println(err)
 		return fmt.Errorf("%v: %w", errCreateRepositoryCredentials, err)
 	}
 	if result.RowsAffected() != 1 {
-		fmt.Println("ERROR: result.RowsAffected() != 1")
 		return fmt.Errorf("%w: %d", errRowsAffected, result.RowsAffected())
 	}
-	fmt.Println("Inserted into database")
 	return nil
 }
 

--- a/backend-shared/config/db/repo_cred.go
+++ b/backend-shared/config/db/repo_cred.go
@@ -28,23 +28,34 @@ func (dbq *PostgreSQLDatabaseQueries) CreateRepositoryCredentials(ctx context.Co
 		}
 	} else {
 		if !IsEmpty(obj.RepositoryCredentialsID) {
+			fmt.Println("ERROR: obj.RepositoryCredentialsID is not empty")
 			return fmt.Errorf("primary key should be empty")
 		}
 
 		obj.RepositoryCredentialsID = generateUuid()
+		fmt.Println("obj.RepositoryCredentialsID: ", obj.RepositoryCredentialsID)
+
 	}
 
+	fmt.Println("Checking for empty values")
 	if err := obj.hasEmptyValues("RepositoryCredentialsID"); err != nil {
+		fmt.Println("ERROR: obj.hasEmptyValues")
 		return err
 	}
+	fmt.Println("No empty values")
 
+	fmt.Println("Inserting into database")
 	result, err := dbq.dbConnection.Model(obj).Context(ctx).Insert()
 	if err != nil {
+		fmt.Println("ERROR: dbq.dbConnection.Model(obj).Context(ctx).Insert()")
+		fmt.Println(err)
 		return fmt.Errorf("%v: %w", errCreateRepositoryCredentials, err)
 	}
 	if result.RowsAffected() != 1 {
+		fmt.Println("ERROR: result.RowsAffected() != 1")
 		return fmt.Errorf("%w: %d", errRowsAffected, result.RowsAffected())
 	}
+	fmt.Println("Inserted into database")
 	return nil
 }
 

--- a/backend-shared/config/db/repo_cred.go
+++ b/backend-shared/config/db/repo_cred.go
@@ -16,9 +16,15 @@ var (
 
 func (dbq *PostgreSQLDatabaseQueries) CreateRepositoryCredentials(ctx context.Context, obj *RepositoryCredentials) error {
 
+	fmt.Println("DEBUG: CreateRepositoryCredentials")
+	fmt.Println("-----------------------------")
+	fmt.Println("obj.RepositoryCredentialsID: ", obj.RepositoryCredentialsID)
+	fmt.Println("&obj.RepositoryCredentialsID: ", &obj.RepositoryCredentialsID)
+	fmt.Println("dbq.allowTestUuids: ", dbq.allowTestUuids)
+
 	if dbq.allowTestUuids {
 		if IsEmpty(obj.RepositoryCredentialsID) {
-			obj.RepositoryCredentialsID = generateUuid()
+			obj.RepositoryCredentialsID = "test-" + generateUuid()
 		}
 	} else {
 		if !IsEmpty(obj.RepositoryCredentialsID) {

--- a/backend-shared/config/db/repo_cred_test.go
+++ b/backend-shared/config/db/repo_cred_test.go
@@ -4,6 +4,7 @@ package db_test
 
 import (
 	"context"
+	"fmt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
@@ -61,6 +62,7 @@ var _ = Describe("RepositoryCredentials Tests", func() {
 			}
 
 			By("Inserting the RepositoryCredentials object to the database")
+			fmt.Println("TEST 1")
 			err = dbq.CreateRepositoryCredentials(ctx, &gitopsRepositoryCredentials)
 			Expect(err).To(BeNil())
 
@@ -82,6 +84,7 @@ var _ = Describe("RepositoryCredentials Tests", func() {
 			}
 
 			By("Inserting the identical RepositoryCredentials object to the database")
+			fmt.Println("TEST 2")
 			err = dbq.CreateRepositoryCredentials(ctx, &gitopsRepositoryCredentials2)
 			Expect(err).ToNot(BeNil())
 
@@ -118,24 +121,27 @@ var _ = Describe("RepositoryCredentials Tests", func() {
 
 			By("Testing the hasEmptyValues function")
 
-			By("Should return error if Primary Key is null")
+			By("Should create a UUID on the spot if Primary Key is null ")
 			updatedCR.RepositoryCredentialsID = ""
+			fmt.Println("TEST 3")
 			err = dbq.CreateRepositoryCredentials(ctx, &updatedCR)
-			Expect(err).ShouldNot(BeNil())
-			expectedErr := "RepositoryCredentials.RepositoryCredentialsID is empty, but it shouldn't (notnull tag found: `repositorycredentials_id,pk,notnull`)"
-			Expect(err.Error()).Should(Equal(expectedErr))
+			Expect(err).Should(BeNil())
+			// expectedErr := "RepositoryCredentials.RepositoryCredentialsID is empty, but it shouldn't (notnull tag found: `repositorycredentials_id,pk,notnull`)"
+			// Expect(err.Error()).Should(Equal(expectedErr))
 			updatedCR.RepositoryCredentialsID = "test-repo-cred-id" // reset the UserID to the original value
 
 			By("Should return error if UserID is null")
 			updatedCR.UserID = ""
+			fmt.Println("TEST 4")
 			err = dbq.CreateRepositoryCredentials(ctx, &updatedCR)
 			Expect(err).ShouldNot(BeNil())
-			expectedErr = "RepositoryCredentials.UserID is empty, but it shouldn't (notnull tag found: `repo_cred_user_id,notnull`)"
+			expectedErr := "RepositoryCredentials.UserID is empty, but it shouldn't (notnull tag found: `repo_cred_user_id,notnull`)"
 			Expect(err.Error()).Should(Equal(expectedErr))
 			updatedCR.UserID = clusterUser.Clusteruser_id // reset the UserID to the original value
 
 			By("Should return error if PrivateURL is null")
 			updatedCR.PrivateURL = ""
+			fmt.Println("TEST 5")
 			err = dbq.CreateRepositoryCredentials(ctx, &updatedCR)
 			Expect(err).ShouldNot(BeNil())
 			expectedErr = "RepositoryCredentials.PrivateURL is empty, but it shouldn't (notnull tag found: `repo_cred_url,notnull`)"
@@ -144,6 +150,7 @@ var _ = Describe("RepositoryCredentials Tests", func() {
 
 			By("Should return error if SecretObj is null")
 			updatedCR.SecretObj = ""
+			fmt.Println("TEST 6")
 			err = dbq.CreateRepositoryCredentials(ctx, &updatedCR)
 			Expect(err).ShouldNot(BeNil())
 			expectedErr = "RepositoryCredentials.SecretObj is empty, but it shouldn't (notnull tag found: `repo_cred_secret,notnull`)"
@@ -152,6 +159,7 @@ var _ = Describe("RepositoryCredentials Tests", func() {
 
 			By("Should return error if EngineClusterID is null")
 			updatedCR.EngineClusterID = ""
+			fmt.Println("TEST 7")
 			err = dbq.CreateRepositoryCredentials(ctx, &updatedCR)
 			Expect(err).ShouldNot(BeNil())
 			expectedErr = "RepositoryCredentials.EngineClusterID is empty, but it shouldn't (notnull tag found: `repo_cred_engine_id,notnull`)"

--- a/backend-shared/config/db/repo_cred_test.go
+++ b/backend-shared/config/db/repo_cred_test.go
@@ -4,7 +4,6 @@ package db_test
 
 import (
 	"context"
-	"fmt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
@@ -62,7 +61,6 @@ var _ = Describe("RepositoryCredentials Tests", func() {
 			}
 
 			By("Inserting the RepositoryCredentials object to the database")
-			fmt.Println("TEST 1")
 			err = dbq.CreateRepositoryCredentials(ctx, &gitopsRepositoryCredentials)
 			Expect(err).To(BeNil())
 
@@ -84,7 +82,6 @@ var _ = Describe("RepositoryCredentials Tests", func() {
 			}
 
 			By("Inserting the identical RepositoryCredentials object to the database")
-			fmt.Println("TEST 2")
 			err = dbq.CreateRepositoryCredentials(ctx, &gitopsRepositoryCredentials2)
 			Expect(err).ToNot(BeNil())
 
@@ -123,16 +120,13 @@ var _ = Describe("RepositoryCredentials Tests", func() {
 
 			By("Should create a UUID on the spot if Primary Key is null ")
 			updatedCR.RepositoryCredentialsID = ""
-			fmt.Println("TEST 3")
 			err = dbq.CreateRepositoryCredentials(ctx, &updatedCR)
 			Expect(err).Should(BeNil())
-			// expectedErr := "RepositoryCredentials.RepositoryCredentialsID is empty, but it shouldn't (notnull tag found: `repositorycredentials_id,pk,notnull`)"
-			// Expect(err.Error()).Should(Equal(expectedErr))
+
 			updatedCR.RepositoryCredentialsID = "test-repo-cred-id" // reset the UserID to the original value
 
 			By("Should return error if UserID is null")
 			updatedCR.UserID = ""
-			fmt.Println("TEST 4")
 			err = dbq.CreateRepositoryCredentials(ctx, &updatedCR)
 			Expect(err).ShouldNot(BeNil())
 			expectedErr := "RepositoryCredentials.UserID is empty, but it shouldn't (notnull tag found: `repo_cred_user_id,notnull`)"
@@ -141,7 +135,6 @@ var _ = Describe("RepositoryCredentials Tests", func() {
 
 			By("Should return error if PrivateURL is null")
 			updatedCR.PrivateURL = ""
-			fmt.Println("TEST 5")
 			err = dbq.CreateRepositoryCredentials(ctx, &updatedCR)
 			Expect(err).ShouldNot(BeNil())
 			expectedErr = "RepositoryCredentials.PrivateURL is empty, but it shouldn't (notnull tag found: `repo_cred_url,notnull`)"
@@ -150,7 +143,6 @@ var _ = Describe("RepositoryCredentials Tests", func() {
 
 			By("Should return error if SecretObj is null")
 			updatedCR.SecretObj = ""
-			fmt.Println("TEST 6")
 			err = dbq.CreateRepositoryCredentials(ctx, &updatedCR)
 			Expect(err).ShouldNot(BeNil())
 			expectedErr = "RepositoryCredentials.SecretObj is empty, but it shouldn't (notnull tag found: `repo_cred_secret,notnull`)"
@@ -159,7 +151,6 @@ var _ = Describe("RepositoryCredentials Tests", func() {
 
 			By("Should return error if EngineClusterID is null")
 			updatedCR.EngineClusterID = ""
-			fmt.Println("TEST 7")
 			err = dbq.CreateRepositoryCredentials(ctx, &updatedCR)
 			Expect(err).ShouldNot(BeNil())
 			expectedErr = "RepositoryCredentials.EngineClusterID is empty, but it shouldn't (notnull tag found: `repo_cred_engine_id,notnull`)"

--- a/backend-shared/config/db/util/utils.go
+++ b/backend-shared/config/db/util/utils.go
@@ -246,7 +246,7 @@ func GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.Context,
 			log.Error(err, "Unable to create GitopsEngineInstance: "+gitopsEngineInstance.Gitopsengineinstance_id)
 			return nil, false, nil, fmt.Errorf("unable to create engine instance, when neither existed: %v", err)
 		}
-		log.Info("Created GitopsEngineInstance: " + gitopsEngineInstance.Gitopsengineinstance_id)
+		// log.Info("Created GitopsEngineInstance: " + gitopsEngineInstance.Gitopsengineinstance_id)
 
 		expectedDBResourceMapping.DBRelationKey = gitopsEngineInstance.Gitopsengineinstance_id
 
@@ -257,8 +257,7 @@ func GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.Context,
 			return nil, false, nil, fmt.Errorf("unable to create mapping when neither existed: %v", err)
 		}
 
-		log.Info("Created KubernetesResourceToDBResourceMapping with KubernetesResourceUID: "+
-			expectedDBResourceMapping.KubernetesResourceUID, expectedDBResourceMapping.GetAsLogKeyValues()...)
+		// log.Info("Created KubernetesResourceToDBResourceMapping with KubernetesResourceUID: "+ expectedDBResourceMapping.KubernetesResourceUID, expectedDBResourceMapping.GetAsLogKeyValues()...)
 
 		return gitopsEngineInstance, true, gitopsEngineCluster, nil
 
@@ -398,8 +397,7 @@ func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context,
 
 			// We have found a mapping without the corresponding mapped entity, so delete the mapping.
 			// (We will recreate the mapping below)
-			log.V(util.LogLevel_Warn).Error(nil, "GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID found a resource mapping, "+
-				"but no engine cluster.")
+			// log.V(util.LogLevel_Warn).Error(nil, "GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID found a resource mapping, but no engine cluster.")
 
 			if _, err := dbq.DeleteKubernetesResourceToDBResourceMapping(ctx, dbResourceMapping); err != nil {
 				log.Error(err, "Unable to delete KubernetesResourceToDBResourceMapping (while the engine cluster was not found)",
@@ -407,8 +405,7 @@ func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context,
 
 				return nil, false, err
 			}
-			log.Info("Deleted KubernetesResourceToDBResourceMapping, as the engine cluster was not found",
-				dbResourceMapping.GetAsLogKeyValues()...)
+			// log.Info("Deleted KubernetesResourceToDBResourceMapping, as the engine cluster was not found", dbResourceMapping.GetAsLogKeyValues()...)
 
 			gitopsEngineCluster = nil
 			dbResourceMapping = nil
@@ -437,8 +434,7 @@ func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context,
 
 			return nil, false, fmt.Errorf("unable to create cluster creds for managed env: %v", err)
 		}
-		log.Info("Created Cluster Credentials for GitOpsEngineCluster: "+clusterCreds.Clustercredentials_cred_id,
-			clusterCreds.GetAsLogKeyValues()...)
+		// log.Info("Created Cluster Credentials for GitOpsEngineCluster: "+clusterCreds.Clustercredentials_cred_id, clusterCreds.GetAsLogKeyValues()...)
 
 		gitopsEngineCluster = &db.GitopsEngineCluster{
 			Clustercredentials_id: clusterCreds.Clustercredentials_cred_id,
@@ -447,14 +443,14 @@ func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context,
 			log.Error(err, "Unable to create GitopsEngineCluster", gitopsEngineCluster.GetAsLogKeyValues()...)
 			return nil, false, fmt.Errorf("unable to create engine cluster, when neither existed: %v", err)
 		}
-		log.Info("Created GitopsEngineCluster: "+gitopsEngineCluster.Gitopsenginecluster_id, gitopsEngineCluster.GetAsLogKeyValues()...)
+		//log.Info("Created GitopsEngineCluster: "+gitopsEngineCluster.Gitopsenginecluster_id, gitopsEngineCluster.GetAsLogKeyValues()...)
 
 		expectedDBResourceMapping.DBRelationKey = gitopsEngineCluster.Gitopsenginecluster_id
 		if err := dbq.CreateKubernetesResourceToDBResourceMapping(ctx, &expectedDBResourceMapping); err != nil {
 			log.Error(err, "Unable to create KubernetesResourceToDBResourceMapping", expectedDBResourceMapping.GetAsLogKeyValues()...)
 			return nil, false, fmt.Errorf("unable to create mapping when neither existed: %v", err)
 		}
-		log.Info("Created KubernetesResourceToDBResourceMapping with DBRelationKey: "+expectedDBResourceMapping.DBRelationKey, expectedDBResourceMapping.GetAsLogKeyValues()...)
+		// log.Info("Created KubernetesResourceToDBResourceMapping with DBRelationKey: "+expectedDBResourceMapping.DBRelationKey, expectedDBResourceMapping.GetAsLogKeyValues()...)
 
 		return gitopsEngineCluster, true, nil
 
@@ -462,7 +458,7 @@ func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context,
 		// Scenario B) This shouldn't happen: the above logic should ensure that dbResourceMapping is always nil, if gitopsEngineCluster is nil
 
 		err := fmt.Errorf("SEVERE: the dbResourceMapping existed, but the gitops engine cluster did not")
-		log.Error(err, err.Error())
+		//log.Error(err, err.Error())
 
 		return nil, false, err
 
@@ -476,8 +472,7 @@ func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context,
 			return nil, false, fmt.Errorf("unable to create mapping when dbResourceMapping didn't exist: %v", err)
 		}
 
-		log.Info("Created KubernetesResourceToDBResourceMapping with DBRelationKey: "+
-			expectedDBResourceMapping.DBRelationKey, expectedDBResourceMapping.GetAsLogKeyValues()...)
+		// log.Info("Created KubernetesResourceToDBResourceMapping with DBRelationKey: "+ expectedDBResourceMapping.DBRelationKey, expectedDBResourceMapping.GetAsLogKeyValues()...)
 
 		return gitopsEngineCluster, true, nil
 

--- a/backend-shared/config/db/util/utils.go
+++ b/backend-shared/config/db/util/utils.go
@@ -397,7 +397,7 @@ func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context,
 
 			// We have found a mapping without the corresponding mapped entity, so delete the mapping.
 			// (We will recreate the mapping below)
-			// log.V(util.LogLevel_Warn).Error(nil, "GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID found a resource mapping, but no engine cluster.")
+			log.V(util.LogLevel_Warn).Error(nil, "GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID found a resource mapping, but no engine cluster.")
 
 			if _, err := dbq.DeleteKubernetesResourceToDBResourceMapping(ctx, dbResourceMapping); err != nil {
 				log.Error(err, "Unable to delete KubernetesResourceToDBResourceMapping (while the engine cluster was not found)",
@@ -405,7 +405,7 @@ func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context,
 
 				return nil, false, err
 			}
-			// log.Info("Deleted KubernetesResourceToDBResourceMapping, as the engine cluster was not found", dbResourceMapping.GetAsLogKeyValues()...)
+			log.Info("Deleted KubernetesResourceToDBResourceMapping, as the engine cluster was not found", dbResourceMapping.GetAsLogKeyValues()...)
 
 			gitopsEngineCluster = nil
 			dbResourceMapping = nil
@@ -443,7 +443,7 @@ func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context,
 			log.Error(err, "Unable to create GitopsEngineCluster", gitopsEngineCluster.GetAsLogKeyValues()...)
 			return nil, false, fmt.Errorf("unable to create engine cluster, when neither existed: %v", err)
 		}
-		//log.Info("Created GitopsEngineCluster: "+gitopsEngineCluster.Gitopsenginecluster_id, gitopsEngineCluster.GetAsLogKeyValues()...)
+		// log.Info("Created GitopsEngineCluster: "+gitopsEngineCluster.Gitopsenginecluster_id, gitopsEngineCluster.GetAsLogKeyValues()...)
 
 		expectedDBResourceMapping.DBRelationKey = gitopsEngineCluster.Gitopsenginecluster_id
 		if err := dbq.CreateKubernetesResourceToDBResourceMapping(ctx, &expectedDBResourceMapping); err != nil {
@@ -458,7 +458,7 @@ func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context,
 		// Scenario B) This shouldn't happen: the above logic should ensure that dbResourceMapping is always nil, if gitopsEngineCluster is nil
 
 		err := fmt.Errorf("SEVERE: the dbResourceMapping existed, but the gitops engine cluster did not")
-		//log.Error(err, err.Error())
+		log.Error(err, err.Error())
 
 		return nil, false, err
 
@@ -472,7 +472,7 @@ func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context,
 			return nil, false, fmt.Errorf("unable to create mapping when dbResourceMapping didn't exist: %v", err)
 		}
 
-		// log.Info("Created KubernetesResourceToDBResourceMapping with DBRelationKey: "+ expectedDBResourceMapping.DBRelationKey, expectedDBResourceMapping.GetAsLogKeyValues()...)
+		log.Info("Created KubernetesResourceToDBResourceMapping with DBRelationKey: "+ expectedDBResourceMapping.DBRelationKey, expectedDBResourceMapping.GetAsLogKeyValues()...)
 
 		return gitopsEngineCluster, true, nil
 

--- a/backend-shared/config/db/util/utils.go
+++ b/backend-shared/config/db/util/utils.go
@@ -246,7 +246,7 @@ func GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.Context,
 			log.Error(err, "Unable to create GitopsEngineInstance: "+gitopsEngineInstance.Gitopsengineinstance_id)
 			return nil, false, nil, fmt.Errorf("unable to create engine instance, when neither existed: %v", err)
 		}
-		// log.Info("Created GitopsEngineInstance: " + gitopsEngineInstance.Gitopsengineinstance_id)
+		log.Info("Created GitopsEngineInstance: " + gitopsEngineInstance.Gitopsengineinstance_id)
 
 		expectedDBResourceMapping.DBRelationKey = gitopsEngineInstance.Gitopsengineinstance_id
 
@@ -257,7 +257,7 @@ func GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.Context,
 			return nil, false, nil, fmt.Errorf("unable to create mapping when neither existed: %v", err)
 		}
 
-		// log.Info("Created KubernetesResourceToDBResourceMapping with KubernetesResourceUID: "+ expectedDBResourceMapping.KubernetesResourceUID, expectedDBResourceMapping.GetAsLogKeyValues()...)
+		log.Info("Created KubernetesResourceToDBResourceMapping with KubernetesResourceUID: "+ expectedDBResourceMapping.KubernetesResourceUID, expectedDBResourceMapping.GetAsLogKeyValues()...)
 
 		return gitopsEngineInstance, true, gitopsEngineCluster, nil
 
@@ -434,7 +434,7 @@ func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context,
 
 			return nil, false, fmt.Errorf("unable to create cluster creds for managed env: %v", err)
 		}
-		// log.Info("Created Cluster Credentials for GitOpsEngineCluster: "+clusterCreds.Clustercredentials_cred_id, clusterCreds.GetAsLogKeyValues()...)
+		log.Info("Created Cluster Credentials for GitOpsEngineCluster: "+clusterCreds.Clustercredentials_cred_id, clusterCreds.GetAsLogKeyValues()...)
 
 		gitopsEngineCluster = &db.GitopsEngineCluster{
 			Clustercredentials_id: clusterCreds.Clustercredentials_cred_id,
@@ -443,14 +443,14 @@ func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context,
 			log.Error(err, "Unable to create GitopsEngineCluster", gitopsEngineCluster.GetAsLogKeyValues()...)
 			return nil, false, fmt.Errorf("unable to create engine cluster, when neither existed: %v", err)
 		}
-		// log.Info("Created GitopsEngineCluster: "+gitopsEngineCluster.Gitopsenginecluster_id, gitopsEngineCluster.GetAsLogKeyValues()...)
+		log.Info("Created GitopsEngineCluster: "+gitopsEngineCluster.Gitopsenginecluster_id, gitopsEngineCluster.GetAsLogKeyValues()...)
 
 		expectedDBResourceMapping.DBRelationKey = gitopsEngineCluster.Gitopsenginecluster_id
 		if err := dbq.CreateKubernetesResourceToDBResourceMapping(ctx, &expectedDBResourceMapping); err != nil {
 			log.Error(err, "Unable to create KubernetesResourceToDBResourceMapping", expectedDBResourceMapping.GetAsLogKeyValues()...)
 			return nil, false, fmt.Errorf("unable to create mapping when neither existed: %v", err)
 		}
-		// log.Info("Created KubernetesResourceToDBResourceMapping with DBRelationKey: "+expectedDBResourceMapping.DBRelationKey, expectedDBResourceMapping.GetAsLogKeyValues()...)
+		log.Info("Created KubernetesResourceToDBResourceMapping with DBRelationKey: "+expectedDBResourceMapping.DBRelationKey, expectedDBResourceMapping.GetAsLogKeyValues()...)
 
 		return gitopsEngineCluster, true, nil
 

--- a/backend-shared/config/db/util/utils.go
+++ b/backend-shared/config/db/util/utils.go
@@ -257,7 +257,7 @@ func GetOrCreateGitopsEngineInstanceByInstanceNamespaceUID(ctx context.Context,
 			return nil, false, nil, fmt.Errorf("unable to create mapping when neither existed: %v", err)
 		}
 
-		log.Info("Created KubernetesResourceToDBResourceMapping with KubernetesResourceUID: "+ expectedDBResourceMapping.KubernetesResourceUID, expectedDBResourceMapping.GetAsLogKeyValues()...)
+		log.Info("Created KubernetesResourceToDBResourceMapping with KubernetesResourceUID: "+expectedDBResourceMapping.KubernetesResourceUID, expectedDBResourceMapping.GetAsLogKeyValues()...)
 
 		return gitopsEngineInstance, true, gitopsEngineCluster, nil
 
@@ -472,7 +472,7 @@ func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context,
 			return nil, false, fmt.Errorf("unable to create mapping when dbResourceMapping didn't exist: %v", err)
 		}
 
-		log.Info("Created KubernetesResourceToDBResourceMapping with DBRelationKey: "+ expectedDBResourceMapping.DBRelationKey, expectedDBResourceMapping.GetAsLogKeyValues()...)
+		log.Info("Created KubernetesResourceToDBResourceMapping with DBRelationKey: "+expectedDBResourceMapping.DBRelationKey, expectedDBResourceMapping.GetAsLogKeyValues()...)
 
 		return gitopsEngineCluster, true, nil
 

--- a/backend-shared/util/operations/types.go
+++ b/backend-shared/util/operations/types.go
@@ -24,18 +24,16 @@ const (
 
 func CreateOperation(ctx context.Context, waitForOperation bool, dbOperationParam db.Operation, clusterUserID string,
 	operationNamespace string, dbQueries db.ApplicationScopedQueries, gitopsEngineClient client.Client,
-	log logr.Logger) (*managedgitopsv1alpha1.Operation, *db.Operation, error) {
-
+	logger logr.Logger) (*managedgitopsv1alpha1.Operation, *db.Operation, error) {
 	var err error
-
-	log = log.WithValues("Operation GitOpsEngineInstanceID", dbOperationParam.Instance_id,
+	logger = logger.WithValues("Operation GitOpsEngineInstanceID", dbOperationParam.Instance_id,
 		"Operation ResourceID", dbOperationParam.Resource_id,
 		"Operation ResourceType", dbOperationParam.Resource_type,
 		"Operation OwnerUserID", clusterUserID,
 	)
 	var dbOperationList []db.Operation
 	if err = dbQueries.ListOperationsByResourceIdAndTypeAndOwnerId(ctx, dbOperationParam.Resource_id, dbOperationParam.Resource_type, &dbOperationList, clusterUserID); err != nil {
-		log.Error(err, "unable to fetch list of Operations")
+		logger.Error(err, "unable to fetch list of Operations")
 		// We intentionally don't return here: if we were unable to fetch the list,
 		// then we will create an Operation as usual (and it might be duplicate, but that's fine)
 	}
@@ -59,13 +57,13 @@ func CreateOperation(ctx context.Context, waitForOperation bool, dbOperationPara
 		}
 
 		if err = gitopsEngineClient.Get(ctx, client.ObjectKeyFromObject(&k8sOperation), &k8sOperation); err != nil {
-			log.Error(err, "unable to fetch existing Operation from cluster.", "Operation k8s Name", k8sOperation.Name)
+			logger.Error(err, "unable to fetch existing Operation from cluster.", "Operation k8s Name", k8sOperation.Name)
 			// We intentionally don't return here: we keep going through the list, even if an error occurs.
 			// Only one needs to match.
 		} else {
 			// An operation already exists in waiting state, and the Operation CR for it still exists, so we don't need to create
 			// a new operation.
-			log.Info("Skipping Operation creation, as it already exists for resource.", "existingOperationState", string(dbOperation.State))
+			logger.Info("Skipping Operation creation, as it already exists for resource.", "existingOperationState", string(dbOperation.State))
 			return &k8sOperation, &dbOperation, nil
 		}
 	}
@@ -82,10 +80,10 @@ func CreateOperation(ctx context.Context, waitForOperation bool, dbOperationPara
 	}
 
 	if err := dbQueries.CreateOperation(ctx, &dbOperation, clusterUserID); err != nil {
-		log.Error(err, "Unable to create Operation database row")
+		logger.Error(err, "Unable to create Operation database row")
 		return nil, nil, err
 	}
-	log.Info("Created Operation database row")
+	logger.Info("Created Operation database row")
 
 	// Create K8s operation
 	operation := managedgitopsv1alpha1.Operation{
@@ -104,21 +102,21 @@ func CreateOperation(ctx context.Context, waitForOperation bool, dbOperationPara
 	}
 
 	if err := gitopsEngineClient.Create(ctx, &operation, &client.CreateOptions{}); err != nil {
-		log.Error(err, "Unable to create K8s Operation")
+		logger.Error(err, "Unable to create K8s Operation")
 		return nil, nil, err
 	}
-	log.Info("Created K8s Operation CR")
+	logger.Info("Created K8s Operation CR")
 
 	// Wait for operation to complete.
 	if waitForOperation {
-		log.V(sharedutil.LogLevel_Debug).Info("Waiting for Operation to complete")
+		logger.V(sharedutil.LogLevel_Debug).Info("Waiting for Operation to complete")
 
-		if err = waitForOperationToComplete(ctx, &dbOperation, dbQueries, log); err != nil {
-			log.Error(err, "operation did not complete", "operation", dbOperation.Operation_id, "namespace", operation.Namespace)
+		if err = waitForOperationToComplete(ctx, &dbOperation, dbQueries, logger); err != nil {
+			logger.Error(err, "operation did not complete", "operation", dbOperation.Operation_id, "namespace", operation.Namespace)
 			return nil, nil, err
 		}
 
-		log.Info("Operation completed", "operation", fmt.Sprintf("%v", operation.Spec.OperationID))
+		logger.Info("Operation completed", "operation", fmt.Sprintf("%v", operation.Spec.OperationID))
 	}
 
 	return &operation, &dbOperation, nil

--- a/backend-shared/util/operations/types.go
+++ b/backend-shared/util/operations/types.go
@@ -26,7 +26,7 @@ func CreateOperation(ctx context.Context, waitForOperation bool, dbOperationPara
 	operationNamespace string, dbQueries db.ApplicationScopedQueries, gitopsEngineClient client.Client,
 	l logr.Logger) (*managedgitopsv1alpha1.Operation, *db.Operation, error) {
 	var err error
-	l.WithValues("Operation GitOpsEngineInstanceID", dbOperationParam.Instance_id,
+	l = l.WithValues("Operation GitOpsEngineInstanceID", dbOperationParam.Instance_id,
 		"Operation ResourceID", dbOperationParam.Resource_id,
 		"Operation ResourceType", dbOperationParam.Resource_type,
 		"Operation OwnerUserID", clusterUserID,
@@ -83,7 +83,7 @@ func CreateOperation(ctx context.Context, waitForOperation bool, dbOperationPara
 		l.Error(err, "Unable to create Operation database row")
 		return nil, nil, err
 	}
-	l.Info("Created Operation database row")
+	l.Info("Created Operation database row", "Operation DB ID", dbOperation.Operation_id)
 
 	// Create K8s operation
 	operation := managedgitopsv1alpha1.Operation{
@@ -105,7 +105,9 @@ func CreateOperation(ctx context.Context, waitForOperation bool, dbOperationPara
 		l.Error(err, "Unable to create K8s Operation")
 		return nil, nil, err
 	}
-	l.Info("Created K8s Operation CR")
+	l.Info("Created K8s Operation CR", "Operation CR Name", operation.Name,
+		"Operation CR Namespace", operation.Namespace, "Operation CR ID", operation.Spec.OperationID,
+		"Operation CR State", operation.Status)
 
 	// Wait for operation to complete.
 	if waitForOperation {

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -99,7 +99,6 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleDeploym
 				// Not found, so set gitopsDeployment to nil
 				gitopsDeployment = nil
 			} else {
-
 				userError := "unable to retrieve the GitOpsDeployment object from the namespace, due to unknown error."
 				a.log.Error(err, "unable to locate object in handleDeploymentModified", "request", gitopsDeploymentKey)
 				return signalledShutdown_false, nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewUserDevError(userError, err)
@@ -868,10 +867,10 @@ type gitOpsDeploymentAdapter struct {
 }
 
 // newGitOpsDeploymentAdapter returns an initialized gitOpsDeploymentAdapter
-func newGitOpsDeploymentAdapter(gitopsDeployment *managedgitopsv1alpha1.GitOpsDeployment, logger logr.Logger, client client.Client, manager condition.Conditions, ctx context.Context) *gitOpsDeploymentAdapter {
+func newGitOpsDeploymentAdapter(gitopsDeployment *managedgitopsv1alpha1.GitOpsDeployment, l logr.Logger, client client.Client, manager condition.Conditions, ctx context.Context) *gitOpsDeploymentAdapter {
 	return &gitOpsDeploymentAdapter{
 		gitOpsDeployment: gitopsDeployment,
-		logger:           logger,
+		logger:           l,
 		client:           client,
 		conditionManager: manager,
 		ctx:              ctx,

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -3,6 +3,7 @@ package shared_resource_loop
 import (
 	"context"
 	"fmt"
+
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/go-logr/logr"
@@ -503,9 +504,8 @@ func internalProcessMessage_ReconcileRepositoryCredential(ctx context.Context,
 
 		} else {
 			// Something went wrong, retry
-			l.WithValues("Error", err, "DebugErr", errGenericCR, "CR Name", repositoryCredentialCRName, "Namespace", resourceNS)
 			vErr := fmt.Errorf("unexpected error in retrieving repository credentials: %v", err)
-			l.Error(err, vErr.Error())
+			l.Error(err, vErr.Error(), "DebugErr", errGenericCR, "CR Name", repositoryCredentialCRName, "Namespace", resourceNS)
 
 			return nil, vErr
 
@@ -570,6 +570,7 @@ func internalProcessMessage_ReconcileRepositoryCredential(ctx context.Context,
 
 			} else {
 				if _, err := deleteRepoCredFromDB(ctx, dbQueries, repositoryCredentialPrimaryKey, l); err != nil {
+					l.Error(err, "unable to delete repo cred from DB")
 					return nil, err
 				}
 				l.Info("RepositoryCredential row deleted from DB", "RepositoryCredential ID", repositoryCredentialPrimaryKey)

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -595,6 +595,7 @@ func internalProcessMessage_ReconcileRepositoryCredential(ctx context.Context,
 
 			// Delete the APICRToDatabaseMapping referenced by 'item'
 			if rowsDeleted, err := dbQueries.DeleteAPICRToDatabaseMapping(ctx, &oldAPICRToDBMapping); err != nil {
+				oldAPICRToDBMapping := oldAPICRToDBMapping // Fixes G601 (CWE-118): Implicit memory aliasing in for loop. (Confidence: MEDIUM, Severity: MEDIUM)
 				l.Info("unable to delete apiCRToDBmapping", "mapping", oldAPICRToDBMapping.APIResourceUID)
 				return nil, err
 			} else if rowsDeleted == 0 {

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -3,6 +3,7 @@ package shared_resource_loop
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
@@ -717,7 +718,7 @@ func internalProcessMessage_ReconcileRepositoryCredential(ctx context.Context,
 }
 
 func createRepoCredOperation(ctx context.Context, l logr.Logger, dbRepoCred db.RepositoryCredentials, clusterUser *db.ClusterUser, ns string, dbQueries db.DatabaseQueries, apiNamespaceClient client.Client) error {
-	// l.Info("Creating operation...")
+	l.Info("Creating operation...")
 
 	dbOperationInput := db.Operation{
 		Instance_id:             dbRepoCred.EngineClusterID,
@@ -727,15 +728,14 @@ func createRepoCredOperation(ctx context.Context, l logr.Logger, dbRepoCred db.R
 		Operation_owner_user_id: clusterUser.Clusteruser_id,
 	}
 
-	logger := log.Log
-	_, _, err := operations.CreateOperation(ctx, false, dbOperationInput, clusterUser.Clusteruser_id, ns, dbQueries, apiNamespaceClient, logger)
+	operationCR, operationDB, err := operations.CreateOperation(ctx, false, dbOperationInput, clusterUser.Clusteruser_id, ns, dbQueries, apiNamespaceClient, l)
 	if err != nil {
 		err2 := fmt.Errorf("unable to create operation: %v", err)
 		return err2
 	}
 
-	//l.Info("operationCR", "operationCR", operationCR)
-	//l.Info("operationDB", "operationDB", operationDB)
+	l.Info("operationCR", "operationCR", operationCR)
+	l.Info("operationDB", "operationDB", operationDB)
 
 	return nil
 }
@@ -743,14 +743,14 @@ func createRepoCredOperation(ctx context.Context, l logr.Logger, dbRepoCred db.R
 func compareClusterResourceWithDatabaseRow(cr managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredential, dbr *db.RepositoryCredentials, l logr.Logger) bool {
 	var isSecretUpdateNeeded bool
 	if cr.Spec.Secret != dbr.SecretObj {
-		// l.Info("Secret name changed", "old", dbr.SecretObj, "new", cr.Spec.Secret)
+		l.Info("Secret name changed", "old", dbr.SecretObj, "new", cr.Spec.Secret)
 		dbr.SecretObj = cr.Spec.Secret
 		isSecretUpdateNeeded = true
 	}
 
 	var isRepoUpdateNeeded bool
 	if cr.Spec.Repository != dbr.PrivateURL {
-		// l.Info("Repository URL changed", "old", dbr.PrivateURL, "new", cr.Spec.Repository)
+		l.Info("Repository URL changed", "old", dbr.PrivateURL, "new", cr.Spec.Repository)
 		dbr.PrivateURL = cr.Spec.Repository
 		isSecretUpdateNeeded = true
 	}

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -3,13 +3,16 @@ package shared_resource_loop
 import (
 	"context"
 	"fmt"
-
 	"github.com/go-logr/logr"
+	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	db "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
 	dbutil "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db/util"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
+	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/operations"
 	corev1 "k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -27,7 +30,8 @@ import (
 // - managedenv
 // - clusteraccess
 // - clusteruser
-// - gitopsengineinstance (for now)
+// - gitopsengineinstance
+// - repositorycredential
 //
 // Ultimately the goal of this file is to avoid this issue:
 // - In the same moment of time, both these actions happen simultaneously:
@@ -116,7 +120,7 @@ func (srEventLoop *SharedResourceEventLoop) GetGitopsEngineInstanceById(ctx cont
 func (srEventLoop *SharedResourceEventLoop) ReconcileSharedManagedEnv(ctx context.Context,
 	workspaceClient client.Client, workspaceNamespace corev1.Namespace,
 	managedEnvironmentCRName string, managedEnvironmentCRNamespace string, isWorkspaceTarget bool,
-	k8sClientFactory SRLK8sClientFactory, log logr.Logger) (SharedResourceManagedEnvContainer, error) {
+	k8sClientFactory SRLK8sClientFactory, l logr.Logger) (SharedResourceManagedEnvContainer, error) {
 
 	res := newSharedResourceManagedEnvContainer()
 
@@ -135,7 +139,7 @@ func (srEventLoop *SharedResourceEventLoop) ReconcileSharedManagedEnv(ctx contex
 	responseChannel := make(chan any)
 
 	msg := sharedResourceLoopMessage{
-		log:                log,
+		log:                l,
 		ctx:                ctx,
 		workspaceClient:    workspaceClient,
 		workspaceNamespace: workspaceNamespace,
@@ -164,6 +168,44 @@ func (srEventLoop *SharedResourceEventLoop) ReconcileSharedManagedEnv(ctx contex
 
 }
 
+func (srEventLoop *SharedResourceEventLoop) ReconcileRepositoryCredential(ctx context.Context,
+	workspaceClient client.Client, workspaceNamespace corev1.Namespace,
+	repositoryCredentialCRName string, k8sClientFactory SRLK8sClientFactory) (*db.RepositoryCredentials, error) {
+
+	request := sharedResourceLoopMessage_reconcileRepositoryCredentialRequest{
+		repositoryCredentialCRName:      repositoryCredentialCRName,
+		repositoryCredentialCRNamespace: workspaceNamespace.Name,
+		k8sClientFactory:                k8sClientFactory,
+	}
+
+	responseChannel := make(chan any)
+
+	msg := sharedResourceLoopMessage{
+		workspaceClient:    workspaceClient,
+		workspaceNamespace: workspaceNamespace,
+		messageType:        sharedResourceLoopMessage_reconcileRepositoryCredential,
+		responseChannel:    responseChannel,
+		payload:            request,
+	}
+
+	srEventLoop.inputChannel <- msg
+
+	var rawResponse any
+
+	select {
+	case rawResponse = <-responseChannel:
+	case <-ctx.Done():
+		return nil, fmt.Errorf("context cancelled in ReconcileRepositoryCredential")
+	}
+
+	response, ok := rawResponse.(sharedResourceLoopMessage_reconcileRepositoryCredentialResponse)
+	if !ok {
+		return nil, fmt.Errorf("SEVERE: unexpected response type")
+	}
+	return response.repositoryCredential, response.err
+
+}
+
 func NewSharedResourceLoop() *SharedResourceEventLoop {
 
 	sharedResourceEventLoop := &SharedResourceEventLoop{
@@ -181,6 +223,7 @@ const (
 	sharedResourceLoopMessage_getOrCreateSharedManagedEnv          sharedResourceLoopMessageType = "getOrCreateSharedManagedEnv"
 	sharedResourceLoopMessage_getOrCreateClusterUserByNamespaceUID sharedResourceLoopMessageType = "getOrCreateClusterUserByNamespaceUID"
 	sharedResourceLoopMessage_getGitopsEngineInstanceById          sharedResourceLoopMessageType = "getGitopsEngineInstanceById"
+	sharedResourceLoopMessage_reconcileRepositoryCredential        sharedResourceLoopMessageType = "reconcileRepositoryCredential"
 )
 
 type sharedResourceLoopMessage struct {
@@ -211,6 +254,17 @@ type sharedResourceLoopMessage_getOrCreateSharedResourceManagedEnvRequest struct
 type sharedResourceLoopMessage_getOrCreateSharedResourcesResponse struct {
 	err               error
 	responseContainer SharedResourceManagedEnvContainer
+}
+
+type sharedResourceLoopMessage_reconcileRepositoryCredentialRequest struct {
+	repositoryCredentialCRName      string
+	repositoryCredentialCRNamespace string
+	k8sClientFactory                SRLK8sClientFactory
+}
+
+type sharedResourceLoopMessage_reconcileRepositoryCredentialResponse struct {
+	err                  error
+	repositoryCredential *db.RepositoryCredentials
 }
 
 func newSharedResourceManagedEnvContainer() SharedResourceManagedEnvContainer {
@@ -254,10 +308,10 @@ type sharedResourceLoopMessage_getOrCreateClusterUserByNamespaceUIDResponse stru
 func internalSharedResourceEventLoop(inputChan chan sharedResourceLoopMessage) {
 
 	ctx := context.Background()
-	log := log.FromContext(ctx)
+	l := log.FromContext(ctx)
 	dbQueries, err := db.NewSharedProductionPostgresDBQueries(false)
 	if err != nil {
-		log.Error(err, "SEVERE: internalSharedResourceEventLoop exiting before startup")
+		l.Error(err, "SEVERE: internalSharedResourceEventLoop exiting before startup")
 		return
 	}
 
@@ -269,7 +323,7 @@ func internalSharedResourceEventLoop(inputChan chan sharedResourceLoopMessage) {
 			return nil
 		})
 		if err != nil {
-			log.Error(err, "unexpected error from processMessage in internalSharedResourceEventLoop")
+			l.Error(err, "unexpected error from processMessage in internalSharedResourceEventLoop")
 		}
 	}
 }
@@ -346,12 +400,428 @@ func processSharedResourceMessage(ctx context.Context, msg sharedResourceLoopMes
 		go func() {
 			msg.responseChannel <- response
 		}()
+	} else if msg.messageType == sharedResourceLoopMessage_reconcileRepositoryCredential {
+
+		var err error
+		var repositoryCredential *db.RepositoryCredentials
+
+		payload, ok := (msg.payload).(sharedResourceLoopMessage_reconcileRepositoryCredentialRequest)
+		if ok {
+
+			repositoryCredential, err = internalProcessMessage_ReconcileRepositoryCredential(ctx,
+				payload.repositoryCredentialCRName, msg.workspaceNamespace, msg.workspaceClient, payload.k8sClientFactory, dbQueries, log)
+
+		} else {
+			err = fmt.Errorf("SEVERE - unexpected cast in internalSharedResourceEventLoop")
+			log.Error(err, err.Error())
+		}
+
+		response := sharedResourceLoopMessage_reconcileRepositoryCredentialResponse{
+			repositoryCredential: repositoryCredential,
+			err:                  err,
+		}
+
+		// Reply on a separate goroutine so cancelled callers don't block the event loop
+		go func() {
+			msg.responseChannel <- response
+		}()
 
 	} else {
 		log.Error(nil, "SEVERE: unrecognized sharedResourceLoopMessageType: "+string(msg.messageType))
 	}
 
 }
+
+func deleteRepositoryCredentialLeftovers(ctx context.Context, apiNamespaceClient client.Client, clusterUser db.ClusterUser, repositoryCredentialCRName string, repositoryCredentialCRNamespace corev1.Namespace, dbQueries db.DatabaseQueries, l logr.Logger) (bool, error) {
+
+	ns := repositoryCredentialCRNamespace.Name
+
+	// Find any existing database resources for repository credentials that previously existing with this namespace/name
+	var repositoryCredentialsList []db.APICRToDatabaseMapping
+	if err := dbQueries.ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx, db.APICRToDatabaseMapping_ResourceType_GitOpsDeploymentRepositoryCredential,
+		repositoryCredentialCRName, ns, string(repositoryCredentialCRNamespace.GetUID()),
+		db.APICRToDatabaseMapping_DBRelationType_RepositoryCredential, &repositoryCredentialsList); err != nil {
+
+		return false, fmt.Errorf("unable to list APICRs for repository credentials: %v", err)
+	}
+
+	if len(repositoryCredentialsList) > 0 { // if there are any Repository Credentials in the database (leftovers)
+		l.V(sharedutil.LogLevel_Debug).Info("Deleting Repository Credentials from the database ...")
+
+		// ----
+		for _, apiCRToDBMapping := range repositoryCredentialsList {
+
+			// Fetch the repocred from the database
+			dbRepoCred, reconciledResult, err := getDBCred(ctx, dbQueries, apiCRToDBMapping, l)
+			if err != nil {
+				return reconciledResult, err
+			}
+
+			// Delete the repocred from the database
+			if reconciledResult, err := deleteRepoCredFromDB(ctx, dbQueries, apiCRToDBMapping, l); err != nil {
+				return reconciledResult, err
+			}
+
+			// Create an operation to delete the repocred from the cluster
+			err = createRepoCredOperation(ctx, l, *dbRepoCred, &clusterUser, ns, dbQueries, apiNamespaceClient)
+			if err != nil {
+				return false, err
+			}
+
+			// Delete the repocred APICRToDatabaseMapping from the shared resource loop
+			deleteAPICRToDatabaseMapping(ctx, repositoryCredentialsList, dbQueries, l)
+		}
+		// ---
+
+		//for _, item := range repositoryCredentialsList {
+		//	fetchRow := db.APICRToDatabaseMapping{
+		//		APIResourceType: item.APIResourceType,
+		//		APIResourceUID:  item.APIResourceUID,
+		//		DBRelationKey:   item.DBRelationKey,
+		//		DBRelationType:  item.DBRelationType,
+		//	}
+		//
+		//	if err := dbQueries.GetDatabaseMappingForAPICR(ctx, &fetchRow); err != nil {
+		//		l.Error(err, "unable to fetch database mapping for APICR")
+		//		continue
+		//	}
+		//
+		//	// 2b) Delete the corresponding database resources
+		//	rowsAffected, err := dbQueries.DeleteRepositoryCredentialsByID(ctx, fetchRow.DBRelationKey)
+		//	if err != nil {
+		//		// Warn, but continue
+		//		l.V(sharedutil.LogLevel_Warn).Info("Unable to delete RepositoryCredentials DB Row", "item", item.APIResourceUID)
+		//	}
+		//	if rowsAffected != 1 {
+		//		// Warn, but continue.
+		//		l.V(sharedutil.LogLevel_Warn).Info("unexpected number of rows deleted for RepositoryCredentials", "mapping", item.APIResourceUID)
+		//	}
+
+		// repositoryCredentialPrimaryKey := item.DBRelationKey
+
+		//TODO: GITOPSRVCE-96: STUB: Next steps:
+		//- Create the operation row, pointing to the deleted repository credentials table
+
+	} else {
+		l.V(sharedutil.LogLevel_Debug).Info("No APICRToDatabaseMapping found for the deleted GitOpsDeploymentRepositoryCredential CR")
+	}
+
+	return false, nil
+}
+
+func getDBCred(ctx context.Context, dbQueries db.DatabaseQueries, apiCRToDBMapping db.APICRToDatabaseMapping, log logr.Logger) (*db.RepositoryCredentials, bool, error) {
+	const retry, noRetry = true, false
+	dbCred, err := dbQueries.GetRepositoryCredentialsByID(ctx, apiCRToDBMapping.APIResourceUID)
+
+	if err != nil {
+		if db.IsResultNotFoundError(err) {
+			log.V(sharedutil.LogLevel_Warn).Info("Received a message for a repository credential database entry that doesn't exist", "error", err, "ID", apiCRToDBMapping.APIResourceUID)
+
+			return nil, noRetry, err
+		} else {
+			// Looks like random glitch in the database, so we should retry
+
+			return nil, retry, fmt.Errorf("unexpected error in retrieving repo credentials with ID '%v' from the database: %v", err, apiCRToDBMapping.APIResourceUID)
+		}
+	}
+
+	log.V(sharedutil.LogLevel_Warn).Info("The repository credential database entry has been received", "ID", dbCred.RepositoryCredentialsID)
+
+	return &dbCred, noRetry, nil
+}
+
+func deleteRepoCredFromDB(ctx context.Context, dbQueries db.DatabaseQueries, apiCRToDBMapping db.APICRToDatabaseMapping, log logr.Logger) (bool, error) {
+	const retry, noRetry = true, false
+	rowsDeleted, err := dbQueries.DeleteRepositoryCredentialsByID(ctx, apiCRToDBMapping.APIResourceUID)
+
+	if err != nil {
+		// Log the error and retry
+		log.V(sharedutil.LogLevel_Debug).Info("Error deleting Repository Credential from the database", "error", err)
+		return retry, err
+	}
+
+	if rowsDeleted == 0 {
+		// Log the error, but continue to delete the other Repository Credentials (this looks morel like a bug in our code)
+		log.V(sharedutil.LogLevel_Warn).Error(nil, "No rows deleted from the database", "rowsDeleted", rowsDeleted, "repocred id", apiCRToDBMapping.APIResourceUID)
+		return noRetry, err
+	}
+
+	// meaning: err == nil && rowsDeleted > 0
+	log.V(sharedutil.LogLevel_Debug).Info("Deleted Repository Credential from the database", "repocred id", apiCRToDBMapping.APIResourceUID)
+	return noRetry, nil
+}
+
+func deleteAPICRToDatabaseMapping(ctx context.Context, apiCRToDBMappingList []db.APICRToDatabaseMapping, dbQueries db.DatabaseQueries, log logr.Logger) {
+	if len(apiCRToDBMappingList) > 0 {
+		for _, item := range apiCRToDBMappingList {
+			rowsDeleted, err := dbQueries.DeleteAPICRToDatabaseMapping(ctx, &item)
+			if err != nil {
+				// Warn, but continue.
+				log.V(sharedutil.LogLevel_Warn).Info("Unable to delete APICRToDatabaseMapping", "item", item.APIResourceUID)
+			}
+			if rowsDeleted != 1 {
+				// Warn, but continue.
+				log.V(sharedutil.LogLevel_Warn).Info("unexpected number of rows deleted for APICRToDatabaseMapping", "mapping", item.APIResourceUID)
+			}
+
+		}
+	} else {
+		log.V(sharedutil.LogLevel_Debug).Info("No APICRToDatabaseMapping found for the deleted GitOpsDeploymentRepositoryCredential CR")
+	}
+
+	log.V(sharedutil.LogLevel_Debug).Info("APICRToDatabaseMapping deleted successfully")
+}
+
+const (
+	errCRNotFound       = "CR no longer exists in the cluster"
+	errGenericCR        = "unable to retrieve CR from the cluster"
+	errBug              = "unexpected error"
+	errUpdateDBRepoCred = "unable to update repository credential in the database"
+	errCreateDBRepoCred = "unable to create repository credential in the database"
+)
+
+func internalProcessMessage_ReconcileRepositoryCredential(ctx context.Context,
+	repositoryCredentialCRName string,
+	repositoryCredentialCRNamespace corev1.Namespace,
+	apiNamespaceClient client.Client,
+	k8sClientFactory SRLK8sClientFactory,
+	dbQueries db.DatabaseQueries, l logr.Logger) (*db.RepositoryCredentials, error) {
+
+	ns := repositoryCredentialCRNamespace.Name
+	cr := repositoryCredentialCRName
+
+	// ----
+	clusterUser, _, err := internalGetOrCreateClusterUserByNamespaceUID(ctx, string(repositoryCredentialCRNamespace.UID), dbQueries, l)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve cluster user in processMessage, '%s': %v", string(repositoryCredentialCRNamespace.UID), err)
+	}
+	// ----
+	gitopsEngineInstance, _, _, err := internalDetermineGitOpsEngineInstanceForNewApplication(ctx, *clusterUser, apiNamespaceClient, dbQueries, l)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve gitops engine instance")
+	}
+	// ----
+
+	// Allocate a struct pointer in memory for receiving the kubernetes CR object
+	repoCreds := &managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredential{}
+
+	// 2) Attempt to get the CR
+	if err := apiNamespaceClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: cr}, repoCreds); err != nil {
+
+		// If the CR is not found, then we can assume it was deleted
+		if apierr.IsNotFound(err) {
+			if repoCreds == nil {
+				// Delete the related leftovers in the database
+				l.Error(err, errCRNotFound, "CR Name:", cr, "Namespace", ns)
+				_, err = deleteRepositoryCredentialLeftovers(ctx, apiNamespaceClient, *clusterUser, cr, repositoryCredentialCRNamespace, dbQueries, l)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				l.Error(err, errBug, "CR Name:", cr, "Namespace", ns)
+				return nil, nil
+			}
+		}
+
+		// Something went wrong, retry
+		l.Error(err, errGenericCR, "CR Name", cr, "Namespace", ns)
+		return nil, fmt.Errorf("unexpected error in retrieving repo credentials: %v", err)
+	}
+
+	// 3. If CR exists in the cluster, check the DB to see if it exists there
+
+	var privateURL, authUsername, authPassword, authSSHKey, secretObj string
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      repoCreds.Spec.Secret,
+			Namespace: ns, // we assume the secret is in the same namespace as the CR
+		},
+	}
+
+	if err := apiNamespaceClient.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
+		if apierr.IsNotFound(err) {
+			l.Info("secret not found", "secret", repoCreds.Spec.Secret, "namespace", ns)
+			return nil, fmt.Errorf("secret not found: %v", err)
+		} else {
+			// Something went wrong, retry
+			l.Error(err, "error retrieving secret", "secret", repoCreds.Spec.Secret, "namespace", ns)
+			return nil, fmt.Errorf("error retrieving secret: %v", err)
+		}
+	} else {
+		// Secret exists, so get its data
+		privateURL = string(secret.Data["url"]) // is this supposed to the same as the CR's Repository?
+		authUsername = string(secret.Data["username"])
+		authPassword = string(secret.Data["password"])
+		authSSHKey = string(secret.Data["sshPrivateKey"])
+		secretObj = secret.Name
+	}
+
+	dbRepoCred, err := dbQueries.GetRepositoryCredentialsByID(ctx, string(repoCreds.UID))
+	if err != nil {
+
+		if db.IsResultNotFoundError(err) {
+			// If the CR exists in the cluster but not in the DB, then create it in the DB and create an Operation.
+			err = dbQueries.CreateRepositoryCredentials(ctx, &db.RepositoryCredentials{
+				RepositoryCredentialsID: string(repoCreds.UID),
+				UserID:                  clusterUser.Clusteruser_id, // comply with the constraint 'fk_clusteruser_id'
+				PrivateURL:              privateURL,                 // or repoCreds.Spec.Repository?
+				AuthUsername:            authUsername,
+				AuthPassword:            authPassword,
+				AuthSSHKey:              authSSHKey,
+				SecretObj:               secretObj,
+				EngineClusterID:         gitopsEngineInstance.Gitopsengineinstance_id, // comply with the constraint 'fk_gitopsengineinstance_id',
+			})
+			if err != nil {
+				l.Error(err, errCreateDBRepoCred, "CR Name", cr, "Namespace", ns)
+				return nil, fmt.Errorf("unable to create repository credential in the database: %v", err)
+			}
+
+			err = createRepoCredOperation(ctx, l, dbRepoCred, clusterUser, ns, dbQueries, apiNamespaceClient)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			l.Error(err, "error retrieving repository credentials from DB", "repositoryCredentialsID", repoCreds.UID)
+			return nil, fmt.Errorf("error retrieving repository credentials from DB: %v", err)
+		}
+	} else {
+		// If the CR exists in the cluster and in the DB, then check if the data is the same and create an Operation
+		isUpdateNeeded := compareClusterResourceWithDatabaseRow(*repoCreds, &dbRepoCred, l)
+		if isUpdateNeeded {
+			l.Info("Syncing with database...")
+			if err = dbQueries.UpdateRepositoryCredentials(ctx, &dbRepoCred); err != nil {
+				l.Error(err, errUpdateDBRepoCred)
+				return nil, err
+			}
+
+			err = createRepoCredOperation(ctx, l, dbRepoCred, clusterUser, ns, dbQueries, apiNamespaceClient)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	//// This is a best effort operation, so we don't return an error if it fails.
+	//
+	//// 2a) Find any existing database resources for repository credentials that previously existing with this namespace/name
+	//var apiCRToDBMappingList []db.APICRToDatabaseMapping
+	//if err := dbQueries.ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx, db.APICRToDatabaseMapping_ResourceType_GitOpsDeploymentRepositoryCredential,
+	//	cr, ns, string(repositoryCredentialCRNamespace.GetUID()),
+	//	db.APICRToDatabaseMapping_DBRelationType_RepositoryCredential, &apiCRToDBMappingList); err != nil {
+	//
+	//	return nil, fmt.Errorf("unable to list APICRs for repository credentials: %v", err)
+	//}
+	//
+	//for _, item := range apiCRToDBMappingList {
+	//
+	//	fmt.Println("Type", item.APIResourceType)
+	//	fmt.Println("UID", item.APIResourceUID)
+	//	fmt.Println("Namespace", item.APIResourceNamespace)
+	//	fmt.Println("Name", item.APIResourceName)
+	//	fmt.Println("DB Relation Type", item.DBRelationType)
+	//	fmt.Println("DB Relation Key", item.DBRelationKey)
+	//
+	//	fetchRow := db.APICRToDatabaseMapping{
+	//		APIResourceType: item.APIResourceType,
+	//		APIResourceUID:  item.APIResourceUID,
+	//		DBRelationKey:   item.DBRelationKey,
+	//		DBRelationType:  item.DBRelationType,
+	//	}
+	//
+	//	if err = dbQueries.GetDatabaseMappingForAPICR(ctx, &fetchRow); err != nil {
+	//		log.Error(err, "unable to fetch database mapping for APICR")
+	//		continue
+	//	}
+	//
+	//	// 2b) Delete the corresponding database resources
+	//	rowsAffected, err := dbQueries.DeleteRepositoryCredentialsByID(ctx, fetchRow.DBRelationKey)
+	//	if err != nil {
+	//		// Warn, but continue
+	//		log.V(sharedutil.LogLevel_Warn).Info("Unable to delete RepositoryCredentials DB Row", "item", item.APIResourceUID)
+	//	}
+	//	if rowsAffected != 1 {
+	//		// Warn, but continue.
+	//		log.V(sharedutil.LogLevel_Warn).Info("unexpected number of rows deleted for RepositoryCredentials", "mapping", item.APIResourceUID)
+	//	}
+	//
+	//	// repositoryCredentialPrimaryKey := item.DBRelationKey
+	//
+	//	fmt.Println("STUB:", item)
+
+	// TODO: GITOPSRVCE-96: STUB: Next steps:
+	// - Delete the repository credential from the database
+	// - Create the operation row, pointing to the deleted repository credentials table
+	// - Delete the APICRToDatabaseMapping referenced by 'item'
+
+	// Success!
+	// return nil, nil
+
+	// }
+
+	// TODO: GITOPSRVCE-96: We should probably rename this to internalDetermineGitOpsEngineInstance, given how it is being used :P
+
+	// TODO: GITOPSRVCE-96: STUB:
+	// - If the GitOpsDeploymentRepositoryCredential does exist, but not in the DB, then create a RepositoryCredential DB entry
+	// - If the GitOpsDeploymentRepositoryCredential does exist, and also in the DB, then compare and change the RepositoryCredential DB entry
+	// Then, in both cases, create an Operation to update the cluster-agent
+
+	return nil, fmt.Errorf("STUB!")
+
+}
+
+func createRepoCredOperation(ctx context.Context, l logr.Logger, dbRepoCred db.RepositoryCredentials, clusterUser *db.ClusterUser, ns string, dbQueries db.DatabaseQueries, apiNamespaceClient client.Client) error {
+	l.Info("Creating operation...")
+	dbOperationInput := db.Operation{
+		Instance_id:             dbRepoCred.EngineClusterID,
+		Resource_id:             dbRepoCred.RepositoryCredentialsID,
+		Resource_type:           db.OperationResourceType_RepositoryCredentials,
+		State:                   db.OperationState_Waiting,
+		Operation_owner_user_id: clusterUser.Clusteruser_id,
+	}
+
+	operationCR, operationDB, err := operations.CreateOperation(ctx, false, dbOperationInput, clusterUser.Clusteruser_id, ns, dbQueries, apiNamespaceClient, l)
+	if err != nil {
+		return fmt.Errorf("unable to create operation: %v", err)
+	}
+
+	l.Info("operationCR", "operationCR", operationCR)
+	l.Info("operationDB", "operationDB", operationDB)
+
+	return nil
+}
+
+func compareClusterResourceWithDatabaseRow(cr managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredential, dbr *db.RepositoryCredentials, l logr.Logger) bool {
+	var isSecretUpdateNeeded bool
+	if cr.Spec.Secret != dbr.SecretObj {
+		l.Info("Secret name changed", "old", dbr.SecretObj, "new", cr.Spec.Secret)
+		dbr.SecretObj = cr.Spec.Secret
+		isSecretUpdateNeeded = true
+	}
+
+	var isRepoUpdateNeeded bool
+	if cr.Spec.Repository != dbr.PrivateURL {
+		l.Info("Repository URL changed", "old", dbr.PrivateURL, "new", cr.Spec.Repository)
+		dbr.PrivateURL = cr.Spec.Repository
+		isSecretUpdateNeeded = true
+	}
+
+	return isSecretUpdateNeeded || isRepoUpdateNeeded
+}
+
+//func getRepoCredFromDB(ctx context.Context, dbQueries db.DatabaseQueries, req ctrl.Request, namespace *corev1.Namespace) ([]db.APICRToDatabaseMapping, bool, error) {
+//	const retry, noRetry = true, false
+//
+//	var apiCRToDBMappingList []db.APICRToDatabaseMapping
+//	if err := dbQueries.ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx, db.APICRToDatabaseMapping_ResourceType_GitOpsDeploymentRepositoryCredential,
+//		req.Name, req.Namespace, string(namespace.GetUID()), db.APICRToDatabaseMapping_DBRelationType_RepositoryCredential, &apiCRToDBMappingList); err != nil {
+//
+//		// We don't know wha t happened, so we'll retry
+//		return nil, retry, fmt.Errorf("unable to list API CRs for repository credentials: %v", err)
+//	}
+//
+//	// Return the list of repository credentials
+//	return apiCRToDBMappingList, noRetry, nil
+//}
 
 func internalProcessMessage_GetGitopsEngineInstanceById(ctx context.Context, id string, dbq db.DatabaseQueries) (*db.GitopsEngineInstance, error) {
 
@@ -400,21 +870,21 @@ const (
 // The bool return value is 'true' if respective resource is created; 'false' if it already exists in DB or in case of failure.
 func internalProcessMessage_GetOrCreateSharedResources(ctx context.Context, gitopsEngineClient client.Client,
 	workspaceNamespace corev1.Namespace, dbQueries db.DatabaseQueries,
-	log logr.Logger) (SharedResourceManagedEnvContainer, error) {
+	l logr.Logger) (SharedResourceManagedEnvContainer, error) {
 
-	clusterUser, isNewUser, err := internalGetOrCreateClusterUserByNamespaceUID(ctx, string(workspaceNamespace.UID), dbQueries, log)
+	clusterUser, isNewUser, err := internalGetOrCreateClusterUserByNamespaceUID(ctx, string(workspaceNamespace.UID), dbQueries, l)
 	if err != nil {
 		return SharedResourceManagedEnvContainer{},
 			fmt.Errorf("unable to retrieve cluster user in processMessage, '%s': %v", string(workspaceNamespace.UID), err)
 	}
 
-	managedEnv, isNewManagedEnv, err := dbutil.GetOrCreateManagedEnvironmentByNamespaceUID(ctx, workspaceNamespace, dbQueries, log)
+	managedEnv, isNewManagedEnv, err := dbutil.GetOrCreateManagedEnvironmentByNamespaceUID(ctx, workspaceNamespace, dbQueries, l)
 	if err != nil {
 		return SharedResourceManagedEnvContainer{},
 			fmt.Errorf("unable to get or created managed env on deployment modified event: %v", err)
 	}
 
-	engineInstance, isNewInstance, gitopsEngineCluster, err := internalDetermineGitOpsEngineInstanceForNewApplication(ctx, *clusterUser, *managedEnv, gitopsEngineClient, dbQueries, log)
+	engineInstance, isNewInstance, gitopsEngineCluster, err := internalDetermineGitOpsEngineInstanceForNewApplication(ctx, *clusterUser, gitopsEngineClient, dbQueries, l)
 	if err != nil {
 		return SharedResourceManagedEnvContainer{}, fmt.Errorf("unable to determine gitops engine instance: %v", err)
 	}
@@ -426,7 +896,7 @@ func internalProcessMessage_GetOrCreateSharedResources(ctx context.Context, gito
 		Clusteraccess_gitops_engine_instance_id: engineInstance.Gitopsengineinstance_id,
 	}
 
-	err, isNewClusterAccess := internalGetOrCreateClusterAccess(ctx, &ca, dbQueries, log)
+	err, isNewClusterAccess := internalGetOrCreateClusterAccess(ctx, &ca, dbQueries, l)
 	if err != nil {
 		return SharedResourceManagedEnvContainer{}, fmt.Errorf("unable to create cluster access: %v", err)
 	}
@@ -456,7 +926,7 @@ func internalProcessMessage_GetOrCreateSharedResources(ctx context.Context, gito
 // The bool return value is 'true' if GitOpsEngineInstance is created; 'false' if it already exists in DB or in case of failure.
 //
 // This logic would be improved by https://issues.redhat.com/browse/GITOPSRVCE-73 (and others)
-func internalDetermineGitOpsEngineInstanceForNewApplication(ctx context.Context, user db.ClusterUser, managedEnv db.ManagedEnvironment,
+func internalDetermineGitOpsEngineInstanceForNewApplication(ctx context.Context, user db.ClusterUser,
 	k8sClient client.Client, dbq db.DatabaseQueries, log logr.Logger) (*db.GitopsEngineInstance, bool, *db.GitopsEngineCluster, error) {
 
 	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: dbutil.GetGitOpsEngineSingleInstanceNamespace(), Namespace: dbutil.GetGitOpsEngineSingleInstanceNamespace()}}
@@ -478,7 +948,7 @@ func internalDetermineGitOpsEngineInstanceForNewApplication(ctx context.Context,
 	//
 	// algorithm input:
 	// - user
-	// - managed environment
+	// - API namespace (this assumes that all gitopsdeployment* APIs in a single namespace will share the same Argo CD instance)
 	//
 	// output:
 	// - gitops engine instance

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -520,6 +520,7 @@ func internalProcessMessage_ReconcileRepositoryCredential(ctx context.Context,
 				return nil, nil
 			} else {
 				for _, item := range apiCRToDBMappingList {
+					item := item // reassign the iteration variable inside the loop to fix G601 (CWE-118) issue
 					repositoryCredentialPrimaryKey := item.APIResourceName
 					dbRepoCred, err2 := dbQueries.GetRepositoryCredentialsByID(ctx, repositoryCredentialPrimaryKey)
 

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -668,7 +668,6 @@ func internalProcessMessage_ReconcileRepositoryCredential(ctx context.Context,
 			l.Info("Created Operation for RepositoryCredential")
 
 			// Create the mapping
-			apiCRToDBList = append(apiCRToDBList, mapping)
 			var operationDB db.Operation
 			var o []db.Operation
 			primaryKey := dbRepoCred.RepositoryCredentialsID

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
@@ -400,9 +400,10 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			err = k8sClient.List(ctx, operationList)
 			Expect(err).To(BeNil())
 
-			if len(operationList.Items) == 1 {
-				operationDB.Operation_id = operationList.Items[0].Spec.OperationID
-			}
+			//if len(operationList.Items) == 1 {
+			//	operationDB.Operation_id = operationList.Items[0].Spec.OperationID
+			//}
+			l.Info("operationList.Items", "operationList.Items", operationList.Items)
 
 			err = dbq.GetOperationById(ctx, &operationDB)
 			Expect(err).To(BeNil())

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
@@ -3,7 +3,6 @@ package shared_resource_loop
 import (
 	"context"
 	"fmt"
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -385,7 +384,8 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			repositoryCredentialCRNamespace.UID = types.UID(gitopsEngineInstance.Namespace_uid)
 
 			var k8sClientFactory SRLK8sClientFactory
-			var l logr.Logger
+			l := log
+			fmt.Println("Logger variable withing the Ginkgo Tests:", l)
 
 			dbRepoCred, err := internalProcessMessage_ReconcileRepositoryCredential(ctx, cr.Name, repositoryCredentialCRNamespace, k8sClient, k8sClientFactory, dbq, l)
 			fmt.Println("dbRepoCred: ", dbRepoCred)

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
@@ -440,6 +440,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			Expect(err).To(BeNil())
 			dbRepoCred, err = internalProcessMessage_ReconcileRepositoryCredential(ctx, cr.Name, repositoryCredentialCRNamespace, k8sClient, k8sClientFactory, dbq, l)
 			Expect(err).To(BeNil())
+			Expect(dbRepoCred).ToNot(BeNil())
 
 			// Check if there are any operations left (should not create 2nd operation if already exists for this resource)
 			operationList = &managedgitopsv1alpha1.OperationList{}

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
@@ -459,6 +459,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			dbRepoCred.SecretObj = "test-secret-2"
 			err = dbq.UpdateRepositoryCredentials(ctx, dbRepoCred)
 			Expect(err).To(BeNil())
+
 			dbRepoCred, err = internalProcessMessage_ReconcileRepositoryCredential(ctx, cr.Name, repositoryCredentialCRNamespace, k8sClient, k8sClientFactory, dbq, l)
 			Expect(err).To(BeNil())
 			Expect(dbRepoCred).ToNot(BeNil())

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/types"
-
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -390,9 +389,10 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 
 			// Create again the CR
 			// Expected: Since there's no DB entry for the CR, it will create an operation
-			dbRepoCred, err = internalProcessMessage_ReconcileRepositoryCredential(ctx, cr.Name, repositoryCredentialCRNamespace, k8sClient, k8sClientFactory, dbq, l)
+			dbRepoCred, err = internalProcessMessage_ReconcileRepositoryCredential(ctx, cr.Name, repositoryCredentialCRNamespace, k8sClient, k8sClientFactory, dbq, false, l)
 			Expect(err).To(BeNil())
 			Expect(dbRepoCred).NotTo(BeNil())
+
 			var operationDB db.Operation
 			var operations []db.Operation
 
@@ -430,7 +430,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 
 			// Re-running should not error
 			l.Info("Re-running the internalProcessMessage_ReconcileRepositoryCredential()")
-			dbRepoCred, err = internalProcessMessage_ReconcileRepositoryCredential(ctx, cr.Name, repositoryCredentialCRNamespace, k8sClient, k8sClientFactory, dbq, l)
+			dbRepoCred, err = internalProcessMessage_ReconcileRepositoryCredential(ctx, cr.Name, repositoryCredentialCRNamespace, k8sClient, k8sClientFactory, dbq, false, l)
 			Expect(err).To(BeNil())
 			Expect(dbRepoCred).NotTo(BeNil())
 
@@ -460,7 +460,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			err = dbq.UpdateRepositoryCredentials(ctx, dbRepoCred)
 			Expect(err).To(BeNil())
 
-			dbRepoCred, err = internalProcessMessage_ReconcileRepositoryCredential(ctx, cr.Name, repositoryCredentialCRNamespace, k8sClient, k8sClientFactory, dbq, l)
+			dbRepoCred, err = internalProcessMessage_ReconcileRepositoryCredential(ctx, cr.Name, repositoryCredentialCRNamespace, k8sClient, k8sClientFactory, dbq, false, l)
 			Expect(err).To(BeNil())
 			Expect(dbRepoCred).ToNot(BeNil())
 
@@ -490,7 +490,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			// Expected: Since there is no GitOpsDeploymentRepositoryCredential CR, it will delete the DB entry
 			err = k8sClient.Delete(ctx, cr)
 			Expect(err).To(BeNil())
-			dbRepoCred, err = internalProcessMessage_ReconcileRepositoryCredential(ctx, cr.Name, repositoryCredentialCRNamespace, k8sClient, k8sClientFactory, dbq, l)
+			dbRepoCred, err = internalProcessMessage_ReconcileRepositoryCredential(ctx, cr.Name, repositoryCredentialCRNamespace, k8sClient, k8sClientFactory, dbq, false, l)
 			Expect(err).To(BeNil())
 			Expect(dbRepoCred).To(BeNil())
 
@@ -513,7 +513,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 
 			// Negative test: Try again to reconcile the RepositoryCredential
 			// Expected: It should not error (both db row and CR should be deleted). Nothing we can do.
-			dbRepoCred, err = internalProcessMessage_ReconcileRepositoryCredential(ctx, cr.Name, repositoryCredentialCRNamespace, k8sClient, k8sClientFactory, dbq, l)
+			dbRepoCred, err = internalProcessMessage_ReconcileRepositoryCredential(ctx, cr.Name, repositoryCredentialCRNamespace, k8sClient, k8sClientFactory, dbq, false, l)
 			Expect(err).To(BeNil())
 			Expect(dbRepoCred).To(BeNil())
 		})

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
@@ -2,6 +2,7 @@ package shared_resource_loop
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -367,7 +368,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 
 			var k8sClientFactory SRLK8sClientFactory
 
-			dbRepoCred, err := internalProcessMessage_ReconcileRepositoryCredential(ctx, cr.Name, repositoryCredentialCRNamespace, k8sClient, k8sClientFactory, dbq, l)
+			dbRepoCred, err := internalProcessMessage_ReconcileRepositoryCredential(ctx, cr.Name, repositoryCredentialCRNamespace, k8sClient, k8sClientFactory, dbq, false, l)
 
 			// Negative test (there is no Secret)
 			Expect(err).NotTo(BeNil())

--- a/backend/eventloop/workspace_resource_event_loop.go
+++ b/backend/eventloop/workspace_resource_event_loop.go
@@ -198,46 +198,48 @@ func internalProcessWorkspaceResourceMessage(ctx context.Context, msg workspaceR
 			return false, nil
 		}
 
-		repoCreds := &managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredential{}
+		// REVIEWER: Please advise
 
-		if err := msg.apiNamespaceClient.Get(ctx, req.NamespacedName, repoCreds); err != nil {
-
-			if !apierr.IsNotFound(err) {
-				return true, fmt.Errorf("unexpected error in retrieving repo credentials: %v", err)
-			}
-
-			// The repository credentials necessarily don't exist
-
-			// Find any existing database resources for repository credentials that previously existing with this namespace/name
-			apiCRToDBMappingList := []db.APICRToDatabaseMapping{}
-			if err := dbQueries.ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx, db.APICRToDatabaseMapping_ResourceType_GitOpsDeploymentRepositoryCredential,
-				req.Name, req.Namespace, string(namespace.GetUID()), db.APICRToDatabaseMapping_DBRelationType_RepositoryCredential, &apiCRToDBMappingList); err != nil {
-
-				return true, fmt.Errorf("unable to list APICRs for repository credentials: %v", err)
-			}
-
-			for _, item := range apiCRToDBMappingList {
-
-				fmt.Println("STUB:", item)
-
-				// TODO: GITOPSRVCE-96: STUB: Next steps:
-				// - Delete the repository credential from the database
-				// - Create the operation row, pointing to the deleted repository credentials table
-				// - Delete the APICRToDatabaseMapping referenced by 'item'
-
-			}
-
-			// TODO: GITOPSRVCE-96:  STUB - reconcile on the missing repository credentials
-
-			return false, fmt.Errorf("STUB: reconcile on the missing repository credentials")
-
-		}
-
-		// TODO: GITOPSRVCE-96: STUB: If it exists, compare it with what's in the database
-		// - If it doesn't exist in the database, create it
-		// - If it does exist in the database, but the values are different, update it
-
-		return false, fmt.Errorf("STUB: not yet implemented")
+		//repoCreds := &managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredential{}
+		//
+		//if err := msg.apiNamespaceClient.Get(ctx, req.NamespacedName, repoCreds); err != nil {
+		//
+		//	if !apierr.IsNotFound(err) {
+		//		return true, fmt.Errorf("unexpected error in retrieving repo credentials: %v", err)
+		//	}
+		//
+		//	// The repository credentials necessarily don't exist
+		//
+		//	// Find any existing database resources for repository credentials that previously existing with this namespace/name
+		//	apiCRToDBMappingList := []db.APICRToDatabaseMapping{}
+		//	if err := dbQueries.ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx, db.APICRToDatabaseMapping_ResourceType_GitOpsDeploymentRepositoryCredential,
+		//		req.Name, req.Namespace, string(namespace.GetUID()), db.APICRToDatabaseMapping_DBRelationType_RepositoryCredential, &apiCRToDBMappingList); err != nil {
+		//
+		//		return true, fmt.Errorf("unable to list APICRs for repository credentials: %v", err)
+		//	}
+		//
+		//	for _, item := range apiCRToDBMappingList {
+		//
+		//		fmt.Println("STUB:", item)
+		//
+		//		// TODO: GITOPSRVCE-96: STUB: Next steps:
+		//		// - Delete the repository credential from the database
+		//		// - Create the operation row, pointing to the deleted repository credentials table
+		//		// - Delete the APICRToDatabaseMapping referenced by 'item'
+		//
+		//	}
+		//
+		//	// TODO: GITOPSRVCE-96:  STUB - reconcile on the missing repository credentials
+		//
+		//	return false, fmt.Errorf("STUB: reconcile on the missing repository credentials")
+		//
+		//}
+		//
+		//// TODO: GITOPSRVCE-96: STUB: If it exists, compare it with what's in the database
+		//// - If it doesn't exist in the database, create it
+		//// - If it does exist in the database, but the values are different, update it
+		//
+		//return false, fmt.Errorf("STUB: not yet implemented")
 	} else if msg.messageType == workspaceResourceLoopMessageType_processManagedEnvironment {
 
 		evlMessage, ok := (msg.payload).(eventlooptypes.EventLoopMessage)

--- a/backend/eventloop/workspace_resource_event_loop.go
+++ b/backend/eventloop/workspace_resource_event_loop.go
@@ -7,8 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
-	db "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
+	"github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/eventlooptypes"
 	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/shared_resource_loop"
@@ -90,11 +89,11 @@ func internalWorkspaceResourceEventLoop(inputChan chan workspaceResourceLoopMess
 	workspaceEventLoopInputChannel chan workspaceEventLoopMessage) {
 
 	ctx := context.Background()
-	log := log.FromContext(ctx).WithValues("component", "workspace_resource_event_loop")
+	l := log.FromContext(ctx).WithValues("component", "workspace_resource_event_loop")
 
 	dbQueries, err := db.NewSharedProductionPostgresDBQueries(false)
 	if err != nil {
-		log.Error(err, "SEVERE: internalSharedResourceEventLoop exiting before startup")
+		l.Error(err, "SEVERE: internalSharedResourceEventLoop exiting before startup")
 		return
 	}
 
@@ -109,7 +108,7 @@ func internalWorkspaceResourceEventLoop(inputChan chan workspaceResourceLoopMess
 
 			repoCred, ok := (msg.payload).(ctrl.Request)
 			if !ok {
-				log.Error(nil, "SEVERE: Unexpected payload type in workspace resource event loop")
+				l.Error(nil, "SEVERE: Unexpected payload type in workspace resource event loop")
 				continue
 			}
 
@@ -119,14 +118,14 @@ func internalWorkspaceResourceEventLoop(inputChan chan workspaceResourceLoopMess
 
 			evlMsg, ok := (msg.payload).(eventlooptypes.EventLoopMessage)
 			if !ok {
-				log.Error(nil, "SEVERE: Unexpected payload type in workspace resource event loop")
+				l.Error(nil, "SEVERE: Unexpected payload type in workspace resource event loop")
 				continue
 			}
 
 			mapKey = "managed-env-" + evlMsg.Event.Request.Namespace + "-" + evlMsg.Event.Request.Name
 
 		} else {
-			log.Error(nil, "SEVERE: Unexpected message type: "+string(msg.messageType))
+			l.Error(nil, "SEVERE: Unexpected message type: "+string(msg.messageType))
 			continue
 		}
 
@@ -136,7 +135,7 @@ func internalWorkspaceResourceEventLoop(inputChan chan workspaceResourceLoopMess
 		task := &workspaceResourceEventTask{
 			msg:                            msg,
 			dbQueries:                      dbQueries,
-			log:                            log,
+			log:                            l,
 			sharedResourceLoop:             sharedResourceLoop,
 			workspaceEventLoopInputChannel: workspaceEventLoopInputChannel,
 		}
@@ -289,112 +288,4 @@ func internalProcessWorkspaceResourceMessage(ctx context.Context, msg workspaceR
 	}
 
 	return false, nil
-}
-
-func getDBCred(ctx context.Context, dbQueries db.DatabaseQueries, apiCRToDBMapping db.APICRToDatabaseMapping, log logr.Logger) (*db.RepositoryCredentials, bool, error) {
-	const retry, noRetry = true, false
-	dbCred, err := dbQueries.GetRepositoryCredentialsByID(ctx, apiCRToDBMapping.APIResourceUID)
-
-	if err != nil {
-		if db.IsResultNotFoundError(err) {
-			log.V(sharedutil.LogLevel_Warn).Info("Received a message for a repository credential database entry that doesn't exist", "error", err, "ID", apiCRToDBMapping.APIResourceUID)
-
-			return nil, noRetry, err
-		} else {
-			// Looks like random glitch in the database, so we should retry
-
-			return nil, retry, fmt.Errorf("unexpected error in retrieving repo credentials with ID '%v' from the database: %v", err, apiCRToDBMapping.APIResourceUID)
-		}
-	}
-
-	log.V(sharedutil.LogLevel_Warn).Info("The repository credential database entry has been received", "ID", dbCred.RepositoryCredentialsID)
-
-	return &dbCred, noRetry, nil
-}
-
-func deleteAPICRToDatabaseMapping(ctx context.Context, apiCRToDBMappingList []db.APICRToDatabaseMapping, dbQueries db.DatabaseQueries, log logr.Logger) {
-	if len(apiCRToDBMappingList) > 0 {
-		for _, item := range apiCRToDBMappingList {
-			rowsDeleted, err := dbQueries.DeleteAPICRToDatabaseMapping(ctx, &item)
-			if err != nil {
-				// Warn, but continue.
-				log.V(sharedutil.LogLevel_Warn).Info("Unable to delete APICRToDatabaseMapping", "item", item.APIResourceUID)
-			}
-			if rowsDeleted != 1 {
-				// Warn, but continue.
-				log.V(sharedutil.LogLevel_Warn).Info("unexpected number of rows deleted for APICRToDatabaseMapping", "mapping", item.APIResourceUID)
-			}
-
-		}
-	} else {
-		log.V(sharedutil.LogLevel_Debug).Info("No APICRToDatabaseMapping found for the deleted GitOpsDeploymentRepositoryCredential CR")
-	}
-
-	log.V(sharedutil.LogLevel_Debug).Info("APICRToDatabaseMapping deleted successfully")
-}
-
-func deleteRepoCredFromDB(ctx context.Context, dbQueries db.DatabaseQueries, apiCRToDBMapping db.APICRToDatabaseMapping, log logr.Logger) (bool, error) {
-	const retry, noRetry = true, false
-	rowsDeleted, err := dbQueries.DeleteRepositoryCredentialsByID(ctx, apiCRToDBMapping.APIResourceUID)
-
-	if err != nil {
-		// Log the error and retry
-		log.V(sharedutil.LogLevel_Debug).Info("Error deleting Repository Credential from the database", "error", err)
-		return retry, err
-	}
-
-	if rowsDeleted == 0 {
-		// Log the error, but continue to delete the other Repository Credentials (this looks morel like a bug in our code)
-		log.V(sharedutil.LogLevel_Warn).Error(nil, "No rows deleted from the database", "rowsDeleted", rowsDeleted, "repocred id", apiCRToDBMapping.APIResourceUID)
-		return noRetry, err
-	}
-
-	// meaning: err == nil && rowsDeleted > 0
-	log.V(sharedutil.LogLevel_Debug).Info("Deleted Repository Credential from the database", "repocred id", apiCRToDBMapping.APIResourceUID)
-	return noRetry, nil
-}
-
-func getCR(ctx context.Context, msg workspaceResourceLoopMessage, req ctrl.Request, log logr.Logger) (*managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredential, bool, error) {
-	const retry, noRetry = true, false
-	repoCreds := &managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredential{}
-
-	if err := msg.apiNamespaceClient.Get(ctx, req.NamespacedName, repoCreds); err != nil {
-
-		if !apierr.IsNotFound(err) {
-			// We don't know what happened, so we'll retry
-			return nil, retry, fmt.Errorf("unexpected error in retrieving repo credentials CR: %v", err)
-		}
-
-		// The CR was deleted, (Note: this is not an error)
-		log.V(sharedutil.LogLevel_Warn).Info("Received a message for a repository credential CR that doesn't exist", "CR", repoCreds)
-		return nil, noRetry, nil
-	}
-
-	// The CR exists
-	return repoCreds, noRetry, nil
-}
-
-func getNamespace(ctx context.Context, msg workspaceResourceLoopMessage, req ctrl.Request, log logr.Logger) (*corev1.Namespace, bool, error) {
-	const retry, noRetry = true, false
-	namespace := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      req.Namespace,
-			Namespace: req.Namespace,
-		},
-	}
-
-	if err := msg.apiNamespaceClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
-
-		if !apierr.IsNotFound(err) {
-			// We don't know if the namespace exists or not, so we need to retry
-			return namespace, retry, fmt.Errorf("unexpected error in retrieving repo credentials namespace: %v", err)
-		}
-
-		// Namespace doesn't exist (Note: this is not an error)
-		log.V(sharedutil.LogLevel_Warn).Info("Received a message for a repository credential in a namespace that doesn't exist", "namespace", namespace)
-		return namespace, noRetry, nil
-	}
-
-	// The namespace exists
-	return namespace, noRetry, nil
 }

--- a/backend/eventloop/workspace_resource_event_loop.go
+++ b/backend/eventloop/workspace_resource_event_loop.go
@@ -204,7 +204,7 @@ func internalProcessWorkspaceResourceMessage(ctx context.Context, msg workspaceR
 		_, err := sharedResourceLoop.ReconcileRepositoryCredential(ctx, msg.apiNamespaceClient, *namespace, req.Name, shared_resource_loop.DefaultK8sClientFactory{})
 
 		if err != nil {
-			return retry, fmt.Errorf("unable to reconcile repository credential")
+			return retry, fmt.Errorf("unable to reconcile repository credential. Error: %v", err)
 		}
 
 		return noRetry, nil

--- a/examples/m10-demo/README.md
+++ b/examples/m10-demo/README.md
@@ -1,0 +1,296 @@
+# 10 Demo
+
+Get an openshift cluster.
+
+```bash
+# Install GitOps Operator + ArgoCD with new keys
+$ make install-argocd-openshift
+
+# Get the password for ArgoCD Web UI
+$ ARGOCD_SERVER=$(oc -n gitops-service-argocd get routes gitops-service-argocd-server -o jsonpath="{.spec.host}")
+$ ARGOCD_PASSWORD=$(oc -n gitops-service-argocd get secret gitops-service-argocd-cluster -o jsonpath="{.data.admin\.password}" | base64 --decode)
+
+# Login with ArgoCD binary (optional, if you use argocd binary to verify)
+$ argocd login $ARGOCD_SERVER --username admin --password $ARGOCD_PASSWORD
+
+# Check for the keys
+$ oc -n gitops-service-argocd get configmap -o jsonpath='{.data.ssh_known_hosts}'  argocd-ssh-known-hosts-cm | grep 'github.com ssh-ed25519'
+$ oc -n gitops-service-argocd get configmap -o jsonpath='{.data.ssh_known_hosts}'  argocd-ssh-known-hosts-cm | grep 'github.com ecdsa-sha2-nistp256'
+
+# Create a key pair
+# You can do it in a container if you like
+$ docker run --rm -it --name demo fedora /bin/bash
+$ dnf install openssh-server -y
+$ ssh-keygen -t ed25519
+$ cat /root/.ssh/id_ed25519 # Private key
+$ cat /root/.ssh/id_ed25519.pub # Public key
+$ exit
+```
+
+* Go to your GitHub private repo and add the Public key. We will use it for SSH access.
+* Also, generate a personal token for your GitHub account as well. We will use it for HTTPS access.
+
+Lastly, start the Gitops Service controllers:
+
+```bash
+$ make devenv-docker
+$ make start
+```
+
+## Leaking credential notice
+
+> Notice: We cannot publish our token and SSH keys to give you access in our private repository that we use for this demo.
+
+If you would like to follow along with this demo, create your own private repo at GitHub or Gitlab (the both are tested and they work fine). There create a folder `resources` and inside create a `configmap.yaml` file: 
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-map-in-private-repo
+data: {}
+```
+
+For example:
+
+```
+https://github.com/YOUR_GITHUB_USERNAME/YOUR_PRIVATEREPO/resources/configmap.yaml
+```
+
+## Case 1: Access via HTTPS Token
+
+Use GitOps Service to watch over a directory called `resources` that is located into a private-repository [github.com/managed-gitops-test-data/private-repo-test](https://github.com/managed-gitops-test-data/private-repo-test) and deploy the config-map `config-map-in-private-repo` from it, into your OpenShift cluster, in a namespace called `panos`.
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: panos
+  labels:
+    # If you forget this label, you will end up with an error
+    # ComparisonError: Namespace "panos" for ConfigMap "config-map-in-private-repo" is not managed
+    argocd.argoproj.io/managed-by: gitops-service-argocd
+```
+
+To access this private repository you have to already have access to it as a GitHub user.
+That means: either it's already yours (so you have already access) or somebody else (the owner of the private repository) has to add you to the list of GitHub users who have access to it.
+
+As soon as you verify you can acess it, then give access to GitOps Service as well.
+
+To do this, you will use [your personal HTTPS token from GitHub](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). Given your GitHub user/account already has access there, then your personal token will also have access there.
+
+Create a Kubernetes Secret resource, with your GitHub Username and your password.
+But, **instead** of your *password*, type your *token*.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  # Remember the name of the secret and the namespace
+  # as you need them later for the GitOpsDeploymentRepositoryCredential
+  name: private-repo-creds-secret-https-token
+  namespace: panos
+type: Opaque
+stringData:
+  # Your GitHub e-mail
+  username: PUT_HERE_YOUR_GITHUB_EMAIL
+  # Your Token (remember, this is not your GitHub password)
+  password: PUT_HERE_YOUR_GITHUB_PERSONAL_TOKEN
+```
+
+Then create a `gitopsdeploymentrepositorycredential` CR that associates this Secret with the private repository.
+
+```yaml
+apiVersion: managed-gitops.redhat.com/v1alpha1
+kind: GitOpsDeploymentRepositoryCredential
+metadata:
+  name: private-repo-https
+  # Put the Secret's namespace
+  namespace: panos
+spec:
+  # Use the HTTPS address of the private repository
+  repository: https://github.com/managed-gitops-test-data/private-repo-test.git
+  # Put the Secret's name
+  secret: private-repo-creds-secret-https-token
+```
+
+In the end, create a `gitopsdeployment` CR that points to this private repository,
+and looks for manifests inside the directory called `resources`.
+
+```yaml
+apiVersion: managed-gitops.redhat.com/v1alpha1
+kind: GitOpsDeployment
+metadata:
+  name: private-https-depl
+  namespace: panos
+spec:
+  source:
+    # It has to be the same HTTPS link
+    repoURL: https://github.com/managed-gitops-test-data/private-repo-test.git
+    path: resources
+  type: automated
+```
+ 
+In one YAML, all this would be:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: panos
+  labels:
+    argocd.argoproj.io/managed-by: gitops-service-argocd
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: private-repo-creds-secret-https-token
+  namespace: panos
+type: Opaque
+stringData:
+  username: PUT_HERE_YOUR_GITHUB_EMAIL
+  password: PUT_HERE_YOUR_GITHUB_PERSONAL_TOKEN
+
+---
+apiVersion: managed-gitops.redhat.com/v1alpha1
+kind: GitOpsDeploymentRepositoryCredential
+metadata:
+  name: private-repo-https
+  namespace: panos
+spec:
+  repository: https://github.com/managed-gitops-test-data/private-repo-test.git
+  secret: private-repo-creds-secret-https-token
+
+---
+apiVersion: managed-gitops.redhat.com/v1alpha1
+kind: GitOpsDeployment
+metadata:
+  name: private-https-depl
+  namespace: panos
+spec:
+  source:
+    repoURL: https://github.com/managed-gitops-test-data/private-repo-test.git
+    path: resources
+  type: automated
+```
+
+If everything went well, this `configmap` has to exist:
+
+```bash
+oc -n panos get cm config-map-in-private-repo
+```
+
+You can also see the ArgoCD secret that has been created behind the scenes.
+It has the same name with your secret but instead of living into `panos` namespace,
+it exists into `gitops-service-argocd`:
+
+```bash
+$ oc -n gitops-service-argocd get secret private-repo-creds-secret-https-token -o yaml
+```
+
+Notice the `argocd.argoproj.io/secret-type: repository` and the values are base64.
+
+You can also verify the Health of ArgoCD via looking either at ArgoCD Dashboard or CLI:
+
+```bash
+# Check the private repo access
+$ argocd repo list --grpc-web --refresh hard
+
+TYPE  NAME                                   REPO                                                               INSECURE  OCI    LFS    CREDS  STATUS      MESSAGE  PROJECT
+git   private-repo-creds-secret-https-token  https://github.com/managed-gitops-test-data/private-repo-test.git  false     false  false  true   Successful
+
+
+# Check the app that deploys from this private repo
+$ argocd app list --grpc-web 
+
+NAME                                                                   CLUSTER     NAMESPACE  PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                                               PATH       TARGET
+gitops-service-argocd/gitopsdepl-c9ec8a71-0580-4662-9070-fbb9461d5eb1  in-cluster  panos      default  Synced  Healthy  Auto-Prune  <none>      https://github.com/managed-gitops-test-data/private-repo-test.git  resources
+```
+
+Same verification can be obtained from ArgoCD UI:
+
+![](https://i.imgur.com/HrAdh2U.png)
+
+![](https://i.imgur.com/V1NeGyY.png)
+
+## Case 2: Access via SSH Key
+
+Do the same thing, but this time deploy into another namespace, called `drpaneas` and use an SSH key that is specific to this private repository (instead of your personal GitHub account).
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: drpaneas
+  labels:
+    argocd.argoproj.io/managed-by: gitops-service-argocd
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: private-repo-creds-secret-ssh
+  namespace: drpaneas
+type: Opaque
+stringData:
+  sshPrivateKey: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    PUT
+    HERE
+    YOUR
+    KEY
+    -----END OPENSSH PRIVATE KEY-----
+
+---
+apiVersion: managed-gitops.redhat.com/v1alpha1
+kind: GitOpsDeploymentRepositoryCredential
+metadata:
+  name: private-repo-ssh
+  namespace: drpaneas
+spec:
+  repository: git@github.com:managed-gitops-test-data/private-repo-test.git
+  secret: private-repo-creds-secret-ssh
+
+---
+apiVersion: managed-gitops.redhat.com/v1alpha1
+kind: GitOpsDeployment
+metadata:
+  name: private-ssh-depl
+  namespace: drpaneas
+spec:
+  source:
+    repoURL: git@github.com:managed-gitops-test-data/private-repo-test.git
+    path: resources
+  type: automated
+```
+
+If everything went well, you should see:
+
+```bash
+$ oc -n drpaneas get cm config-map-in-private-repo
+NAME                         DATA   AGE
+config-map-in-private-repo   0      7m58
+```
+
+You can also verify this via the ArgoCD UI:
+
+![](https://i.imgur.com/QtU6uld.png)
+
+![](https://i.imgur.com/xRWtxxJ.png)
+
+Or you can use the CLI:
+
+```bash
+# List the apps using the private repo (HTTPS & SSH)
+$ argocd app list --grpc-web
+NAME                                                                   CLUSTER     NAMESPACE  PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                                               PATH       TARGET
+gitops-service-argocd/gitopsdepl-46f91243-2d52-480d-b5f5-7c6a45492c04  in-cluster  panos      default  Synced  Healthy  Auto-Prune  <none>      https://github.com/managed-gitops-test-data/private-repo-test.git  resources
+gitops-service-argocd/gitopsdepl-d8c2c272-9cf0-44bc-9218-e4759a7de7a7  in-cluster  drpaneas   default  Synced  Healthy  Auto-Prune  <none>      git@github.com:managed-gitops-test-data/private-repo-test.git      resources
+
+# List the private repo (access via HTTPS & SSH)
+$ argocd app list --grpc-web
+NAME                                                                   CLUSTER     NAMESPACE  PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                                               PATH       TARGET
+gitops-service-argocd/gitopsdepl-46f91243-2d52-480d-b5f5-7c6a45492c04  in-cluster  panos      default  Synced  Healthy  Auto-Prune  <none>      https://github.com/managed-gitops-test-data/private-repo-test.git  resources
+gitops-service-argocd/gitopsdepl-d8c2c272-9cf0-44bc-9218-e4759a7de7a7  in-cluster  drpaneas   default  Synced  Healthy  Auto-Prune  <none>      git@github.com:managed-gitops-test-data/private-repo-test.git      resources
+```

--- a/manifests/staging-cluster-resources/argo-cd.yaml
+++ b/manifests/staging-cluster-resources/argo-cd.yaml
@@ -56,7 +56,11 @@ spec:
       requests:
         cpu: 250m
         memory: 128Mi
-  initialSSHKnownHosts: {}
+  initialSSHKnownHosts:
+    excludedefaulthosts: false
+    keys: |
+      github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+      github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
   prometheus:
     enabled: false
     ingress:

--- a/tests-e2e/core/privaterepo_test.go
+++ b/tests-e2e/core/privaterepo_test.go
@@ -1,0 +1,303 @@
+package core
+
+/* To run the tests, you need to set the following environment variables:
+//
+// 		GITHUB_USERNAME: The username of the GitHub account
+//		e.g. export GITHUB_USERNAME=bruce@wayne.com
+//
+//		GITHUB_TOKEN: The token of the GitHub account
+//		e.g. export GITHUB_TOKEN=1234567890
+//
+//		GITHUB_SSH_KEY: The SSH key of the private GitHub repository
+//		e.g. export GITHUB_SSH_KEY=$(echo "-----BEGIN OPENSSH PRIVATE KEY-----\nFOOBAR\nFOOBAR\nFOOBAR\nFOOBAR\nFOOBAR\n-----END OPENSSH PRIVATE KEY-----")
+*/
+
+// To execute them:
+// 1. Set the environment variables
+// 2. Run the tests with the following command:
+//		 go test -v -run Core -args -ginkgo.v -ginkgo.progress
+
+import (
+	"errors"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
+	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
+	gitopsDeplFixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/gitopsdeployment"
+	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const (
+	gitServer       = "https://github.com"
+	privateRepoURL  = "https://github.com/managed-gitops-test-data/private-repo-test.git"
+	privateRepoSSH  = "git@github.com:managed-gitops-test-data/private-repo-test.git"
+	privateRepoPath = "resources" // Path to the resources folder in the private repo
+	secretToken     = "private-repo-secret-token"
+	secretSSHKey    = "private-repo-secret-ssh"
+	configMapName   = "config-map-in-private-repo" // Name of the config map to be deployed from the private repo
+)
+
+var (
+	errGitHubUsernameNotSet  = errors.New("GITHUB_USERNAME env variable not set")
+	errGitHubTokenNotSet     = errors.New("GITHUB_TOKEN env variable not set")
+	errGitHubSSHKeyNotSet    = errors.New("GITHUB_SSH_KEY env variable not set")
+	errGitHubOffline         = errors.New("GitHub is offline")
+	errGitHubRepoURLNotValid = errors.New("GitHub repo URL is not valid")
+)
+
+func gitopsDeploymentRepositoryCredentialCRForTokenTest() *managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredential {
+	return &managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "private-repo-https",
+			Namespace: fixture.GitOpsServiceE2ENamespace,
+		},
+		Spec: managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredentialSpec{
+			Repository: privateRepoURL,
+			Secret:     secretToken,
+		},
+	}
+}
+
+func gitopsDeploymentRepositoryCredentialCRForSSHTest() *managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredential {
+	return &managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "private-repo-ssh",
+			Namespace: fixture.GitOpsServiceE2ENamespace,
+		},
+		Spec: managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredentialSpec{
+			Repository: privateRepoSSH,
+			Secret:     secretSSHKey,
+		},
+	}
+}
+
+type envConfig struct {
+	ready    bool
+	username string
+	token    string
+	sshKey   string
+}
+
+var _ = Describe("GitOpsRepositoryCredentials E2E tests", func() {
+	Context("Deploy from a private repository (access via username/password)", func() {
+		It("Should work without access authentication issues", func() {
+			// --- Setup --- //
+			// Prepare the test environment by reading appropriate environment variables and reaching out to the git server
+			// or else skip the test if the environment is not properly configured
+			By("0. Get the environment variables required for the test")
+
+			var env envConfig
+			var err error
+
+			env, err = getEnvironmentConfig()
+			if err != nil {
+				Skip(err.Error())
+			}
+
+			Expect(env.ready).To(BeTrue())        // Skip the test if GitHub is offline (unreachable for some reason)
+			Expect(env.username).NotTo(BeEmpty()) // Skip the test if the GITHUB_USERNAME environment variable is not set
+			Expect(env.token).NotTo(BeEmpty())    // Skip the test if the GITHUB_TOKEN environment variable is not set
+			Expect(env.sshKey).NotTo(BeEmpty())   // Skip the test if the GITHUB_SSH_KEY environment variable is not set
+
+			// Get a k8s client to use in the tests
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
+
+			// --- Tests --- //
+			By("1. Clean the test environment")
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+
+			By("2. Create the Secret with the user/pass credentials")
+			stringData := map[string]string{
+				"username": env.username,
+				"password": env.token,
+			}
+			Expect(k8s.CreateSecret(fixture.GitOpsServiceE2ENamespace, secretToken, stringData, k8sClient)).To(Succeed())
+
+			// --- Step 3: Create the GitOpsRepositoryCredentials CR // ---
+			// It has to be in the same namespace with the Secret we created earlier
+			By("3. Create the GitOpsDeploymentRepositoryCredential CR for HTTPS")
+			CR := gitopsDeploymentRepositoryCredentialCRForTokenTest()
+			Expect(k8s.Create(CR, k8sClient)).To(Succeed())
+
+			// --- Step 4: Create the GitOpsDeployment pointing to the previously created GitOpsRepositoryCredential CR // ---
+			By("4. Create the GitOpsDeployment CR")
+			gitOpsDeployment := buildGitOpsDeploymentResource("private-https-depl", privateRepoURL, privateRepoPath,
+				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
+			Expect(k8s.Create(&gitOpsDeployment, k8sClient)).To(Succeed())
+
+			// --- Step 5: Wait for the GitOpsDeployment to be deployed and be healthy // ---
+			By("5. GitOpsDeployment should have expected health and status")
+			Eventually(gitOpsDeployment, "4m", "1s").Should(
+				SatisfyAll(
+					gitopsDeplFixture.HaveSyncStatusCode(managedgitopsv1alpha1.SyncStatusCodeSynced),
+					gitopsDeplFixture.HaveHealthStatusCode(managedgitopsv1alpha1.HeathStatusCodeHealthy)),
+			)
+
+			// --- Step 6: Check if the ConfigMap is deployed // ---
+			By("6. ConfigMap should be deployed")
+			configMap := &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: fixture.GitOpsServiceE2ENamespace,
+				},
+			}
+			Eventually(func() error { return k8s.Get(configMap, k8sClient) }, "4m", "1s").Should(Succeed())
+		})
+	})
+
+	Context("Deploy from a private repository (access via SSH Key)", func() {
+		It("Should work without access authentication issues", func() {
+			// --- Setup --- //
+			// Prepare the test environment by reading appropriate environment variables and reaching out to the git server
+			// or else skip the test if the environment is not properly configured
+			By("0. Get the environment variables required for the test")
+
+			var env envConfig
+			var err error
+
+			env, err = getEnvironmentConfig()
+			if err != nil {
+				Skip(err.Error())
+			}
+
+			Expect(env.ready).To(BeTrue())        // Skip the test if GitHub is offline (unreachable for some reason)
+			Expect(env.username).NotTo(BeEmpty()) // Skip the test if the GITHUB_USERNAME environment variable is not set
+			Expect(env.token).NotTo(BeEmpty())    // Skip the test if the GITHUB_TOKEN environment variable is not set
+			Expect(env.sshKey).NotTo(BeEmpty())   // Skip the test if the GITHUB_SSH_KEY environment variable is not set
+
+			// Get a k8s client to use in the tests
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
+
+			// --- Tests --- //
+			By("1. Clean the test environment")
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+
+			By("2. Create the Secret with the SSH key")
+			stringData := map[string]string{
+				"sshPrivateKey": env.sshKey,
+			}
+			Expect(k8s.CreateSecret(fixture.GitOpsServiceE2ENamespace, secretSSHKey, stringData, k8sClient)).To(Succeed())
+
+			// --- Step 3: Create the GitOpsRepositoryCredentials CR // ---
+			// It has to be in the same namespace with the Secret we created earlier
+			By("3. Create the GitOpsDeploymentRepositoryCredential CR for SSH")
+			CR := gitopsDeploymentRepositoryCredentialCRForSSHTest()
+			Expect(k8s.Create(CR, k8sClient)).To(Succeed())
+
+			// --- Step 4: Create the GitOpsDeployment pointing to the previously created GitOpsRepositoryCredential CR // ---
+			By("4. Create the GitOpsDeployment CR")
+			gitOpsDeployment := buildGitOpsDeploymentResource("private-ssh-depl", privateRepoSSH, privateRepoPath,
+				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
+			Expect(k8s.Create(&gitOpsDeployment, k8sClient)).To(Succeed())
+
+			// --- Step 5: Wait for the GitOpsDeployment to be deployed and be healthy // ---
+			By("5. GitOpsDeployment should have expected health and status")
+			Eventually(gitOpsDeployment, "4m", "1s").Should(
+				SatisfyAll(
+					gitopsDeplFixture.HaveSyncStatusCode(managedgitopsv1alpha1.SyncStatusCodeSynced),
+					gitopsDeplFixture.HaveHealthStatusCode(managedgitopsv1alpha1.HeathStatusCodeHealthy)),
+			)
+
+			// --- Step 6: Check if the ConfigMap is deployed // ---
+			By("6. ConfigMap should be deployed")
+			configMap := &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: fixture.GitOpsServiceE2ENamespace,
+				},
+			}
+			Eventually(func() error { return k8s.Get(configMap, k8sClient) }, "4m", "1s").Should(Succeed())
+		})
+	})
+})
+
+// getGithubUsername returns the value of the GITHUB_TOKEN environment variable, or an error if it is not set
+func getGithubUsername() (string, error) {
+	var err error
+	username, present := os.LookupEnv("GITHUB_USERNAME")
+
+	if !present {
+		err = errGitHubUsernameNotSet
+	}
+
+	return username, err
+}
+
+// getGithubToken returns the value of the GITHUB_TOKEN environment variable, or an error if it is not set
+func getGithubToken() (string, error) {
+	var err error
+	password, present := os.LookupEnv("GITHUB_TOKEN")
+
+	if !present {
+		err = errGitHubTokenNotSet
+	}
+
+	return password, err
+}
+
+// getGithubSSHKey returns the value of the GITHUB_SSH_KEY environment variable, or an error if it is not set
+func getGithubSSHKey() (string, error) {
+	var err error
+	sshKey, present := os.LookupEnv("GITHUB_SSH_KEY")
+
+	if !present {
+		err = errGitHubSSHKeyNotSet
+	}
+
+	return sshKey, err
+}
+
+// isGitServerOnline returns true if the git server (e.g. GitHub) is online, or false if it is offline
+func isGitServerOnline(gitServer string) bool {
+	r, e := http.Head(gitServer)
+	return e == nil && r.StatusCode == 200
+}
+
+// getEnvironmentConfig returns the environment configuration, or an error if it is not properly set
+func getEnvironmentConfig() (envConfig, error) {
+	var err error
+
+	var env = envConfig{}
+
+	// Grab the git Server's (e.g. GitHub) username from the environment variable
+	env.username, err = getGithubUsername()
+	if err != nil {
+		return env, err
+	}
+
+	// Grab the git Server's (e.g. GitHub) token from the environment variable
+	env.token, err = getGithubToken()
+	if err != nil {
+		return env, err
+	}
+
+	// Grab the git Server's (e.g. GitHub) SSH key from the environment variable
+	env.sshKey, err = getGithubSSHKey()
+	if err != nil {
+		return env, err
+	}
+
+	// Check if the git Server (e.g. GitHub) is online or the test environment is blocking the connection.
+	env.ready = isGitServerOnline(gitServer)
+	if !env.ready {
+		err = errGitHubOffline
+		return env, err
+	}
+
+	// Check if the gitServer is part of the privateRepoURL
+	if !strings.Contains(privateRepoURL, gitServer) {
+		err = errGitHubRepoURLNotValid
+		return env, err
+	}
+
+	return env, nil
+}

--- a/tests-e2e/core/privaterepo_test.go
+++ b/tests-e2e/core/privaterepo_test.go
@@ -9,7 +9,7 @@ package core
 //		e.g. export GITHUB_TOKEN=1234567890
 //
 //		GITHUB_SSH_KEY: The SSH key of the private GitHub repository
-//		e.g. export GITHUB_SSH_KEY=$(echo "-----BEGIN OPENSSH PRIVATE KEY-----\nFOOBAR\nFOOBAR\nFOOBAR\nFOOBAR\nFOOBAR\n-----END OPENSSH PRIVATE KEY-----")
+//		e.g. export GITHUB_SSH_KEY=$(echo "-----BEGIN OPENSSH PRIVATE KEY-----\nFOOBAR\nFOOBAR\nFOOBAR\nFOOBAR\nFOOBAR\n-----END OPENSSH PRIVATE KEY-----") # gitleaks:allow
 */
 
 // To execute them:
@@ -113,7 +113,7 @@ var _ = Describe("GitOpsRepositoryCredentials E2E tests", func() {
 
 	Context("Deploy from a private repository (access via username/password)", func() {
 
-		FIt("Should work without HTTPS/Token authentication issues", func() {
+		It("Should work without HTTPS/Token authentication issues", func() {
 			// --- Tests --- //
 			By("1. Clean the test environment")
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())
@@ -148,7 +148,7 @@ var _ = Describe("GitOpsRepositoryCredentials E2E tests", func() {
 
 	Context("Deploy from a private repository (access via SSH Key)", func() {
 
-		FIt("Should work without SSH authentication issues", func() {
+		It("Should work without SSH authentication issues", func() {
 			// --- Tests --- //
 			By("1. Clean the test environment")
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())

--- a/tests-e2e/fixture/k8s/fixture.go
+++ b/tests-e2e/fixture/k8s/fixture.go
@@ -3,6 +3,8 @@ package k8s
 import (
 	"context"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -131,4 +133,22 @@ func Update(obj client.Object, k8sClient client.Client) error {
 	}
 
 	return nil
+}
+
+// CreateSecret creates a secret with the given stringData.
+func CreateSecret(namespace string, secretName string, stringData map[string]string, k8sClient client.Client) error {
+
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		Immutable:  nil,
+		Data:       nil,
+		StringData: stringData,
+		Type:       "",
+	}
+
+	return Create(secret, k8sClient)
 }


### PR DESCRIPTION
#### Description:
- Processing logic for Backend controller that is responsible for acting upon a  GitOpsDeploymentRepositoryCredential CR.

#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-96


Instruction for the reviewer:

- There were a number of problems with logging. That is why you will find many replacements of `log` and `logger` into `l`.
- The main that has he logic is the `sharedresourceloop.go`
- The test file is the `sharedresourceloop_test.go` the last `It` context.
- What is missing is that the function `internalProcessMessage_ReconcileRepositoryCredential` is not getting triggered by the backend controller when you create a real `GitOpsDeploymentRepositoryCredential` CR. Most likely this is related to the code relocation from the file [application_event_runner_deployments.go](https://github.com/redhat-appstudio/managed-gitops/pull/239/files#diff-c77031be4bccf13100733b7e5389de32b45fb0ab49c8f586942cff535b3f4784)

To run the tests with the GinkgoWritter logger: `go test -v  ./eventloop/shared_resource_loop -args -ginkgo.v "GitOpsDeploymentRepositoryCredential"`

logs:
```
  Begin Captured GinkgoWriter Output >>
    1.6656705627196548e+09	DEBUG	sharedResourceEventLoop received message: getGitopsEngineInstanceById	{"workspace": "923beaa6-a156-4db5-b7f6-533288a101c5"}
    1.665670562721324e+09	DEBUG	sharedResourceEventLoop received message: getOrCreateClusterUserByNamespaceUID	{"workspace": "923beaa6-a156-4db5-b7f6-533288a101c5"}
    1.665670562724163e+09	INFO	Created Cluster User with User ID: c240706e-1508-4b2f-b124-847737f60ea3	{"clusteruser_id": "c240706e-1508-4b2f-b124-847737f60ea3", "user_name": "923beaa6-a156-4db5-b7f6-533288a101c5"}
    1.6656705627242088e+09	DEBUG	sharedResourceEventLoop received message: getOrCreateClusterUserByNamespaceUID	{"workspace": "923beaa6-a156-4db5-b7f6-533288a101c5"}
    1.6656705627373629e+09	INFO	Created Cluster Credentials for GitOpsEngineCluster: 61ccec9f-baf8-4f14-9e59-6be42c0c6f17	{"host": "host", "kube-config-length": 11, "kube-config-context": 19, "serviceaccount_ns": "serviceaccount_ns", "serviceaccount-bearer-token-length": 27}
    1.665670562739448e+09	INFO	Created GitopsEngineCluster: 8bcc64a4-b449-4c95-80c4-7e47b82b4beb	{"clustercredentials_id": "61ccec9f-baf8-4f14-9e59-6be42c0c6f17", "gitopsenginecluster_id": "8bcc64a4-b449-4c95-80c4-7e47b82b4beb"}
    1.6656705627421172e+09	INFO	Created KubernetesResourceToDBResourceMapping with DBRelationKey: 8bcc64a4-b449-4c95-80c4-7e47b82b4beb	{"k8sResourceType": "Namespace", "k8sResourceUID": "df5c3c96-532c-47e2-97ca-95df0a3c393d", "dbRelationType": "GitopsEngineCluster", "dbRelationKey": "8bcc64a4-b449-4c95-80c4-7e47b82b4beb"}
    1.665670562744859e+09	INFO	Created GitopsEngineInstance: ff3ab762-b007-4424-9e12-b2fa69c20a60
    1.6656705627466161e+09	INFO	Created KubernetesResourceToDBResourceMapping with KubernetesResourceUID: df5c3c96-532c-47e2-97ca-95df0a3c393d	{"k8sResourceType": "Namespace", "k8sResourceUID": "df5c3c96-532c-47e2-97ca-95df0a3c393d", "dbRelationType": "GitopsEngineInstance", "dbRelationKey": "ff3ab762-b007-4424-9e12-b2fa69c20a60"}
    1.665670562746634e+09	INFO	Attempting to get the CR
    1.6656705627537699e+09	INFO	Attempting to get the CR
    1.665670562758892e+09	INFO	Creating operation...
    1.665670562764606e+09	INFO	Created Operation database row
    1.665670562764638e+09	INFO	Created K8s Operation CR
    1.665670562764643e+09	INFO	operationCR	{"operationCR": {"metadata":{"name":"operation-f0943aa8-2b57-4b02-9e56-31729a8f5946","namespace":"my-user","resourceVersion":"1","creationTimestamp":null},"spec":{"operationID":"f0943aa8-2b57-4b02-9e56-31729a8f5946"},"status":{}}}
    1.66567056276468e+09	INFO	operationDB	{"operationDB": {"Operation_id":"f0943aa8-2b57-4b02-9e56-31729a8f5946","Instance_id":"ff3ab762-b007-4424-9e12-b2fa69c20a60","Resource_id":"test-gitopsdeploymenrepositorycredential","Operation_owner_user_id":"c240706e-1508-4b2f-b124-847737f60ea3","Resource_type":"RepositoryCredentials","Created_on":"2022-10-13T16:16:02.762078+02:00","Last_state_update":"2022-10-13T16:16:02.762078+02:00","State":"Waiting","Human_readable_state":"","SeqID":47,"GC_expiration_time":0}}
    1.665670562773057e+09	INFO	Attempting to get the CR
    1.6656705627832398e+09	INFO	Attempting to get the CR
    1.6656705627845278e+09	INFO	Secret name changed	{"old": "test-secret-2", "new": "test-secret"}
    1.665670562784543e+09	INFO	Syncing with database...
    1.665670562786245e+09	INFO	Creating operation...
    1.665670562787413e+09	INFO	Skipping Operation creation, as it already exists for resource.	{"existingOperationState": "Waiting"}
    1.665670562787424e+09	INFO	operationCR	{"operationCR": {"kind":"Operation","apiVersion":"managed-gitops.redhat.com/v1alpha1","metadata":{"name":"operation-f0943aa8-2b57-4b02-9e56-31729a8f5946","namespace":"my-user","resourceVersion":"1","creationTimestamp":null},"spec":{"operationID":"f0943aa8-2b57-4b02-9e56-31729a8f5946"},"status":{}}}
    1.66567056278744e+09	INFO	operationDB	{"operationDB": {"Operation_id":"f0943aa8-2b57-4b02-9e56-31729a8f5946","Instance_id":"ff3ab762-b007-4424-9e12-b2fa69c20a60","Resource_id":"test-gitopsdeploymenrepositorycredential","Operation_owner_user_id":"c240706e-1508-4b2f-b124-847737f60ea3","Resource_type":"RepositoryCredentials","Created_on":"2022-10-13T14:16:02.762078Z","Last_state_update":"2022-10-13T14:16:02.762078Z","State":"Waiting","Human_readable_state":"","SeqID":47,"GC_expiration_time":0}}
    1.6656705627955399e+09	INFO	Attempting to get the CR
    1.665670562795558e+09	INFO	Error getting the CR
    1.665670562796917e+09	INFO	[Leftover] RepositoryCredential row found in DB
    1.665670562798645e+09	DEBUG	Deleted Repository Credential from the database	{"repocred id": "test-gitopsdeploymenrepositorycredential"}
    1.665670562798662e+09	INFO	RepositoryCredential row deleted from DB
    1.665670562798665e+09	INFO	Creating an Operation for the deleted RepositoryCredential DB row
    1.665670562798667e+09	INFO	Creating operation...
    1.665670562802567e+09	INFO	Created Operation database row
    1.66567056280259e+09	INFO	Created K8s Operation CR
    1.665670562802593e+09	INFO	operationCR	{"operationCR": {"metadata":{"name":"operation-7fa6d9f1-e31e-4df0-afcb-a30c3696276a","namespace":"my-user","resourceVersion":"1","creationTimestamp":null},"spec":{"operationID":"7fa6d9f1-e31e-4df0-afcb-a30c3696276a"},"status":{}}}
    1.66567056280261e+09	INFO	operationDB	{"operationDB": {"Operation_id":"7fa6d9f1-e31e-4df0-afcb-a30c3696276a","Instance_id":"ff3ab762-b007-4424-9e12-b2fa69c20a60","Resource_id":"test-gitopsdeploymenrepositorycredential","Operation_owner_user_id":"c240706e-1508-4b2f-b124-847737f60ea3","Resource_type":"RepositoryCredentials","Created_on":"2022-10-13T16:16:02.800886+02:00","Last_state_update":"2022-10-13T16:16:02.800886+02:00","State":"Waiting","Human_readable_state":"","SeqID":48,"GC_expiration_time":0}}
    1.665670562802621e+09	INFO	Operation created for the deleted RepositoryCredential DB row
    1.665670562810223e+09	INFO	Attempting to get the CR
    1.665670562810238e+09	INFO	Error getting the CR
    1.665670562811154e+09	INFO	DB entry not found
    1.665670562811162e+09	INFO	No leftovers. Nothing to do
```