### PR TITLE
Convert strings to typed constants, add a sanity test, and clean up old TODOs

### DIFF
--- a/backend-shared/config/db/apicrtodatabasemapping.go
+++ b/backend-shared/config/db/apicrtodatabasemapping.go
@@ -108,8 +108,9 @@ func (dbq *PostgreSQLDatabaseQueries) GetDatabaseMappingForAPICR(ctx context.Con
 }
 
 // ListAPICRToDatabaseMappingByAPINamespaceAndName returns the DBRelationKey and APIResourceUID for a given type/name/namespace/namespace uid/db-relation-type query
-func (dbq *PostgreSQLDatabaseQueries) ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx context.Context, apiCRResourceType string,
-	crName string, crNamespace string, crNamespaceUID string, dbRelationType string, apiCRToDBMappingParam *[]APICRToDatabaseMapping) error {
+func (dbq *PostgreSQLDatabaseQueries) ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx context.Context,
+	apiCRResourceType APICRToDatabaseMapping_ResourceType, crName string, crNamespace string, crNamespaceUID string,
+	dbRelationType APICRToDatabaseMapping_DBRelationType, apiCRToDBMappingParam *[]APICRToDatabaseMapping) error {
 
 	if err := validateQueryParamsEntity(apiCRToDBMappingParam, dbq); err != nil {
 		return err

--- a/backend-shared/config/db/operations.go
+++ b/backend-shared/config/db/operations.go
@@ -233,7 +233,8 @@ func (dbq *PostgreSQLDatabaseQueries) CheckedDeleteOperationById(ctx context.Con
 	return deleteResult.RowsAffected(), nil
 }
 
-func (dbq *PostgreSQLDatabaseQueries) ListOperationsByResourceIdAndTypeAndOwnerId(ctx context.Context, resourceID string, resourceType string, operations *[]Operation, ownerId string) error {
+func (dbq *PostgreSQLDatabaseQueries) ListOperationsByResourceIdAndTypeAndOwnerId(ctx context.Context, resourceID string,
+	resourceType OperationResourceType, operations *[]Operation, ownerId string) error {
 
 	if err := validateQueryParamsEntity(operations, dbq); err != nil {
 		return err

--- a/backend-shared/config/db/queries.go
+++ b/backend-shared/config/db/queries.go
@@ -78,7 +78,6 @@ type DatabaseQueries interface {
 
 	CheckedDeleteDeploymentToApplicationMappingByDeplId(ctx context.Context, id string, ownerId string) (int, error)
 
-	// TODO: GITOPSRVCE-67 - DEBT - I think this should still have an owner, even if it presumed that it is user id:
 	DeleteClusterAccessById(ctx context.Context, userId string, managedEnvironmentId string, gitopsEngineInstanceId string) (int, error)
 	CheckedDeleteGitopsEngineInstanceById(ctx context.Context, id string, ownerId string) (int, error)
 	CheckedDeleteManagedEnvironmentById(ctx context.Context, id string, ownerId string) (int, error)
@@ -170,7 +169,8 @@ type ApplicationScopedQueries interface {
 
 	CreateOperation(ctx context.Context, obj *Operation, ownerId string) error
 	GetOperationById(ctx context.Context, operation *Operation) error
-	ListOperationsByResourceIdAndTypeAndOwnerId(ctx context.Context, resourceID string, resourceType string, operations *[]Operation, ownerId string) error
+	ListOperationsByResourceIdAndTypeAndOwnerId(ctx context.Context, resourceID string, resourceType OperationResourceType,
+		operations *[]Operation, ownerId string) error
 	CheckedDeleteOperationById(ctx context.Context, id string, ownerId string) (int, error)
 	DeleteOperationById(ctx context.Context, id string) (int, error)
 
@@ -196,7 +196,9 @@ type ApplicationScopedQueries interface {
 	CreateAPICRToDatabaseMapping(ctx context.Context, obj *APICRToDatabaseMapping) error
 
 	// ListAPICRToDatabaseMappingByAPINamespaceAndName returns the DBRelationKey for a given type/name/namespace/namespace uid/db-relation-type query
-	ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx context.Context, apiCRResourceType string, crName string, crNamespace string, crNamespaceUID string, dbRelationType string, apiCRToDBMappingParam *[]APICRToDatabaseMapping) error
+	ListAPICRToDatabaseMappingByAPINamespaceAndName(ctx context.Context, apiCRResourceType APICRToDatabaseMapping_ResourceType,
+		crName string, crNamespace string, crNamespaceUID string, dbRelationType APICRToDatabaseMapping_DBRelationType,
+		apiCRToDBMappingParam *[]APICRToDatabaseMapping) error
 
 	GetDatabaseMappingForAPICR(ctx context.Context, obj *APICRToDatabaseMapping) error
 	DeleteAPICRToDatabaseMapping(ctx context.Context, obj *APICRToDatabaseMapping) (int, error)

--- a/backend-shared/config/db/types.go
+++ b/backend-shared/config/db/types.go
@@ -149,11 +149,13 @@ const (
 	OperationState_Failed      OperationState = "Failed"
 )
 
+type OperationResourceType string
+
 const (
-	OperationResourceType_ManagedEnvironment    = "ManagedEnvironment"
-	OperationResourceType_SyncOperation         = "SyncOperation"
-	OperationResourceType_Application           = "Application"
-	OperationResourceType_RepositoryCredentials = "RepositoryCredentials"
+	OperationResourceType_ManagedEnvironment    OperationResourceType = "ManagedEnvironment"
+	OperationResourceType_SyncOperation         OperationResourceType = "SyncOperation"
+	OperationResourceType_Application           OperationResourceType = "Application"
+	OperationResourceType_RepositoryCredentials OperationResourceType = "RepositoryCredentials"
 )
 
 // Operation
@@ -182,7 +184,7 @@ type Operation struct {
 	// -- The user that initiated the operation.
 	Operation_owner_user_id string `pg:"operation_owner_user_id"`
 
-	// Resource type of the the resoutce that was updated.
+	// Resource type of the the resource that was updated.
 	// This value lets the operation know which table contains the resource.
 	//
 	// Possible values:
@@ -190,7 +192,7 @@ type Operation struct {
 	// * GitopsEngineInstance (specified to CRUD an Argo instance, for example to create a new namespace and put Argo CD in it, then signal when it's done)
 	// * Application (user creates a new Application via service/web UI)
 	// * RepositoryCredentials (user provides private repository credentials via web UI)
-	Resource_type string `pg:"resource_type"`
+	Resource_type OperationResourceType `pg:"resource_type"`
 
 	// -- When the operation was created. Used for garbage collection, as operations should be short lived.
 	Created_on time.Time `pg:"created_on"`
@@ -286,8 +288,6 @@ type ApplicationState struct {
 // (https://docs.google.com/document/d/1e1UwCbwK-Ew5ODWedqp_jZmhiZzYWaxEvIL-tqebMzo/edit#heading=h.45brv1rx6wmo)
 type DeploymentToApplicationMapping struct {
 
-	// TODO: GITOPSRVCE-67 - DEBT - PK should be (mapping uid, application_id), rather than just mapping uid?
-
 	//lint:ignore U1000 used by go-pg
 	tableName struct{} `pg:"deploymenttoapplicationmapping,alias:dta"` //nolint
 
@@ -312,17 +312,22 @@ type DeploymentToApplicationMapping struct {
 	SeqID int64 `pg:"seq_id"`
 }
 
+// APICRToDatabaseMapping_ResourceType: see 'db-schema.sql' for a description of these values.
+type APICRToDatabaseMapping_ResourceType string
+
 const (
+	APICRToDatabaseMapping_ResourceType_GitOpsDeploymentManagedEnvironment   APICRToDatabaseMapping_ResourceType = "GitOpsDeploymentManagedEnvironment"
+	APICRToDatabaseMapping_ResourceType_GitOpsDeploymentSyncRun              APICRToDatabaseMapping_ResourceType = "GitOpsDeploymentSyncRun"
+	APICRToDatabaseMapping_ResourceType_GitOpsDeploymentRepositoryCredential APICRToDatabaseMapping_ResourceType = "GitOpsDeploymentRepositoryCredential"
+)
 
-	// TODO: GITOPSRVCE-67: Convert these into typed constants
+// APICRToDatabaseMapping_DBRelationType: see 'db-schema.sql' for a description of these values.
+type APICRToDatabaseMapping_DBRelationType string
 
-	APICRToDatabaseMapping_ResourceType_GitOpsDeploymentManagedEnvironment   = "GitOpsDeploymentManagedEnvironment"
-	APICRToDatabaseMapping_ResourceType_GitOpsDeploymentSyncRun              = "GitOpsDeploymentSyncRun"
-	APICRToDatabaseMapping_ResourceType_GitOpsDeploymentRepositoryCredential = "GitOpsDeploymentRepositoryCredential"
-
-	APICRToDatabaseMapping_DBRelationType_ManagedEnvironment   = "ManagedEnvironment"
-	APICRToDatabaseMapping_DBRelationType_SyncOperation        = "SyncOperation"
-	APICRToDatabaseMapping_DBRelationType_RepositoryCredential = "RepositoryCredential"
+const (
+	APICRToDatabaseMapping_DBRelationType_ManagedEnvironment   APICRToDatabaseMapping_DBRelationType = "ManagedEnvironment"
+	APICRToDatabaseMapping_DBRelationType_SyncOperation        APICRToDatabaseMapping_DBRelationType = "SyncOperation"
+	APICRToDatabaseMapping_DBRelationType_RepositoryCredential APICRToDatabaseMapping_DBRelationType = "RepositoryCredential"
 )
 
 // APICRToDatabaseMapping maps API custom resources on the workspace (such as GitOpsDeploymentSyncRun), to a corresponding entry in the database.
@@ -337,15 +342,15 @@ type APICRToDatabaseMapping struct {
 	//lint:ignore U1000 used by go-pg
 	tableName struct{} `pg:"apicrtodatabasemapping,alias:atdbm"` //nolint
 
-	APIResourceType string `pg:"api_resource_type"`
-	APIResourceUID  string `pg:"api_resource_uid"`
+	APIResourceType APICRToDatabaseMapping_ResourceType `pg:"api_resource_type"`
+	APIResourceUID  string                              `pg:"api_resource_uid"`
 
 	APIResourceName      string `pg:"api_resource_name"`
 	APIResourceNamespace string `pg:"api_resource_namespace"`
 	NamespaceUID         string `pg:"api_resource_namespace_uid"`
 
-	DBRelationType string `pg:"db_relation_type"`
-	DBRelationKey  string `pg:"db_relation_key"`
+	DBRelationType APICRToDatabaseMapping_DBRelationType `pg:"db_relation_type"`
+	DBRelationKey  string                                `pg:"db_relation_key"`
 
 	SeqID int64 `pg:"seq_id"`
 }
@@ -400,11 +405,18 @@ type SyncOperation struct {
 	DesiredState string `pg:"desired_state"`
 }
 
-// TODO: GITOPSRVCE-67 - DEBT - Add comment.
+// DisposableResource can be implemented by a type, such that calling Dispose(...) on an instance of that type will delete
+// the corresponding row from the database.
+//
+// This is an optional interface, for convenience purposes.
 type DisposableResource interface {
 	Dispose(ctx context.Context, dbq DatabaseQueries) error
 }
 
+// AppScopedDisposableResource can be implemented by an application-scoped type, such they calling Dispose() on an instance
+// of that type will delete the row from the database.
+//
+// This is an optional interface, for convenience purposes.
 type AppScopedDisposableResource interface {
 	DisposeAppScoped(ctx context.Context, dbq ApplicationScopedQueries) error
 }

--- a/backend-shared/config/db/utils.go
+++ b/backend-shared/config/db/utils.go
@@ -131,10 +131,10 @@ func (e *APICRToDatabaseMapping) ShortString() string {
 	res := ""
 	res += "name: " + e.APIResourceName + ", "
 	res += "namespace: " + e.APIResourceNamespace + ", "
-	res += "resource-type: : " + e.APIResourceType + ", "
+	res += "resource-type: : " + string(e.APIResourceType) + ", "
 	res += "namespace-uid: " + e.NamespaceUID + ", "
 	res += "db-relation-key: " + e.DBRelationKey + ", "
-	res += "db-relation-type: " + e.DBRelationType
+	res += "db-relation-type: " + string(e.DBRelationType)
 
 	return res
 }
@@ -145,7 +145,7 @@ func (o *Operation) ShortString() string {
 	res += "instance-id: " + o.Instance_id + ", "
 	res += "owner: " + o.Operation_owner_user_id + ", "
 	res += "resource: " + o.Resource_id + ", "
-	res += "resource-type: " + o.Resource_type + ", "
+	res += "resource-type: " + string(o.Resource_type) + ", "
 	return res
 }
 
@@ -155,7 +155,7 @@ func (o *Operation) LongString() string {
 	res += "operation-id: " + o.Operation_id + ", "
 	res += "owner: " + o.Operation_owner_user_id + ", "
 	res += "resource: " + o.Resource_id + ", "
-	res += "resource-type: " + o.Resource_type + ", "
+	res += "resource-type: " + string(o.Resource_type) + ", "
 
 	res += "human-readable-state: " + o.Human_readable_state + ", "
 	res += "state: " + string(o.State) + ", "

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -456,7 +456,13 @@ func (a applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplEvent(ctx cont
 		}
 	}
 
-	// TODO: GITOPSRVCE-67 - Sanity check that the application.name matches the expected value set in handleCreateGitOpsEvent
+	// Sanity check that the application.name matches the expected value set in handleCreateGitOpsEvent
+	expectedAppName := argosharedutil.GenerateArgoCDApplicationName(string(gitopsDeployment.UID))
+	if expectedAppName != application.Name {
+		log.Error(nil, "SEVERE: The name of the Argo CD Application CR should remain constant")
+		return false, nil, nil, deploymentModifiedResult_Failed,
+			fmt.Errorf("name of the Argo CD Application should not change:'%s' '%s'", expectedAppName, application.Name)
+	}
 
 	// If the user specified a value, always use it. If not, use the API resource namespace (but only in the workspace target case)
 	destinationNamespace := gitopsDeployment.Spec.Destination.Namespace

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
@@ -394,7 +394,7 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleSyncRun
 			return false, err
 		}
 
-		// TODO: GITOPSRVCE-67 - DEBT - Include test case to check that the various goroutines are terminated when the CR is deleted.
+		// TODO: GITOPSRVCE-166 - DEBT - Include test case to check that the various goroutines are terminated when the CR is deleted.
 
 		return false, nil
 	}

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
@@ -425,7 +425,9 @@ func (a *applicationEventLoopRunner_Action) cleanupOldSyncDBEntry(ctx context.Co
 	}
 
 	var operations []db.Operation
-	if err := dbQueries.ListOperationsByResourceIdAndTypeAndOwnerId(ctx, apiCRToDB.DBRelationKey, apiCRToDB.DBRelationType, &operations, clusterUser.Clusteruser_id); err != nil {
+	if err := dbQueries.ListOperationsByResourceIdAndTypeAndOwnerId(ctx, apiCRToDB.DBRelationKey, db.OperationResourceType_SyncOperation,
+		&operations, clusterUser.Clusteruser_id); err != nil {
+
 		log.Error(err, "unable to retrieve operations pointing to sync operation", "key", apiCRToDB.DBRelationKey)
 		return err
 	} else {

--- a/backend/eventloop/application_event_loop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_test.go
@@ -1638,7 +1638,7 @@ var _ = Describe("application_event_runner_deployments.go Tests", func() {
 			return managedEnvRow, application, nil
 		}
 
-		listOperationRowsForResource := func(resourceId string, resourceType string) ([]db.Operation, error) {
+		listOperationRowsForResource := func(resourceId string, resourceType db.OperationResourceType) ([]db.Operation, error) {
 			operations := []db.Operation{}
 			if err := dbQueries.UnsafeListAllOperations(ctx, &operations); err != nil {
 				return []db.Operation{}, err

--- a/backend/eventloop/application_event_loop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_test.go
@@ -521,6 +521,30 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 
 		})
 
+		It("should return an error if the Argo CD Application name field changed between when the GitOpsDeployment was created, and when it was updated", func() {
+
+			By("calling handleDeploymentModified to simulate a new GitOpsDeployment")
+			_, applicationDBRow, _, result, err := appEventLoopRunnerAction.applicationEventRunner_handleDeploymentModified(ctx, dbQueries)
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(deploymentModifiedResult_Created))
+
+			By("calling handleDeploymentModified again, to simulate an unchanged GitOpsDeployment")
+			_, _, _, result, err = appEventLoopRunnerAction.applicationEventRunner_handleDeploymentModified(ctx, dbQueries)
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(deploymentModifiedResult_NoChange))
+
+			By("updating the Application name field, simulating the case where a different name was set in the Create logic of handleDeploymentModified")
+			applicationDBRow.Name = "a-different-name-than-the-one-set-by-create"
+			err = dbQueries.UpdateApplication(ctx, applicationDBRow)
+			Expect(err).To(BeNil())
+
+			By("calling handleDeploymentModified again, and expected an error")
+			_, _, _, result, err = appEventLoopRunnerAction.applicationEventRunner_handleDeploymentModified(ctx, dbQueries)
+			Expect(err).ToNot(BeNil())
+			Expect(result).To(Equal(deploymentModifiedResult_Failed))
+
+		})
+
 	})
 
 	Context("Handle sync run modified", func() {

--- a/backend/eventloop/workspace_event_loop.go
+++ b/backend/eventloop/workspace_event_loop.go
@@ -289,7 +289,7 @@ func handleOrphaned(ctx context.Context, event eventlooptypes.EventLoopMessage, 
 			}
 		}
 
-		// TODO: GITOPSRVCE-67 - DEBT - Make sure it's not still orphaned before adding it to orphanedResources
+		// TODO: GITOPSRVCE-224: Make sure it's not still orphaned before adding it to orphanedResources.
 
 		gitopsDeplMap, exists := orphanedResources[syncRunCR.Spec.GitopsDeploymentName]
 		if !exists {

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
@@ -320,7 +320,7 @@ func (task *processOperationEventTask) internalPerformTask(taskContext context.C
 		return &dbOperation, shouldRetry, err
 
 	} else {
-		log.Error(nil, "SEVERE: unrecognized resource type: "+dbOperation.Resource_type)
+		log.Error(nil, "SEVERE: unrecognized resource type: "+string(dbOperation.Resource_type))
 		return &dbOperation, shouldRetryFalse, nil
 	}
 

--- a/utilities/db-migration/go.mod
+++ b/utilities/db-migration/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/onsi/ginkgo/v2 v2.1.3 // indirect
 	github.com/onsi/gomega v1.19.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect

--- a/utilities/db-migration/go.sum
+++ b/utilities/db-migration/go.sum
@@ -611,6 +611,7 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
@@ -913,6 +914,7 @@ github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.1.3 h1:e/3Cwtogj0HA+25nMP1jCMDIf8RtRYbGwGGuBIFztkc=
+github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -922,6 +924,7 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
+github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=


### PR DESCRIPTION
#### Description:
- Cleaning up old technical debt by:
    - Converting some strings to be typed constants 
    - Adding a sanity test for detecting changes to name field of Application row, when processing GitOpsDeployment events
    - Removing outdated TODOs
    - Moving TODOs that are still relevant to a more appropriate story #

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-67

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
