### PR TITLE
Fixes E2E: AppStudio controller manifest PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,10 +122,10 @@ undeploy-appstudio-controller-rbac: kustomize ## Remove appstudio-controller rel
 
 deploy-appstudio-controller: deploy-appstudio-controller-crd deploy-appstudio-controller-rbac ## Deploy appstudio-controller operator into Kubernetes -- e.g. make appstudio-controller IMG=quay.io/pgeorgia/gitops-service:latest
 	kubectl create namespace gitops 2> /dev/null || true
-	COMMON_IMAGE=${IMG} envsubst < $(MAKEFILE_ROOT)/manifests/controller-deployments/managed-gitops-appstudio-controller-deployment.yaml | kubectl apply -f -
+	COMMON_IMAGE=${IMG} envsubst < $(MAKEFILE_ROOT)/manifests/controller-deployments/appstudio-controller/managed-gitops-appstudio-controller-deployment.yaml | kubectl apply -f -
 
 undeploy-appstudio-controller: undeploy-appstudio-controller-rbac undeploy-appstudio-controller-crd ## Undeploy appstudio-controller from Kubernetes
-	kubectl delete -f $(MAKEFILE_ROOT)/manifests/controller-deployments/managed-gitops-appstudio-controller-deployment.yaml
+	kubectl delete -f $(MAKEFILE_ROOT)/manifests/controller-deployments/appstudio-controller/managed-gitops-appstudio-controller-deployment.yaml
 
 build-appstudio-controller: ## Build only
 	cd $(MAKEFILE_ROOT)/appstudio-controller && make build


### PR DESCRIPTION
#### Description:
Fixes the e2e:

```
COMMON_IMAGE=quay.io/redhat-appstudio/gitops-service:latest envsubst < /go/src/github.com/redhat-appstudio/managed-gitops/manifests/controller-deployments/managed-gitops-appstudio-controller-deployment.yaml | kubectl apply -f -
/bin/sh: /go/src/github.com/redhat-appstudio/managed-gitops/manifests/controller-deployments/managed-gitops-appstudio-controller-deployment.yaml: No such file or directory
error: no objects passed to apply
make: *** [deploy-appstudio-controller] Error 1
{"component":"entrypoint","error":"wrapped process failed: exit status 2","file":"k8s.io/test-infra/prow/entrypoint/run.go:79","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2022-10-17T09:03:17Z"}
error: failed to execute wrapped command: exit status 2 
INFO[2022-10-17T09:03:21Z] Step managed-gitops-unit-tests-managed-gitops-unit-tests failed after 2m30s. 
INFO[2022-10-17T09:03:21Z] Step phase test failed after 2m30s. 
```

#### Link to JIRA Story (if applicable):

None