### PR TITLE
Exclude *.kcp.dev resources from Argo CD watch list

### DIFF
--- a/cluster-agent/utils/argocd_create.go
+++ b/cluster-agent/utils/argocd_create.go
@@ -51,7 +51,7 @@ func CreateNamespaceScopedArgoCD(ctx context.Context, argocdCRName string, names
 
 	resourceExclusions, err := yaml.Marshal([]settings.FilteredResource{
 		{
-			APIGroups: []string{"tenancy.kcp.dev"},
+			APIGroups: []string{"*.kcp.dev"},
 			Clusters:  []string{"*"},
 			Kinds:     []string{"*"},
 		},

--- a/kcp/utils.sh
+++ b/kcp/utils.sh
@@ -9,7 +9,7 @@ SCRIPTPATH="$(
 
 CPS_KUBECONFIG="${CPS_KUBECONFIG:-$(realpath kcp/cps-kubeconfig)}"
 WORKLOAD_KUBECONFIG="${WORKLOAD_KUBECONFIG:-$HOME/.kube/config}"
-SYNCER_IMAGE="${SYNCER_IMAGE:-ghcr.io/kcp-dev/kcp/syncer:v0.8.2}"
+SYNCER_IMAGE="${SYNCER_IMAGE:-ghcr.io/kcp-dev/kcp/syncer:v0.9.1}"
 SYNCER_MANIFESTS=$(mktemp -d)/cps-syncer.yaml
 
 ARGOCD_MANIFEST="$(realpath manifests/kcp/argocd/install-argocd.yaml)"
@@ -236,7 +236,7 @@ createAPIBinding() {
     fi
 
     KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws use "${USER_WS}" &> /dev/null
-    acceptedPermissionClaims='
+    permissionClaims='
   permissionClaims:
   - group: ""
     resource: "secrets"
@@ -246,7 +246,7 @@ createAPIBinding() {
     state: "Accepted"'
 
     if [ "${exportName}" == "gitopsrvc-appstudio-shared" ]; then
-      permissionClaims="${acceptedPermissionClaims}
+      permissionClaims="${permissionClaims}
   - group: \"managed-gitops.redhat.com\"
     resource: \"gitopsdeployments\"
     state: \"Accepted\"
@@ -267,12 +267,12 @@ ${permissionClaims}
       exportName: ${exportName}
 EOF
 
-    yamllint -c "${SCRIPTPATH}"/../../utilities/yamllint.yaml "${SCRIPTPATH}"/../../createAPIBinding.yaml
+    yamllint -c "${SCRIPTPATH}"/../utilities/yamllint.yaml "${SCRIPTPATH}"/../createAPIBinding.yaml
 
     printf "APIBinding yaml for %s \n" "${1}"
     cat createAPIBinding.yaml
 
-    KUBECONFIG="${CPS_KUBECONFIG}" kubectl apply -f "${SCRIPTPATH}"/../../createAPIBinding.yaml
+    KUBECONFIG="${CPS_KUBECONFIG}" kubectl apply -f "${SCRIPTPATH}"/../createAPIBinding.yaml
     rm createAPIBinding.yaml
 }
 
@@ -333,11 +333,11 @@ subjects:
   name: "$userName"
 EOF
 
-    yamllint -c "${SCRIPTPATH}"/../../utilities/yamllint.yaml "${SCRIPTPATH}"/../../permissionToBindAPIExport.yaml
+    yamllint -c "${SCRIPTPATH}"/../utilities/yamllint.yaml "${SCRIPTPATH}"/../permissionToBindAPIExport.yaml
 
     printf "permissionToBindAPIExport yaml: \n"
     cat permissionToBindAPIExport.yaml
 
-    KUBECONFIG="${CPS_KUBECONFIG}" kubectl apply -f "${SCRIPTPATH}"/../../permissionToBindAPIExport.yaml
+    KUBECONFIG="${CPS_KUBECONFIG}" kubectl apply -f "${SCRIPTPATH}"/../permissionToBindAPIExport.yaml
     rm permissionToBindAPIExport.yaml
 }

--- a/kcp/virtual-workspace.sh
+++ b/kcp/virtual-workspace.sh
@@ -22,6 +22,7 @@ trap cleanup_workspace EXIT
 readKUBECONFIGPath
 
 echo "Initializing service provider workspace"
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace
 createAndEnterWorkspace "$SERVICE_WS"
 
 echo "Creating APIExports and APIResourceSchemas in workspace $SERVICE_WS"
@@ -30,11 +31,12 @@ KUBECONFIG="${CPS_KUBECONFIG}" make apply-kcp-api-all
 permissionToBindAPIExport 
 
 echo "Initializing user workspace"
+KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace
 createAndEnterWorkspace "$USER_WS"
 
 echo "Creating APIBindings in workspace $USER_WS"
-createAPIBinding gitopsrvc-backend-shared
-createAPIBinding gitopsrvc-appstudio-shared
+createAPIBinding gitopsrvc-backend-shared "" $SERVICE_WS
+createAPIBinding gitopsrvc-appstudio-shared "" $SERVICE_WS
 
 # Checking if the bindings are in Ready state
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl wait --for=condition=Ready apibindings/gitopsrvc-appstudio-shared

--- a/manifests/kcp/argocd/install-argocd.yaml
+++ b/manifests/kcp/argocd/install-argocd.yaml
@@ -9304,7 +9304,7 @@ metadata:
 data:
   resource.exclusions: |
     - apiGroups:
-      - "tenancy.kcp.dev"
+      - "*.kcp.dev"
       clusters:
       - "*"
       kinds:

--- a/manifests/kcp/argocd/install-argocd.yaml
+++ b/manifests/kcp/argocd/install-argocd.yaml
@@ -9301,6 +9301,14 @@ metadata:
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd
   name: argocd-cm
+data:
+  resource.exclusions: |
+    - apiGroups:
+      - "tenancy.kcp.dev"
+      clusters:
+      - "*"
+      kinds:
+      - "*"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/manifests/staging-cluster-resources/argo-cd.yaml
+++ b/manifests/staging-cluster-resources/argo-cd.yaml
@@ -107,7 +107,7 @@ spec:
     ca: {}
   resourceExclusions: |
     - apiGroups:
-      - tenancy.kcp.dev
+      - *.kcp.dev
       clusters:
       - "*"
       kinds:

--- a/manifests/staging-cluster-resources/argo-cd.yaml
+++ b/manifests/staging-cluster-resources/argo-cd.yaml
@@ -105,3 +105,10 @@ spec:
       type: ""
   tls:
     ca: {}
+  resourceExclusions: |
+    - apiGroups:
+      - tenancy.kcp.dev
+      clusters:
+      - "*"
+      kinds:
+      - "*"

--- a/manifests/staging-cluster-resources/argo-cd.yaml
+++ b/manifests/staging-cluster-resources/argo-cd.yaml
@@ -107,7 +107,7 @@ spec:
     ca: {}
   resourceExclusions: |
     - apiGroups:
-      - *.kcp.dev
+      - "*.kcp.dev"
       clusters:
       - "*"
       kinds:


### PR DESCRIPTION
#### Description:
- Add resource exclusions to Argo CD CR and argocd-cm config map
- Update syncer image to v0.9.1 and fix the script

#### Link to JIRA Story (if applicable):
https://issues.redhat.com/browse/GITOPSRVCE-242