### PR TITLE
Enhance cleanup for KCP E2E

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,10 +153,10 @@ e2e-reset: ## Kills the port-forwarding and the controllers
 	pkill kubectl
 
 install-argocd-openshift: ## Using OpenShift GitOps, install Argo CD to the gitops-service-argocd namespace
-	manifests/openshift-argo-deploy/deploy.sh
+	timeout 5m bash manifests/openshift-argo-deploy/deploy.sh
 
 install-argocd-k8s: ## (Non-OpenShift): Install Argo CD to the gitops-service-argocd namespace
-	ARGO_CD_VERSION=$(ARGO_CD_VERSION) manifests/k8s-argo-deploy/deploy.sh
+	ARGO_CD_VERSION=$(ARGO_CD_VERSION) timeout 5m bash manifests/k8s-argo-deploy/deploy.sh
 
 uninstall-argocd: ## Uninstall Argo CD from gitops-service-argocd namespace (from either OpenShift or K8s)
 	kubectl delete namespace "$(ARGO_CD_NAMESPACE)" || true

--- a/kcp/ckcp/openshift_dev_setup.sh
+++ b/kcp/ckcp/openshift_dev_setup.sh
@@ -205,7 +205,17 @@ install_openshift_gitops() {
   local cluster_name="plnsvc"
   echo -n "  - Register host cluster to Argo CD as '$cluster_name': "
   if ! KUBECONFIG="$KUBECONFIG_MERGED" argocd cluster get "$cluster_name" >/dev/null 2>&1; then
-    argocd cluster add "$(yq e ".current-context" <"$KUBECONFIG")" --name="$cluster_name" --upsert --yes >/dev/null
+    argocd cluster add "$(yq e ".current-context" <"$KUBECONFIG")" --name="$cluster_name" --upsert --yes
+    echo "Retry again 1"
+    argocd cluster add "$(yq e ".current-context" <"$KUBECONFIG")" --name="$cluster_name" --upsert --yes
+    echo "Retry again 2"
+    argocd cluster add "$(yq e ".current-context" <"$KUBECONFIG")" --name="$cluster_name" --upsert --yes
+    echo "Retry again 3"
+    argocd cluster add "$(yq e ".current-context" <"$KUBECONFIG")" --name="$cluster_name" --upsert --yes
+    echo "Retry again 4"
+    argocd cluster add "$(yq e ".current-context" <"$KUBECONFIG")" --name="$cluster_name" --upsert --yes
+    echo "Retry again 5"
+    argocd cluster add "$(yq e ".current-context" <"$KUBECONFIG")" --name="$cluster_name" --upsert --yes
   fi
   echo "OK"
 }
@@ -393,7 +403,9 @@ main() {
   precheck
   check_cluster_role
   for APP in "${APP_LIST[@]}"; do
-    echo "[$APP]"
+    echo
+    echo "=== $APP ==="
+    echo
     install_"$(echo "$APP" | tr '-' '_')"
     echo
   done

--- a/kcp/ckcp/setup-ckcp-on-openshift.sh
+++ b/kcp/ckcp/setup-ckcp-on-openshift.sh
@@ -251,11 +251,11 @@ test-gitops-service-e2e-in-kcp-in-ci() {
 }
 
 delete-gitops-namespace() {
-  echo "=== delete-gitops-namespace() ==="
+  echo "=== delete-gitops-namespac  e() ==="
   # delete openshift-gitops ns to clear out the resources
   echo "[INFO] Delete openshift-gitops namespace to clear our the resources within 1 minute"
   timeout 1m kubectl delete ns openshift-gitops
-  if kubectl get ns openshift-gitop | grep openshift-gitops; then echo '[FAIL] openshift-gitops namespace stil exists'; exit 1; else echo '[PASSED] openshift-gitops namespace has been deleted'; fi
+  if kubectl get ns openshift-gitos | grep openshift-gitops; then echo '[FAIL] openshift-gitops namespace stil exists'; exit 1; else echo '[PASSED] openshift-gitops namespace has been deleted'; fi
 }
 
 install-argocd-kcp() {
@@ -339,8 +339,9 @@ run-tests() {
 # ~~~~
 
 check_if_go_v_compatibility
-clone-and-setup-ckcp
+clone-and-setup-ckcp # This one is running another script as well!
 delete-gitops-namespace
 install-argocd-kcp
 run-tests
 cleanup
+exit 0 # It should have exited long ago in case of problem

--- a/kcp/ckcp/setup-ckcp-on-openshift.sh
+++ b/kcp/ckcp/setup-ckcp-on-openshift.sh
@@ -285,5 +285,6 @@ fi
 
 # clean the tmp directory created for the local setup
 echo "e2e tests on kcp ran successfully, cleanup initiated ..."
-rm -rf ${TMP_DIR}
-cleanup
+exit 0
+#rm -rf ${TMP_DIR}
+#cleanup

--- a/kcp/ckcp/setup-ckcp-on-openshift.sh
+++ b/kcp/ckcp/setup-ckcp-on-openshift.sh
@@ -8,6 +8,10 @@ SCRIPT_DIR="$(
   pwd
 )"
 
+echo "========================================="
+echo "Running setup-ckcp-on-openshift.sh script"
+echo "========================================="
+
 ARGOCD_MANIFEST="$SCRIPT_DIR/../../manifests/kcp/argocd/install-argocd.yaml"
 ARGOCD_NAMESPACE="gitops-service-argocd"
 export TMP_DIR="$(mktemp -d -t kcp-gitops-service.XXXXXXXXX)"
@@ -21,10 +25,10 @@ export CONFIG_YAML="${SCRIPT_DIR}/config.yaml"
 export WORKSPACE="gitops-service-compute"
 
 
-[ ! -f "$ARGOCD_MANIFEST" ] && echo "$ARGOCD_MANIFEST does not exist."
-[ ! -f "$TMP_DIR" ] && echo "$TMP_DIR does not exist."
-[ ! -f "$OPENSHIFT_DEV_SCRIPT" ] && echo "$OPENSHIFT_DEV_SCRIPT does not exist."
-[ ! -f "$CONFIG_YAML" ] && echo "$CONFIG_YAML does not exist."
+[ ! -f "$ARGOCD_MANIFEST" ] && (echo "$ARGOCD_MANIFEST does not exist."; exit 1)
+[ ! -d "$TMP_DIR" ] && (echo "$TMP_DIR does not exist."; exit 1)
+[ ! -f "$OPENSHIFT_DEV_SCRIPT" ] && (echo "$OPENSHIFT_DEV_SCRIPT does not exist."; exit 1)
+[ ! -f "$CONFIG_YAML" ] && (echo "$CONFIG_YAML does not exist."; exit 1)
 
 
 echo "Temporary directory: ${TMP_DIR}"
@@ -33,9 +37,6 @@ check_if_go_v_compatibility
 clone-and-setup-ckcp
 delete-gitops-namespace
 install-argocd-kcp
-
-
-
 
 OPENSHIFT_CI="${OPENSHIFT_CI:-false}"
 

--- a/kcp/ckcp/setup-ckcp-on-openshift.sh
+++ b/kcp/ckcp/setup-ckcp-on-openshift.sh
@@ -232,9 +232,9 @@ install-argocd-kcp() {
   echo "[INFO] Installing Argo CD resources in workspace $WORKSPACE and namespace $ARGOCD_NAMESPACE"
   TMP_KUBE_CONFIG="${TMP_DIR}/ckcp-ckcp.default.managed-gitops-compute.kubeconfig"
  [ ! -f "$TMP_KUBE_CONFIG" ] && (echo "[FAIL] $TMP_KUBE_CONFIG does not exist."; exit 1)
-  echo "[INFO] Create $$ARGOCD_NAMESPACE namespace"
-  KUBECONFIG="$TMP_KUBE_CONFIG" kubectl create ns $ARGOCD_NAMESPACE || true
-  if kubectl get ns $ARGOCD_NAMESPACE | grep $ARGOCD_NAMESPACE ; then echo "[PASS] Namespace created"; else echo "[FAIL] Namespace failed to be created"; exit 1; fi
+  echo "[INFO] Create $ARGOCD_NAMESPACE namespace"
+  KUBECONFIG="$TMP_KUBE_CONFIG" kubectl create namespace $ARGOCD_NAMESPACE
+  if KUBECONFIG="$TMP_KUBE_CONFIG" kubectl get namespace $ARGOCD_NAMESPACE | grep $ARGOCD_NAMESPACE ; then echo "[PASS] Namespace created"; else echo "[FAIL] Namespace failed to be created"; exit 1; fi
   echo "[INFO] Apply the manifest $ARGOCD_MANIFEST"
   KUBECONFIG="$TMP_KUBE_CONFIG" kubectl apply -f $ARGOCD_MANIFEST -n $ARGOCD_NAMESPACE
 
@@ -242,10 +242,10 @@ install-argocd-kcp() {
 
  echo "[INFO] Creating KUBECONFIG secrets for argocd server and argocd application controller service accounts"
  create_kubeconfig_secret "argocd-server" "kcp-kubeconfig-controller"
- if kubectl -n kcp-kubeconfig-controller get secret argocd-server | grep argocd-server; then echo "[PASS] argocd-server secret applied"; else echo "[FAIL] Cannot apply argocd-server secret"; exit 1; fi
+ if KUBECONFIG="$TMP_KUBE_CONFIG" kubectl -n kcp-kubeconfig-controller get secret argocd-server | grep argocd-server; then echo "[PASS] argocd-server secret applied"; else echo "[FAIL] Cannot apply argocd-server secret"; exit 1; fi
 
  create_kubeconfig_secret "argocd-application-controller" "kcp-kubeconfig-server"
-if kubectl -n argocd-application-controller get secret argocd-application-controller | grep argocd-application-controller; then echo "[PASS] argocd-application-controller secret applied"; else echo "[FAIL] Cannot apply argocd-application-controller secret"; exit 1; fi
+if KUBECONFIG="$TMP_KUBE_CONFIG" kubectl -n argocd-application-controller get secret argocd-application-controller | grep argocd-application-controller; then echo "[PASS] argocd-application-controller secret applied"; else echo "[FAIL] Cannot apply argocd-application-controller secret"; exit 1; fi
 
 
 echo "[INFO] Verifying if argocd components are up and running after mounting kubeconfig secrets within 3 minutes"
@@ -287,7 +287,7 @@ stringData:
     }
 EOF
 
-if kubectl -n "$ARGOCD_NAMESPACE" get secret  argocd-cluster-config | grep  argocd-cluster-config; then echo "[PASS]  argocd-cluster-config secret applied"; else echo "[FAIL] Cannot apply  argocd-cluster-config secret"; exit 1; fi
+if KUBECONFIG="$TMP_KUBE_CONFIG" kubectl -n "$ARGOCD_NAMESPACE" get secret  argocd-cluster-config | grep  argocd-cluster-config; then echo "[PASS]  argocd-cluster-config secret applied"; else echo "[FAIL] Cannot apply  argocd-cluster-config secret"; exit 1; fi
 
 echo "[PASS] Argo CD is successfully installed in namespace $ARGOCD_NAMESPACE"
 


### PR DESCRIPTION
#### Description:
This PR is extending the cleanup functionallity for KCP E2E. Especially, it sends a SIGKILL signal followed by SIGTERM in case the processes were not stopped. If all fails, it prints more verbose information about the processes and tries (for one last time) to kill any Go processes (since the Makefile is running `go run ./main.go --this --that --flags`).

The reason for going down that route is because we have experienced a strange behavior for E2E KCP tests, were the controllers were not stopped, thus the CI was timing out -- resulting into a test failure. From the related Slack thread:

> In the [build log](https://storage.googleapis.com/origin-ci-test/pr-logs/pull/redhat-appstudio_managed-gitops/237/pull-ci-redhat-appstudio-managed-gitops-main-managed-gitops-e2e-tests-on-kcp/1582082265867882496/build-log.txt) for the test, you can see that:
The test suite failed at 2022-10-17 20:08:53Z (which should be the end of the job)
But, for some reason the controllers weren't killed until 2022-10-17T 21:24:31Z

I have also added a 5 minute timeout for ArgoCD deploy.sh which seems to take 2 hours.

#### Link to JIRA Story (if applicable):

None