### PR TITLE
ci: Bump golangci

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: "Ensure 'backend' passes 'go-lint' - run 'make lint' to identify issues"
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
           cd $GITHUB_WORKSPACE/backend
           make lint 
 

--- a/backend/routes/webhooks/webhooks.go
+++ b/backend/routes/webhooks/webhooks.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"strings"
 
@@ -31,7 +31,7 @@ func ParseWebhookInfo(request *restful.Request, response *restful.Response) {
 		log.Fatalln(nil, errors.New("No event Id!"))
 	}
 	// assigning payload data
-	payload, err := ioutil.ReadAll(request.Request.Body)
+	payload, err := io.ReadAll(request.Request.Body)
 	if err != nil {
 		log.Printf("error reading request body: err=%s\n", err)
 		return

--- a/cluster-agent/utils/retrieve_metrics.go
+++ b/cluster-agent/utils/retrieve_metrics.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -12,7 +12,7 @@ func GetAPIServerMetrics(routeEndpoint string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -27,7 +27,7 @@ func GetRepoServerMetrics(routeEndpoint string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -42,7 +42,7 @@ func GetApplicationControllerMetrics(routeEndpoint string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	appv1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -217,7 +216,7 @@ func extractKubeConfigValues() (string, string, error) {
 		}
 	}
 
-	kubeConfigContents, err := ioutil.ReadFile(kubeConfigDefault)
+	kubeConfigContents, err := os.ReadFile(kubeConfigDefault)
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
#### Description:
- Bump golangci-lint version to keep up
- Had to replace the deprecated `io/ioutils` packages (since Go 1.16) with either `io` or `os`.

#### Link to JIRA Story (if applicable):

None