### PR TITLE
Update E2E test harness/code to work with KCP virtual workspaces (Solves: #GITOPSRVCE-213)

### DIFF
--- a/kcp/kcp-e2e/setup-ws-e2e.sh
+++ b/kcp/kcp-e2e/setup-ws-e2e.sh
@@ -7,6 +7,8 @@ SCRIPTPATH="$(
   pwd -P
 )"
 
+export DISABLE_KCP_VIRTUAL_WORKSPACE="false"
+
 source "${SCRIPTPATH}/../utils.sh"
 
 PARENT_E2E_WS="gitops-service-e2e-test"

--- a/kcp/kcp-e2e/setup-ws-e2e.sh
+++ b/kcp/kcp-e2e/setup-ws-e2e.sh
@@ -35,6 +35,8 @@ echo "Initializing service provider workspace"
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace use "${PARENT_E2E_WS}"
 createAndEnterWorkspace "${SERVICE_WS}"
+KUBECONFIG="${CPS_KUBECONFIG}"  kubectl config view > /tmp/serviceWs.kubeconfig
+export SERVICE_PROVIDER_KUBECONFIG=/tmp/serviceWs.kubeconfig
 
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workload sync "service-ws-test-cluster" --resources "services,statefulsets.apps,deployments.apps,routes.route.openshift.io" --syncer-image ghcr.io/kcp-dev/kcp/syncer:v0.9.0 --output-file ./syncer-servicews.yaml --namespace kcp-syncer
 kubectl apply -f ./syncer-servicews.yaml
@@ -53,7 +55,8 @@ echo "Initializing user workspace"
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp workspace use "${PARENT_E2E_WS}"
 createAndEnterWorkspace "${USER_WS}"
-
+KUBECONFIG="${CPS_KUBECONFIG}"  kubectl config view > /tmp/userWs.kubeconfig
+export USER_KUBECONFIG=/tmp/userWs.kubeconfig
 
 echo "Creating APIBindings in workspace ${USER_WS}"
 createAPIBinding gitopsrvc-backend-shared "${PARENT_E2E_WS}" "${SERVICE_WS}"

--- a/tests-e2e/core/argocd_application_test.go
+++ b/tests-e2e/core/argocd_application_test.go
@@ -26,7 +26,14 @@ var _ = Describe("Argo CD Application", func() {
 			gitOpsDeployment := buildGitOpsDeploymentResource("my-gitops-depl-automated",
 				"https://github.com/redhat-appstudio/gitops-repository-template", "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
-			err := k8s.Create(&gitOpsDeployment)
+
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
+			err = k8s.Create(&gitOpsDeployment, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("GitOpsDeployment should have expected health and status")

--- a/tests-e2e/core/argocd_application_test.go
+++ b/tests-e2e/core/argocd_application_test.go
@@ -27,9 +27,10 @@ var _ = Describe("Argo CD Application", func() {
 				"https://github.com/redhat-appstudio/gitops-repository-template", "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
-			err := k8s.Create(&gitOpsDeployment, k8sClient)
+			err = k8s.Create(&gitOpsDeployment, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("GitOpsDeployment should have expected health and status")

--- a/tests-e2e/core/argocd_application_test.go
+++ b/tests-e2e/core/argocd_application_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
 	dbutil "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db/util"
-	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	appFixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/application"
 	gitopsDeplFixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/gitopsdeployment"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
@@ -27,13 +26,9 @@ var _ = Describe("Argo CD Application", func() {
 				"https://github.com/redhat-appstudio/gitops-repository-template", "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
-
-			err = k8s.Create(&gitOpsDeployment, k8sClient)
+			err := k8s.Create(&gitOpsDeployment, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("GitOpsDeployment should have expected health and status")

--- a/tests-e2e/core/argocd_application_test.go
+++ b/tests-e2e/core/argocd_application_test.go
@@ -20,7 +20,7 @@ import (
 var _ = Describe("Argo CD Application", func() {
 	Context("Creating GitOpsDeployment should result in an Argo CD Application", func() {
 		It("Argo CD Application should have has prune, allowEmpty and selfHeal enabled", func() {
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 
 			By("create a new GitOpsDeployment CR")
 			gitOpsDeployment := buildGitOpsDeploymentResource("my-gitops-depl-automated",

--- a/tests-e2e/core/argocd_application_test.go
+++ b/tests-e2e/core/argocd_application_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
 	dbutil "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db/util"
+	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	appFixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/application"
 	gitopsDeplFixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/gitopsdeployment"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
@@ -19,7 +20,7 @@ import (
 var _ = Describe("Argo CD Application", func() {
 	Context("Creating GitOpsDeployment should result in an Argo CD Application", func() {
 		It("Argo CD Application should have has prune, allowEmpty and selfHeal enabled", func() {
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			By("create a new GitOpsDeployment CR")
 			gitOpsDeployment := buildGitOpsDeploymentResource("my-gitops-depl-automated",

--- a/tests-e2e/core/argocd_instance_test.go
+++ b/tests-e2e/core/argocd_instance_test.go
@@ -34,7 +34,11 @@ var _ = Describe("Standalone ArgoCD instance E2E tests", func() {
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			By("deleting the namespace before the test starts, so that the code can create it")
-			err := fixture.DeleteNamespace(argocdNamespace)
+			config, err := fixture.GetKubeConfig()
+			if err != nil {
+				panic(err)
+			}
+			err = fixture.DeleteNamespace(config, argocdNamespace)
 			Expect(err).To(BeNil())
 
 		})
@@ -53,7 +57,7 @@ var _ = Describe("Standalone ArgoCD instance E2E tests", func() {
 			Expect(err).To(BeNil())
 			apiHost := config.Host
 
-			k8sClient, err := fixture.GetKubeClient()
+			k8sClient, err := fixture.GetKubeClient(config)
 			Expect(err).To(BeNil())
 
 			err = argocdv1.CreateNamespaceScopedArgoCD(ctx, argocdCRName, argocdNamespace, k8sClient, log)

--- a/tests-e2e/core/argocd_instance_test.go
+++ b/tests-e2e/core/argocd_instance_test.go
@@ -67,7 +67,8 @@ var _ = Describe("Standalone ArgoCD instance E2E tests", func() {
 			argocdInstance := &apps.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: argocdCRName + "-server", Namespace: argocdNamespace},
 			}
-			Eventually(argocdInstance, "60s", "5s").Should(k8s.ExistByName())
+
+			Eventually(argocdInstance, "60s", "5s").Should(k8s.ExistByName(k8sClient))
 			Expect(err).To(BeNil())
 
 			By("ensuring ArgoCD resource exists in kube-system namespace")
@@ -103,7 +104,8 @@ var _ = Describe("Standalone ArgoCD instance E2E tests", func() {
 					},
 				},
 			}
-			err = k8s.Create(&app)
+
+			err = k8s.Create(&app, k8sClient)
 			Expect(err).To(BeNil())
 
 			cs := argocdv1.NewCredentialService(nil, true)

--- a/tests-e2e/core/argocd_instance_test.go
+++ b/tests-e2e/core/argocd_instance_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Standalone ArgoCD instance E2E tests", func() {
 		BeforeEach(func() {
 
 			By("Delete old namespaces, and kube-system resources")
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 
 			By("deleting the namespace before the test starts, so that the code can create it")
 			config, err := fixture.GetKubeConfig()

--- a/tests-e2e/core/argocd_instance_test.go
+++ b/tests-e2e/core/argocd_instance_test.go
@@ -34,11 +34,11 @@ var _ = Describe("Standalone ArgoCD instance E2E tests", func() {
 			Expect(EnsureCleanSlate()).To(Succeed())
 
 			By("deleting the namespace before the test starts, so that the code can create it")
-			config, err := fixture.GetKubeConfig()
+			config, err := fixture.GetSystemKubeConfig()
 			if err != nil {
 				panic(err)
 			}
-			err = fixture.DeleteNamespace(config, argocdNamespace)
+			err = fixture.DeleteNamespace(argocdNamespace, config)
 			Expect(err).To(BeNil())
 
 		})
@@ -53,7 +53,7 @@ var _ = Describe("Standalone ArgoCD instance E2E tests", func() {
 			ctx := context.Background()
 			log := log.FromContext(ctx)
 
-			config, err := fixture.GetKubeConfig()
+			config, err := fixture.GetSystemKubeConfig()
 			Expect(err).To(BeNil())
 			apiHost := config.Host
 

--- a/tests-e2e/core/argocd_instance_test.go
+++ b/tests-e2e/core/argocd_instance_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Standalone ArgoCD instance E2E tests", func() {
 		BeforeEach(func() {
 
 			By("Delete old namespaces, and kube-system resources")
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			By("deleting the namespace before the test starts, so that the code can create it")
 			config, err := fixture.GetSystemKubeConfig()

--- a/tests-e2e/core/core_suite_test.go
+++ b/tests-e2e/core/core_suite_test.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -31,9 +31,19 @@ func EnsureCleanSlate() error {
 
 	if !sharedutil.IsKCPVirtualWorkspaceDisabled() {
 		Expect(fixture.EnsureCleanSlateNonKCPVirtualWorkspace()).To(Succeed())
+		return nil
 	} else {
 		Expect(fixture.EnsureCleanSlateKCPVirtualWorkspace()).To(Succeed())
+		return nil
 	}
+}
 
-	return fmt.Errorf("Error in deciding which function to use against EnsureCleanSlate")
+func GetE2ETestUserWorkspaceKubeClient() client.Client {
+	config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+	Expect(err).To(BeNil())
+
+	k8sClient, err := fixture.GetKubeClient(config)
+	Expect(err).To(BeNil())
+
+	return k8sClient
 }

--- a/tests-e2e/core/core_suite_test.go
+++ b/tests-e2e/core/core_suite_test.go
@@ -6,9 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	"go.uber.org/zap/zapcore"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -24,14 +22,4 @@ func TestCore(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Core Suite", reporterConfig)
-}
-
-func GetE2ETestUserWorkspaceKubeClient() client.Client {
-	config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-	Expect(err).To(BeNil())
-
-	k8sClient, err := fixture.GetKubeClient(config)
-	Expect(err).To(BeNil())
-
-	return k8sClient
 }

--- a/tests-e2e/core/core_suite_test.go
+++ b/tests-e2e/core/core_suite_test.go
@@ -1,11 +1,14 @@
 package core
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
+	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	"go.uber.org/zap/zapcore"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -22,4 +25,15 @@ func TestCore(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Core Suite", reporterConfig)
+}
+
+func EnsureCleanSlate() error {
+
+	if !sharedutil.IsKCPVirtualWorkspaceDisabled() {
+		Expect(fixture.EnsureCleanSlateNonKCPVirtualWorkspace()).To(Succeed())
+	} else {
+		Expect(fixture.EnsureCleanSlateKCPVirtualWorkspace()).To(Succeed())
+	}
+
+	return fmt.Errorf("Error in deciding which function to use against EnsureCleanSlate")
 }

--- a/tests-e2e/core/core_suite_test.go
+++ b/tests-e2e/core/core_suite_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -25,17 +24,6 @@ func TestCore(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Core Suite", reporterConfig)
-}
-
-func EnsureCleanSlate() error {
-
-	if !sharedutil.IsKCPVirtualWorkspaceDisabled() {
-		Expect(fixture.EnsureCleanSlateNonKCPVirtualWorkspace()).To(Succeed())
-		return nil
-	} else {
-		Expect(fixture.EnsureCleanSlateKCPVirtualWorkspace()).To(Succeed())
-		return nil
-	}
 }
 
 func GetE2ETestUserWorkspaceKubeClient() client.Client {

--- a/tests-e2e/core/gitopsdeployment_resource_test.go
+++ b/tests-e2e/core/gitopsdeployment_resource_test.go
@@ -37,7 +37,13 @@ var _ = Describe("GitOpsDeployment Condition Tests", func() {
 				},
 			}
 
-			err := k8s.Create(&gitOpsDeploymentResource)
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
+			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 
 			expectedConditions := []managedgitopsv1alpha1.GitOpsDeploymentCondition{
@@ -56,7 +62,7 @@ var _ = Describe("GitOpsDeployment Condition Tests", func() {
 			)
 
 			By("delete the GitOpsDeployment resource")
-			err = k8s.Delete(&gitOpsDeploymentResource)
+			err = k8s.Delete(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 		})
 	})

--- a/tests-e2e/core/gitopsdeployment_resource_test.go
+++ b/tests-e2e/core/gitopsdeployment_resource_test.go
@@ -16,7 +16,7 @@ var _ = Describe("GitOpsDeployment Condition Tests", func() {
 
 		It("ensures that GitOpsDeployment .status.condition field is populated with the corrrect error when an illegal GitOpsDeployment is created", func() {
 
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			By("create an invalid GitOpsDeployment application")
 			gitOpsDeploymentResource := managedgitopsv1alpha1.GitOpsDeployment{

--- a/tests-e2e/core/gitopsdeployment_resource_test.go
+++ b/tests-e2e/core/gitopsdeployment_resource_test.go
@@ -16,7 +16,7 @@ var _ = Describe("GitOpsDeployment Condition Tests", func() {
 
 		It("ensures that GitOpsDeployment .status.condition field is populated with the corrrect error when an illegal GitOpsDeployment is created", func() {
 
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 
 			By("create an invalid GitOpsDeployment application")
 			gitOpsDeploymentResource := managedgitopsv1alpha1.GitOpsDeployment{

--- a/tests-e2e/core/gitopsdeployment_resource_test.go
+++ b/tests-e2e/core/gitopsdeployment_resource_test.go
@@ -37,13 +37,9 @@ var _ = Describe("GitOpsDeployment Condition Tests", func() {
 				},
 			}
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
-
-			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
+			err := k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 
 			expectedConditions := []managedgitopsv1alpha1.GitOpsDeploymentCondition{

--- a/tests-e2e/core/gitopsdeployment_resource_test.go
+++ b/tests-e2e/core/gitopsdeployment_resource_test.go
@@ -37,9 +37,10 @@ var _ = Describe("GitOpsDeployment Condition Tests", func() {
 				},
 			}
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
-			err := k8s.Create(&gitOpsDeploymentResource, k8sClient)
+			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 
 			expectedConditions := []managedgitopsv1alpha1.GitOpsDeploymentCondition{

--- a/tests-e2e/core/gitopsdeployment_status_test.go
+++ b/tests-e2e/core/gitopsdeployment_status_test.go
@@ -183,8 +183,7 @@ var _ = Describe("GitOpsDeployment SyncError test", func() {
 				),
 			)
 
-			// this assumes that service is running on non aware kcp client
-			config, err := fixture.GetKubeConfig()
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
 			Expect(err).To(BeNil())
 
 			k8sClient, err := fixture.GetKubeClient(config)

--- a/tests-e2e/core/gitopsdeployment_status_test.go
+++ b/tests-e2e/core/gitopsdeployment_status_test.go
@@ -27,7 +27,13 @@ var _ = Describe("GitOpsDeployment Status Tests", func() {
 				"https://github.com/redhat-appstudio/gitops-repository-template", "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			err := k8s.Create(&gitOpsDeploymentResource)
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
+			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("ensuring the GitOpsDeployment status field have health, sync and resources fields populated")
@@ -91,7 +97,7 @@ var _ = Describe("GitOpsDeployment Status Tests", func() {
 			)
 
 			By("delete the GitOpsDeployment resource")
-			err = k8s.Delete(&gitOpsDeploymentResource)
+			err = k8s.Delete(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 		})
 	})
@@ -120,7 +126,13 @@ var _ = Describe("GitOpsDeployment SyncError test", func() {
 				},
 			}
 
-			err := k8s.Create(&gitOpsDeploymentResource)
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
+			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 
 			Eventually(gitOpsDeploymentResource, ArgoCDReconcileWaitTime, "1s").Should(
@@ -183,12 +195,6 @@ var _ = Describe("GitOpsDeployment SyncError test", func() {
 				),
 			)
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
-
 			err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&gitOpsDeploymentResource), &gitOpsDeploymentResource)
 			Expect(err).To(Succeed())
 
@@ -196,7 +202,7 @@ var _ = Describe("GitOpsDeployment SyncError test", func() {
 			gitOpsDeploymentResource.Spec.Source.RepoURL = "https://github.com/redhat-appstudio/gitops-repository-template"
 			gitOpsDeploymentResource.Spec.Source.Path = "environments/overlays/dev"
 
-			err = k8s.Update(&gitOpsDeploymentResource)
+			err = k8s.Update(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Wait until ArgoCD Application .conditions.Message value is cleared")
@@ -231,7 +237,7 @@ var _ = Describe("GitOpsDeployment SyncError test", func() {
 			)
 
 			By("delete the GitOpsDeployment resource")
-			err = k8s.Delete(&gitOpsDeploymentResource)
+			err = k8s.Delete(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 		})
 	})

--- a/tests-e2e/core/gitopsdeployment_status_test.go
+++ b/tests-e2e/core/gitopsdeployment_status_test.go
@@ -183,7 +183,11 @@ var _ = Describe("GitOpsDeployment SyncError test", func() {
 				),
 			)
 
-			k8sClient, err := fixture.GetKubeClient()
+			// this assumes that service is running on non aware kcp client
+			config, err := fixture.GetKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
 			Expect(err).To(BeNil())
 
 			err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&gitOpsDeploymentResource), &gitOpsDeploymentResource)

--- a/tests-e2e/core/gitopsdeployment_status_test.go
+++ b/tests-e2e/core/gitopsdeployment_status_test.go
@@ -20,7 +20,7 @@ import (
 var _ = Describe("GitOpsDeployment Status Tests", func() {
 	Context("Status field of GitOpsDeployment is updated accurately", func() {
 		It("GitOpsDeployment .status.resources field is populated with the right resources", func() {
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			By("create a new GitOpsDeployment resource")
 			gitOpsDeploymentResource := buildGitOpsDeploymentResource("gitops-depl-test-status",
@@ -105,7 +105,7 @@ var _ = Describe("GitOpsDeployment SyncError test", func() {
 
 		It("ensures that GitOpsDeployment .status.sync.syncError field contains the syncError if Application is not synced and error type of the error is SyncError ", func() {
 
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			By("create an invalid GitOpsDeployment application")
 			gitOpsDeploymentResource := managedgitopsv1alpha1.GitOpsDeployment{

--- a/tests-e2e/core/gitopsdeployment_status_test.go
+++ b/tests-e2e/core/gitopsdeployment_status_test.go
@@ -27,9 +27,10 @@ var _ = Describe("GitOpsDeployment Status Tests", func() {
 				"https://github.com/redhat-appstudio/gitops-repository-template", "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
-			err := k8s.Create(&gitOpsDeploymentResource, k8sClient)
+			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("ensuring the GitOpsDeployment status field have health, sync and resources fields populated")
@@ -122,9 +123,10 @@ var _ = Describe("GitOpsDeployment SyncError test", func() {
 				},
 			}
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
-			err := k8s.Create(&gitOpsDeploymentResource, k8sClient)
+			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 
 			Eventually(gitOpsDeploymentResource, ArgoCDReconcileWaitTime, "1s").Should(

--- a/tests-e2e/core/gitopsdeployment_status_test.go
+++ b/tests-e2e/core/gitopsdeployment_status_test.go
@@ -27,13 +27,9 @@ var _ = Describe("GitOpsDeployment Status Tests", func() {
 				"https://github.com/redhat-appstudio/gitops-repository-template", "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
-
-			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
+			err := k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("ensuring the GitOpsDeployment status field have health, sync and resources fields populated")
@@ -126,13 +122,9 @@ var _ = Describe("GitOpsDeployment SyncError test", func() {
 				},
 			}
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
-
-			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
+			err := k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 
 			Eventually(gitOpsDeploymentResource, ArgoCDReconcileWaitTime, "1s").Should(

--- a/tests-e2e/core/gitopsdeployment_status_test.go
+++ b/tests-e2e/core/gitopsdeployment_status_test.go
@@ -20,7 +20,7 @@ import (
 var _ = Describe("GitOpsDeployment Status Tests", func() {
 	Context("Status field of GitOpsDeployment is updated accurately", func() {
 		It("GitOpsDeployment .status.resources field is populated with the right resources", func() {
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 
 			By("create a new GitOpsDeployment resource")
 			gitOpsDeploymentResource := buildGitOpsDeploymentResource("gitops-depl-test-status",
@@ -109,7 +109,7 @@ var _ = Describe("GitOpsDeployment SyncError test", func() {
 
 		It("ensures that GitOpsDeployment .status.sync.syncError field contains the syncError if Application is not synced and error type of the error is SyncError ", func() {
 
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 
 			By("create an invalid GitOpsDeployment application")
 			gitOpsDeploymentResource := managedgitopsv1alpha1.GitOpsDeployment{

--- a/tests-e2e/core/gitopsdeployment_test.go
+++ b/tests-e2e/core/gitopsdeployment_test.go
@@ -31,7 +31,12 @@ const (
 var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 	Context("Create, Update and Delete a GitOpsDeployment ", func() {
-		k8sClient, err := fixture.GetKubeClient()
+
+		// this assumes that service is running on non aware kcp client
+		config, err := fixture.GetKubeConfig()
+		Expect(err).To(BeNil())
+
+		k8sClient, err := fixture.GetKubeClient(config)
 		Expect(err).To(BeNil())
 		ctx := context.Background()
 
@@ -114,7 +119,11 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 			Eventually(func() bool {
 
-				k8sclient, err := fixture.GetKubeClient()
+				// this assumes that service is running on non aware kcp client
+				config, err := fixture.GetKubeConfig()
+				Expect(err).To(BeNil())
+
+				k8sclient, err := fixture.GetKubeClient(config)
 				Expect(err).To(BeNil())
 
 				for _, resourceValue := range expectedResourceStatusList {

--- a/tests-e2e/core/gitopsdeployment_test.go
+++ b/tests-e2e/core/gitopsdeployment_test.go
@@ -119,8 +119,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 			Eventually(func() bool {
 
-				// this assumes that service is running on non aware kcp client
-				config, err := fixture.GetKubeConfig()
+				config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
 				Expect(err).To(BeNil())
 
 				k8sclient, err := fixture.GetKubeClient(config)

--- a/tests-e2e/core/gitopsdeployment_test.go
+++ b/tests-e2e/core/gitopsdeployment_test.go
@@ -155,7 +155,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("Should ensure succesful creation of GitOpsDeployment, by creating the GitOpsDeployment", func() {
 
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 			gitOpsDeploymentResource := buildGitOpsDeploymentResource(name,
 				repoURL, "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
@@ -216,7 +216,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 		})
 
 		It("Should ensure synchronicity of create and update of GitOpsDeployment, by ensurng no updates are done in existing deployment, if CR is submitted again without any changes", func() {
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			gitOpsDeploymentResource := buildGitOpsDeploymentResource(name,
 				repoURL, "environments/overlays/dev",
@@ -279,7 +279,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 		})
 
 		It("Should ensure synchronicity of create and update of GitOpsDeployment, by ensuring GitOpsDeployment should update successfully on changing value(s) within Spec", func() {
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 			gitOpsDeploymentResource := buildGitOpsDeploymentResource(name,
 				repoURL, "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
@@ -320,7 +320,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("Checks whether a change in repo URL is reflected within the cluster", func() {
 
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
@@ -384,7 +384,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("Checks whether a change in source path is reflected within the cluster", func() {
 
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
@@ -474,7 +474,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("Checks whether a change in target revision is reflected within the cluster", func() {
 
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			By("creating a new GitOpsDeployment resource")
 			gitOpsDeploymentResource := buildTargetRevisionGitOpsDeploymentResource("gitops-depl-test",
@@ -535,7 +535,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("Checks whether resources are created in target revision and reflected within the cluster", func() {
 
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			By("creating a new GitOpsDeployment resource")
 			gitOpsDeploymentResource := buildTargetRevisionGitOpsDeploymentResource("gitops-depl-test-status",
@@ -591,7 +591,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("Checks whether deleting the GitOpsDeployment deletes all the resources deployed as part of it", func() {
 
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			By("creating a new GitOpsDeployment resource")
 			gitOpsDeploymentResource := buildGitOpsDeploymentResource("gitops-depl-test-status",
@@ -638,7 +638,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("Checks for failure of deployment when an invalid input is provided", func() {
 
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			By("ensuring GitOpsDeployment Fails to create and deploy application when an invalid field input is passed")
 			gitOpsDeploymentResource := buildGitOpsDeploymentResource("test-should-fail",

--- a/tests-e2e/core/gitopsdeployment_test.go
+++ b/tests-e2e/core/gitopsdeployment_test.go
@@ -119,7 +119,8 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 			Eventually(func() bool {
 
-				k8sclient := GetE2ETestUserWorkspaceKubeClient()
+				k8sclient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+				Expect(err).To(Succeed())
 
 				for _, resourceValue := range expectedResourceStatusList {
 					ns := typed.NamespacedName{
@@ -162,7 +163,8 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 			gitOpsDeploymentResource.Spec.Destination.Environment = ""
 			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
@@ -224,7 +226,8 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 			gitOpsDeploymentResource.Spec.Destination.Environment = ""
 			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
@@ -284,7 +287,8 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				repoURL, "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
@@ -322,7 +326,8 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			By("creating a new GitOpsDeployment resource")
 			gitOpsDeploymentResource := buildTargetRevisionGitOpsDeploymentResource("gitops-depl-test",
@@ -386,7 +391,8 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			By("creating a new GitOpsDeployment resource")
 			gitOpsDeploymentResource := buildTargetRevisionGitOpsDeploymentResource("gitops-depl-test",
@@ -481,7 +487,8 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				"https://github.com/managed-gitops-test-data/deployment-permutations-a", "pathB", "branchA",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
@@ -542,7 +549,8 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				"https://github.com/redhat-appstudio/gitops-repository-template", "environments/overlays/dev", "xyz",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
@@ -598,7 +606,8 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				"https://github.com/redhat-appstudio/gitops-repository-template", "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
@@ -645,7 +654,8 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				"invalid-url", "path/path/path",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())

--- a/tests-e2e/core/gitopsdeployment_test.go
+++ b/tests-e2e/core/gitopsdeployment_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 	Context("Create, Update and Delete a GitOpsDeployment ", func() {
 
 		// this assumes that service is running on non aware kcp client
-		config, err := fixture.GetKubeConfig()
+		config, err := fixture.GetSystemKubeConfig()
 		Expect(err).To(BeNil())
 
 		k8sClient, err := fixture.GetKubeClient(config)
@@ -119,11 +119,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 			Eventually(func() bool {
 
-				config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-				Expect(err).To(BeNil())
-
-				k8sclient, err := fixture.GetKubeClient(config)
-				Expect(err).To(BeNil())
+				k8sclient := GetE2ETestUserWorkspaceKubeClient()
 
 				for _, resourceValue := range expectedResourceStatusList {
 					ns := typed.NamespacedName{
@@ -166,11 +162,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 			gitOpsDeploymentResource.Spec.Destination.Environment = ""
 			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
@@ -232,11 +224,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 			gitOpsDeploymentResource.Spec.Destination.Environment = ""
 			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
@@ -296,11 +284,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				repoURL, "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
@@ -338,11 +322,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 			Expect(EnsureCleanSlate()).To(Succeed())
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			By("creating a new GitOpsDeployment resource")
 			gitOpsDeploymentResource := buildTargetRevisionGitOpsDeploymentResource("gitops-depl-test",
@@ -405,11 +385,8 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 		It("Checks whether a change in source path is reflected within the cluster", func() {
 
 			Expect(EnsureCleanSlate()).To(Succeed())
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
 
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			By("creating a new GitOpsDeployment resource")
 			gitOpsDeploymentResource := buildTargetRevisionGitOpsDeploymentResource("gitops-depl-test",
@@ -504,11 +481,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				"https://github.com/managed-gitops-test-data/deployment-permutations-a", "pathB", "branchA",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
@@ -569,11 +542,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				"https://github.com/redhat-appstudio/gitops-repository-template", "environments/overlays/dev", "xyz",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
@@ -629,11 +598,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				"https://github.com/redhat-appstudio/gitops-repository-template", "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
@@ -680,11 +645,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				"invalid-url", "path/path/path",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())

--- a/tests-e2e/core/gitopsdeployment_test.go
+++ b/tests-e2e/core/gitopsdeployment_test.go
@@ -159,7 +159,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("Should ensure succesful creation of GitOpsDeployment, by creating the GitOpsDeployment", func() {
 
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 			gitOpsDeploymentResource := buildGitOpsDeploymentResource(name,
 				repoURL, "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
@@ -224,7 +224,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 		})
 
 		It("Should ensure synchronicity of create and update of GitOpsDeployment, by ensurng no updates are done in existing deployment, if CR is submitted again without any changes", func() {
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 
 			gitOpsDeploymentResource := buildGitOpsDeploymentResource(name,
 				repoURL, "environments/overlays/dev",
@@ -291,7 +291,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 		})
 
 		It("Should ensure synchronicity of create and update of GitOpsDeployment, by ensuring GitOpsDeployment should update successfully on changing value(s) within Spec", func() {
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 			gitOpsDeploymentResource := buildGitOpsDeploymentResource(name,
 				repoURL, "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
@@ -336,7 +336,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("Checks whether a change in repo URL is reflected within the cluster", func() {
 
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 
 			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
 			Expect(err).To(BeNil())
@@ -404,7 +404,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("Checks whether a change in source path is reflected within the cluster", func() {
 
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
 			Expect(err).To(BeNil())
 
@@ -497,7 +497,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("Checks whether a change in target revision is reflected within the cluster", func() {
 
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 
 			By("creating a new GitOpsDeployment resource")
 			gitOpsDeploymentResource := buildTargetRevisionGitOpsDeploymentResource("gitops-depl-test",
@@ -562,7 +562,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("Checks whether resources are created in target revision and reflected within the cluster", func() {
 
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 
 			By("creating a new GitOpsDeployment resource")
 			gitOpsDeploymentResource := buildTargetRevisionGitOpsDeploymentResource("gitops-depl-test-status",
@@ -622,7 +622,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("Checks whether deleting the GitOpsDeployment deletes all the resources deployed as part of it", func() {
 
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 
 			By("creating a new GitOpsDeployment resource")
 			gitOpsDeploymentResource := buildGitOpsDeploymentResource("gitops-depl-test-status",
@@ -673,7 +673,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("Checks for failure of deployment when an invalid input is provided", func() {
 
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 
 			By("ensuring GitOpsDeployment Fails to create and deploy application when an invalid field input is passed")
 			gitOpsDeploymentResource := buildGitOpsDeploymentResource("test-should-fail",

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -99,7 +99,11 @@ var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 
 			secretList := corev1.SecretList{}
 
-			k8sClient, err := fixture.GetKubeClient()
+			// this assumes that service is running on non aware kcp client
+			config, err := fixture.GetKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
 			Expect(err).To(BeNil())
 			err = k8sClient.List(context.Background(), &secretList, &client.ListOptions{Namespace: dbutil.DefaultGitOpsEngineSingleInstanceNamespace})
 			Expect(err).To(BeNil())

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -43,11 +43,7 @@ var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 
 			managedEnv, secret := buildManagedEnvironment(apiServerURL, kubeConfigContents)
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			err = k8s.Create(&secret, k8sClient)
 			Expect(err).To(BeNil())

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -34,7 +34,7 @@ var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 				Skip("Skipping this test until we support running gitops operator with KCP")
 			}
 
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 
 			By("creating the GitOpsDeploymentManagedEnvironment")
 

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -99,8 +99,7 @@ var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 
 			secretList := corev1.SecretList{}
 
-			// this assumes that service is running on non aware kcp client
-			config, err := fixture.GetKubeConfig()
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
 			Expect(err).To(BeNil())
 
 			k8sClient, err := fixture.GetKubeClient(config)

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -43,7 +43,8 @@ var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 
 			managedEnv, secret := buildManagedEnvironment(apiServerURL, kubeConfigContents)
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			err = k8s.Create(&secret, k8sClient)
 			Expect(err).To(BeNil())

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -34,7 +34,7 @@ var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 				Skip("Skipping this test until we support running gitops operator with KCP")
 			}
 
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			By("creating the GitOpsDeploymentManagedEnvironment")
 

--- a/tests-e2e/core/promotionrun_controller_test.go
+++ b/tests-e2e/core/promotionrun_controller_test.go
@@ -207,8 +207,7 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 			By("Verify that error is updated in Status.conditions field.")
 			Eventually(promotionRun, "3m", "1s").Should(promotionRunFixture.HaveStatusConditions(expectedPromotionRunStatusConditions))
 
-			// this assumes that service is running on non aware kcp client
-			config, err := fixture.GetKubeConfig()
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
 			Expect(err).To(BeNil())
 
 			k8sClient, err := fixture.GetKubeClient(config)

--- a/tests-e2e/core/promotionrun_controller_test.go
+++ b/tests-e2e/core/promotionrun_controller_test.go
@@ -207,7 +207,11 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 			By("Verify that error is updated in Status.conditions field.")
 			Eventually(promotionRun, "3m", "1s").Should(promotionRunFixture.HaveStatusConditions(expectedPromotionRunStatusConditions))
 
-			k8sClient, err := fixture.GetKubeClient()
+			// this assumes that service is running on non aware kcp client
+			config, err := fixture.GetKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
 			Expect(err).To(Succeed())
 
 			err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&promotionRun), &promotionRun)

--- a/tests-e2e/core/promotionrun_controller_test.go
+++ b/tests-e2e/core/promotionrun_controller_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 		var promotionRun appstudiosharedv1.PromotionRun
 
 		BeforeEach(func() {
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
 			Expect(err).To(BeNil())
 

--- a/tests-e2e/core/promotionrun_controller_test.go
+++ b/tests-e2e/core/promotionrun_controller_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 		var promotionRun appstudiosharedv1.PromotionRun
 
 		BeforeEach(func() {
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 

--- a/tests-e2e/core/promotionrun_controller_test.go
+++ b/tests-e2e/core/promotionrun_controller_test.go
@@ -27,25 +27,30 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 
 		BeforeEach(func() {
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
 
 			By("Create Staging Environment.")
 			environmentStage := buildEnvironmentResource("staging", "Staging Environment", "staging", appstudiosharedv1.EnvironmentType_POC)
-			err := k8s.Create(&environmentStage)
+			err = k8s.Create(&environmentStage, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Create Production Environment.")
 			environmentProd = buildEnvironmentResource("prod", "Production Environment", "prod", appstudiosharedv1.EnvironmentType_POC)
-			err = k8s.Create(&environmentProd)
+			err = k8s.Create(&environmentProd, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Create Snapshot.")
 			snapshot := buildSnapshotResource("my-snapshot", "new-demo-app", "Staging Snapshot", "Staging Snapshot", "component-a", "quay.io/jgwest-redhat/sample-workload:latest")
-			err = k8s.Create(&snapshot)
+			err = k8s.Create(&snapshot, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Create Staging Binding.")
 			bindingStage = buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
-			err = k8s.Create(&bindingStage)
+			err = k8s.Create(&bindingStage, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Update Status field.")
@@ -57,7 +62,7 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 			By("Create Production Binding.")
 			bindingProd = buildSnapshotEnvironmentBindingResource("appa-prod-binding", "new-demo-app", "prod",
 				"my-snapshot", 3, []string{"component-a"})
-			err = k8s.Create(&bindingProd)
+			err = k8s.Create(&bindingProd, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Update Status field.")
@@ -87,7 +92,7 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 					Namespace: bindingStage.Namespace,
 				},
 			}
-			err = k8s.Get(&gitOpsDeploymentStage)
+			err = k8s.Get(&gitOpsDeploymentStage, k8sClient)
 			Expect(err).To(Succeed())
 
 			gitOpsDeploymentProd := v1alpha1.GitOpsDeployment{
@@ -96,7 +101,7 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 					Namespace: bindingProd.Namespace,
 				},
 			}
-			err = k8s.Get(&gitOpsDeploymentProd)
+			err = k8s.Get(&gitOpsDeploymentProd, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Create PromotionRun CR.")
@@ -108,9 +113,14 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 			if fixture.IsRunningAgainstKCP() {
 				Skip("Skipping this test in KCP until we fix the race condition")
 			}
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
 
 			By("Create PromotionRun CR.")
-			err := k8s.Create(&promotionRun)
+			err = k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			now := v1.Now()
@@ -148,7 +158,14 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 			promotionRun.Spec.AutomatedPromotion = appstudiosharedv1.AutomatedPromotionConfiguration{
 				InitialEnvironment: "staging",
 			}
-			err := k8s.Create(&promotionRun)
+
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
+			err = k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			expectedPromotionRunStatusConditions := appstudiosharedv1.PromotionRunStatus{
@@ -169,7 +186,14 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 
 			By("Create PromotionRun CR.")
 			promotionRun.Spec.ManualPromotion.TargetEnvironment = ""
-			err := k8s.Create(&promotionRun)
+
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
+			err = k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			expectedPromotionRunStatusConditions := appstudiosharedv1.PromotionRunStatus{
@@ -190,7 +214,13 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 
 			By("Create PromotionRun CR with invalid value.")
 			promotionRun.Spec.ManualPromotion.TargetEnvironment = ""
-			err := k8s.Create(&promotionRun)
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
+			err = k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			expectedPromotionRunStatusConditions := appstudiosharedv1.PromotionRunStatus{
@@ -207,18 +237,12 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 			By("Verify that error is updated in Status.conditions field.")
 			Eventually(promotionRun, "3m", "1s").Should(promotionRunFixture.HaveStatusConditions(expectedPromotionRunStatusConditions))
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(Succeed())
-
 			err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&promotionRun), &promotionRun)
 			Expect(err).To(Succeed())
 
 			By("Update PromotionRun CR with invalid value.")
 			promotionRun.Spec.ManualPromotion.TargetEnvironment = "prod"
-			err = k8s.Update(&promotionRun)
+			err = k8s.Update(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			expectedPromotionRunStatus := appstudiosharedv1.PromotionRunStatus{

--- a/tests-e2e/core/promotionrun_controller_test.go
+++ b/tests-e2e/core/promotionrun_controller_test.go
@@ -28,11 +28,12 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 		BeforeEach(func() {
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			By("Create Staging Environment.")
 			environmentStage := buildEnvironmentResource("staging", "Staging Environment", "staging", appstudiosharedv1.EnvironmentType_POC)
-			err := k8s.Create(&environmentStage, k8sClient)
+			err = k8s.Create(&environmentStage, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Create Production Environment.")
@@ -111,10 +112,11 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 				Skip("Skipping this test in KCP until we fix the race condition")
 			}
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			By("Create PromotionRun CR.")
-			err := k8s.Create(&promotionRun, k8sClient)
+			err = k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			now := v1.Now()
@@ -153,9 +155,10 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 				InitialEnvironment: "staging",
 			}
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
-			err := k8s.Create(&promotionRun, k8sClient)
+			err = k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			expectedPromotionRunStatusConditions := appstudiosharedv1.PromotionRunStatus{
@@ -177,9 +180,10 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 			By("Create PromotionRun CR.")
 			promotionRun.Spec.ManualPromotion.TargetEnvironment = ""
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
-			err := k8s.Create(&promotionRun, k8sClient)
+			err = k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			expectedPromotionRunStatusConditions := appstudiosharedv1.PromotionRunStatus{
@@ -201,9 +205,10 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 			By("Create PromotionRun CR with invalid value.")
 			promotionRun.Spec.ManualPromotion.TargetEnvironment = ""
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
-			err := k8s.Create(&promotionRun, k8sClient)
+			err = k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			expectedPromotionRunStatusConditions := appstudiosharedv1.PromotionRunStatus{

--- a/tests-e2e/core/promotionrun_controller_test.go
+++ b/tests-e2e/core/promotionrun_controller_test.go
@@ -27,15 +27,12 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 
 		BeforeEach(func() {
 			Expect(EnsureCleanSlate()).To(Succeed())
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
 
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			By("Create Staging Environment.")
 			environmentStage := buildEnvironmentResource("staging", "Staging Environment", "staging", appstudiosharedv1.EnvironmentType_POC)
-			err = k8s.Create(&environmentStage, k8sClient)
+			err := k8s.Create(&environmentStage, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Create Production Environment.")
@@ -113,14 +110,11 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 			if fixture.IsRunningAgainstKCP() {
 				Skip("Skipping this test in KCP until we fix the race condition")
 			}
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
 
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			By("Create PromotionRun CR.")
-			err = k8s.Create(&promotionRun, k8sClient)
+			err := k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			now := v1.Now()
@@ -159,13 +153,9 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 				InitialEnvironment: "staging",
 			}
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
-
-			err = k8s.Create(&promotionRun, k8sClient)
+			err := k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			expectedPromotionRunStatusConditions := appstudiosharedv1.PromotionRunStatus{
@@ -187,13 +177,9 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 			By("Create PromotionRun CR.")
 			promotionRun.Spec.ManualPromotion.TargetEnvironment = ""
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
-
-			err = k8s.Create(&promotionRun, k8sClient)
+			err := k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			expectedPromotionRunStatusConditions := appstudiosharedv1.PromotionRunStatus{
@@ -214,13 +200,10 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 
 			By("Create PromotionRun CR with invalid value.")
 			promotionRun.Spec.ManualPromotion.TargetEnvironment = ""
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
 
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
-			err = k8s.Create(&promotionRun, k8sClient)
+			err := k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			expectedPromotionRunStatusConditions := appstudiosharedv1.PromotionRunStatus{

--- a/tests-e2e/core/simple_test.go
+++ b/tests-e2e/core/simple_test.go
@@ -26,7 +26,13 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				"https://github.com/redhat-appstudio/gitops-repository-template", "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			err := k8s.Create(&gitOpsDeploymentResource)
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
+			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("ensuring GitOpsDeployment should have expected health and status")
@@ -44,18 +50,18 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 			componentBDepl := &apps.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "component-b", Namespace: fixture.GitOpsServiceE2ENamespace},
 			}
-			Eventually(componentADepl, "60s", "1s").Should(k8s.ExistByName())
-			Eventually(componentBDepl, "60s", "1s").Should(k8s.ExistByName())
+			Eventually(componentADepl, "60s", "1s").Should(k8s.ExistByName(k8sClient))
+			Eventually(componentBDepl, "60s", "1s").Should(k8s.ExistByName(k8sClient))
 
 			By("deleting the GitOpsDeployment")
 
-			err = k8s.Delete(&gitOpsDeploymentResource)
+			err = k8s.Delete(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("ensuring the resources of the GitOps repo are successfully deleted")
 
-			Eventually(componentADepl, "60s", "1s").ShouldNot(k8s.ExistByName())
-			Eventually(componentBDepl, "60s", "1s").ShouldNot(k8s.ExistByName())
+			Eventually(componentADepl, "60s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
+			Eventually(componentBDepl, "60s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
 
 		})
 	})

--- a/tests-e2e/core/simple_test.go
+++ b/tests-e2e/core/simple_test.go
@@ -26,13 +26,9 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				"https://github.com/redhat-appstudio/gitops-repository-template", "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
-
-			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
+			err := k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("ensuring GitOpsDeployment should have expected health and status")

--- a/tests-e2e/core/simple_test.go
+++ b/tests-e2e/core/simple_test.go
@@ -18,7 +18,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("should be healthy and have synced status, and resources should be deployed", func() {
 
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 
 			By("creating the GitOpsDeployment")
 

--- a/tests-e2e/core/simple_test.go
+++ b/tests-e2e/core/simple_test.go
@@ -26,9 +26,10 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				"https://github.com/redhat-appstudio/gitops-repository-template", "environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
-			err := k8s.Create(&gitOpsDeploymentResource, k8sClient)
+			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("ensuring GitOpsDeployment should have expected health and status")

--- a/tests-e2e/core/simple_test.go
+++ b/tests-e2e/core/simple_test.go
@@ -18,7 +18,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 		It("should be healthy and have synced status, and resources should be deployed", func() {
 
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			By("creating the GitOpsDeployment")
 

--- a/tests-e2e/core/snapshotenvironmentbinding_test.go
+++ b/tests-e2e/core/snapshotenvironmentbinding_test.go
@@ -28,7 +28,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 		var environment appstudiosharedv1.Environment
 		BeforeEach(func() {
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+			Expect(EnsureCleanSlate()).To(Succeed())
 
 			By("creating the 'staging' Environment")
 			environment = appstudiosharedv1.Environment{

--- a/tests-e2e/core/snapshotenvironmentbinding_test.go
+++ b/tests-e2e/core/snapshotenvironmentbinding_test.go
@@ -48,9 +48,10 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 				},
 			}
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
-			err := k8s.Create(&environment, k8sClient)
+			err = k8s.Create(&environment, k8sClient)
 			Expect(err).To(Succeed())
 
 		})
@@ -61,11 +62,12 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			By("Create Binding CR in Cluster and it requires to update the Status field of Binding, because it is not updated while creating object.")
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a", "component-b"})
 
-			err := k8s.Create(&binding, k8sClient)
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update Status field
@@ -129,10 +131,11 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			By("Create Binding CR in Cluster and it requires to update the Status field of Binding, because it is not updated while creating object.")
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
-			err := k8s.Create(&binding, k8sClient)
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update Status field
@@ -197,10 +200,11 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			By("Create Binding CR in Cluster and it requires to update the Status field of Binding, because it is not updated while creating object.")
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
-			err := k8s.Create(&binding, k8sClient)
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update the Status field
@@ -258,10 +262,11 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			By("Create Binding CR in Cluster and it requires to update the Status field of Binding, because it is not updated while creating object.")
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
-			err := k8s.Create(&binding, k8sClient)
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update the Status field
@@ -333,9 +338,10 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
 			binding.Spec.Application = strings.Repeat("abcde", 45)
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
-			err := k8s.Create(&binding, k8sClient)
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update the status field
@@ -374,7 +380,8 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 				Skip("Skipping this test because of race condition when running on KCP based env")
 			}
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			By("creating second managed environment Secret")
 			secret := corev1.Secret{
@@ -387,7 +394,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 					"kubeconfig": ([]byte)("{}"),
 				},
 			}
-			err := k8s.Create(&secret, k8sClient)
+			err = k8s.Create(&secret, k8sClient)
 			Expect(err).To(BeNil())
 
 			err = k8s.Get(&environment, k8sClient)
@@ -442,11 +449,12 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 		It("Should append ASEB labels with key `appstudio.openshift.io` to GitopsDeployment label", func() {
 			By("Create SnapshotEnvironmentBindingResource")
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
 			binding.ObjectMeta.Labels = map[string]string{"appstudio.openshift.io": "testing"}
-			err := k8s.Create(&binding, k8sClient)
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Update Status field of SnapshotEnvironmentBindingResource")
@@ -482,10 +490,11 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 		It("Should not append ASEB label without appstudio.openshift.io label into the GitopsDeployment Label", func() {
 			By("Create SnapshotEnvironmentBindingResource")
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
-			err := k8s.Create(&binding, k8sClient)
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Update Status field of SnapshotEnvironmentBindingResource")
@@ -521,10 +530,11 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 			By("Create SnapshotEnvironmentBindingResource")
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
 
-			k8sClient := GetE2ETestUserWorkspaceKubeClient()
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
 
 			binding.ObjectMeta.Labels = map[string]string{"appstudio.openshift.io": "testing"}
-			err := k8s.Create(&binding, k8sClient)
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update the status field

--- a/tests-e2e/core/snapshotenvironmentbinding_test.go
+++ b/tests-e2e/core/snapshotenvironmentbinding_test.go
@@ -47,7 +47,13 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 					},
 				},
 			}
-			err := k8s.Create(&environment)
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
+			err = k8s.Create(&environment, k8sClient)
 			Expect(err).To(Succeed())
 
 		})
@@ -58,9 +64,15 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			By("Create Binding CR in Cluster and it requires to update the Status field of Binding, because it is not updated while creating object.")
 
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a", "component-b"})
 
-			err := k8s.Create(&binding)
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update Status field
@@ -104,15 +116,15 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			//====================================================
 			By("Verify that GitOpsDeployment CR created by GitOps-Service is having ownerReference according to Binding.")
-			err = k8s.Get(&binding)
+			err = k8s.Get(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
-			err = k8s.Get(&gitOpsDeploymentFirst)
+			err = k8s.Get(&gitOpsDeploymentFirst, k8sClient)
 			Expect(err).To(Succeed())
 			Expect(gitOpsDeploymentFirst.OwnerReferences[0].Name).To(Equal(binding.Name))
 			Expect(gitOpsDeploymentFirst.OwnerReferences[0].UID).To(Equal(binding.UID))
 
-			err = k8s.Get(&gitOpsDeploymentSecond)
+			err = k8s.Get(&gitOpsDeploymentSecond, k8sClient)
 			Expect(err).To(Succeed())
 			Expect(gitOpsDeploymentSecond.OwnerReferences[0].Name).To(Equal(binding.Name))
 			Expect(gitOpsDeploymentSecond.OwnerReferences[0].UID).To(Equal(binding.UID))
@@ -124,12 +136,17 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			By("Create Binding CR in Cluster and it requires to update the Status field of Binding, because it is not updated while creating object.")
 
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
-			err := k8s.Create(&binding)
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update Status field
-
 			err = buildAndUpdateBindingStatus(binding.Spec.Components,
 				"https://github.com/redhat-appstudio/gitops-repository-template", "main", "fdhyqtw",
 				[]string{"components/componentA/overlays/staging"}, &binding)
@@ -161,10 +178,10 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 			//====================================================
 			By("Verify that GitOpsDeployment CR is updated by GitOps-Service as Binding is updated.")
 
-			err = k8s.Get(&binding)
+			err = k8s.Get(&binding, k8sClient)
 			Expect(err).To(Succeed())
 			binding.Status.Components[0].GitOpsRepository.Path = "components/componentA/overlays/dev"
-			err = k8s.Update(&binding)
+			err = k8s.Update(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			//====================================================
@@ -175,7 +192,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 			//====================================================
 			By("Verify that GitOpsDeployment CR updated by GitOps-Service is having Spec.Source as given in Binding.")
 
-			err = k8s.Get(&gitOpsDeployment)
+			err = k8s.Get(&gitOpsDeployment, k8sClient)
 			Expect(err).To(Succeed())
 
 			Eventually(gitOpsDeployment, "2m", "1s").Should(gitopsDeplFixture.HaveSpecSource(managedgitopsv1alpha1.ApplicationSource{
@@ -191,8 +208,14 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			By("Create Binding CR in Cluster and it requires to update the Status field of Binding, because it is not updated while creating object.")
 
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
-			err := k8s.Create(&binding)
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update the Status field
@@ -250,9 +273,14 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			By("Create Binding CR in Cluster and it requires to update the Status field of Binding, because it is not updated while creating object.")
 
-			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app",
-				"staging", "my-snapshot", 3, []string{"component-a"})
-			err := k8s.Create(&binding)
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
+			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update the Status field
@@ -287,10 +315,10 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 			//====================================================
 			By("Delete GitOpsDeployment CR created by GitOps-Service, but not the Binding.")
 
-			err = k8s.Delete(&gitOpsDeploymentBefore)
+			err = k8s.Delete(&gitOpsDeploymentBefore, k8sClient)
 			Expect(err).To(Succeed())
 
-			err = k8s.Get(&gitOpsDeploymentBefore)
+			err = k8s.Get(&gitOpsDeploymentBefore, k8sClient)
 			Expect(err).NotTo(Succeed())
 			Expect(apierr.IsNotFound(err)).To(BeTrue())
 
@@ -298,14 +326,14 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 			By("Verify that GitOpsDeployment CR is recreated by GitOps-Service.")
 
 			// Update any value in Binding just to trigger Reconciler.
-			err = k8s.Get(&binding)
+			err = k8s.Get(&binding, k8sClient)
 			Expect(err).To(Succeed())
 			binding.Spec.Components[0].Configuration.Replicas = 2
-			err = k8s.Update(&binding)
+			err = k8s.Update(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			gitOpsDeploymentAfter := buildGitOpsDeploymentObjectMeta(gitOpsDeploymentName, binding.Namespace)
-			err = k8s.Get(&gitOpsDeploymentAfter)
+			err = k8s.Get(&gitOpsDeploymentAfter, k8sClient)
 			Expect(err).To(Succeed())
 
 			Eventually(gitOpsDeploymentAfter, "2m", "1s").Should(gitopsDeplFixture.HaveSpecSource(managedgitopsv1alpha1.ApplicationSource{
@@ -324,7 +352,13 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
 			binding.Spec.Application = strings.Repeat("abcde", 45)
-			err := k8s.Create(&binding)
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update the status field
@@ -340,12 +374,12 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			// Check no GitOpsDeployment CR found with default name (longer name).
 			gitOpsDeployment := buildGitOpsDeploymentObjectMeta(gitOpsDeploymentName, binding.Namespace)
-			err = k8s.Get(&gitOpsDeployment)
+			err = k8s.Get(&gitOpsDeployment, k8sClient)
 			Expect(apierr.IsNotFound(err)).To(BeTrue())
 
 			// Check GitOpsDeployment is created with short name).
 			gitOpsDeployment.Name = binding.Name + "-" + binding.Spec.Components[0].Name
-			err = k8s.Get(&gitOpsDeployment)
+			err = k8s.Get(&gitOpsDeployment, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Check GitOpsDeployment is having repository data as given in Binding.
@@ -363,6 +397,12 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 				Skip("Skipping this test because of race condition when running on KCP based env")
 			}
 
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
 			By("creating second managed environment Secret")
 			secret := corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -374,10 +414,10 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 					"kubeconfig": ([]byte)("{}"),
 				},
 			}
-			err := k8s.Create(&secret)
+			err = k8s.Create(&secret, k8sClient)
 			Expect(err).To(BeNil())
 
-			err = k8s.Get(&environment)
+			err = k8s.Get(&environment, k8sClient)
 			Expect(err).To(BeNil())
 
 			environment.Spec.UnstableConfigurationFields = &appstudiosharedv1.UnstableEnvironmentConfiguration{
@@ -388,13 +428,13 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 				},
 			}
 
-			err = k8s.Update(&environment)
+			err = k8s.Update(&environment, k8sClient)
 			Expect(err).To(BeNil())
 
 			By("generating the Binding, and waiting for the corresponding GitOpsDeployment to exist")
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
-			err = k8s.Create(&binding)
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(BeNil())
 
 			// Update the status field
@@ -413,9 +453,9 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 				},
 			}
 
-			Eventually(&gitopsDeployment, "60s", "1s").Should(k8s.ExistByName())
+			Eventually(&gitopsDeployment, "60s", "1s").Should(k8s.ExistByName(k8sClient))
 
-			err = k8s.Get(&gitopsDeployment)
+			err = k8s.Get(&gitopsDeployment, k8sClient)
 			Expect(err).To(BeNil())
 
 			Expect(gitopsDeployment.Spec.Destination.Environment).To(Equal("managed-environment-"+environment.Name),
@@ -428,13 +468,19 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 		It("Should append ASEB labels with key `appstudio.openshift.io` to GitopsDeployment label", func() {
 			By("Create SnapshotEnvironmentBindingResource")
+
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
 			binding.ObjectMeta.Labels = map[string]string{"appstudio.openshift.io": "testing"}
-			err := k8s.Create(&binding)
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Update Status field of SnapshotEnvironmentBindingResource")
-
 			// Update the status field
 			err = buildAndUpdateBindingStatus(binding.Spec.Components,
 				"https://github.com/redhat-appstudio/gitops-repository-template", "main", "fdhyqtw",
@@ -458,7 +504,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 				},
 			}
 
-			err = k8s.Get(&gitopsDeployment)
+			err = k8s.Get(&gitopsDeployment, k8sClient)
 			Expect(err).To(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels).ToNot(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels["appstudio.openshift.io"]).To(Equal("testing"))
@@ -466,12 +512,18 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 		It("Should not append ASEB label without appstudio.openshift.io label into the GitopsDeployment Label", func() {
 			By("Create SnapshotEnvironmentBindingResource")
+
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
-			err := k8s.Create(&binding)
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Update Status field of SnapshotEnvironmentBindingResource")
-
 			// Update the status field
 			err = buildAndUpdateBindingStatus(binding.Spec.Components,
 				"https://github.com/redhat-appstudio/gitops-repository-template", "main", "fdhyqtw",
@@ -495,7 +547,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 				},
 			}
 
-			err = k8s.Get(&gitopsDeployment)
+			err = k8s.Get(&gitopsDeployment, k8sClient)
 			Expect(err).To(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels["appstudio.openshift.io"]).ToNot(Equal("testing"))
 		})
@@ -503,8 +555,15 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 		It("Should update gitopsDeployment label if ASEB label gets updated", func() {
 			By("Create SnapshotEnvironmentBindingResource")
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
+
+			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err := fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
 			binding.ObjectMeta.Labels = map[string]string{"appstudio.openshift.io": "testing"}
-			err := k8s.Create(&binding)
+			err = k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update the status field
@@ -530,21 +589,21 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 				},
 			}
 
-			err = k8s.Get(&gitopsDeployment)
+			err = k8s.Get(&gitopsDeployment, k8sClient)
 			Expect(err).To(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels).ToNot(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels["appstudio.openshift.io"]).To(Equal("testing"))
 
-			err = k8s.Get(&binding)
+			err = k8s.Get(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update binding label
 			binding.ObjectMeta.Labels["appstudio.openshift.io"] = "testing-update"
-			err = k8s.Update(&binding)
+			err = k8s.Update(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Verify whether `gitopsDeployment.ObjectMeta.Labels` is updated with ASEB labels")
-			err = k8s.Get(&gitopsDeployment)
+			err = k8s.Get(&gitopsDeployment, k8sClient)
 			Expect(err).To(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels).ToNot(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels["appstudio.openshift.io"]).ToNot(Equal("testing"))
@@ -552,11 +611,11 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			By("Remove ASEB label `appstudio.openshift.io` label and verify whether it is removed from gitopsDeployment label")
 			delete(binding.ObjectMeta.Labels, "appstudio.openshift.io")
-			err = k8s.Update(&binding)
+			err = k8s.Update(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Verify whether gitopsDeployment.ObjectMeta.Label `appstudio.openshift.io` is removed from gitopsDeployment")
-			err = k8s.Get(&gitopsDeployment)
+			err = k8s.Get(&gitopsDeployment, k8sClient)
 			Expect(err).To(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels["appstudio.openshift.io"]).ToNot(Equal("testing-update"))
 		})

--- a/tests-e2e/core/snapshotenvironmentbinding_test.go
+++ b/tests-e2e/core/snapshotenvironmentbinding_test.go
@@ -47,13 +47,10 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 					},
 				},
 			}
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
 
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
-			err = k8s.Create(&environment, k8sClient)
+			err := k8s.Create(&environment, k8sClient)
 			Expect(err).To(Succeed())
 
 		})
@@ -64,15 +61,11 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			By("Create Binding CR in Cluster and it requires to update the Status field of Binding, because it is not updated while creating object.")
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a", "component-b"})
 
-			err = k8s.Create(&binding, k8sClient)
+			err := k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update Status field
@@ -136,14 +129,10 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			By("Create Binding CR in Cluster and it requires to update the Status field of Binding, because it is not updated while creating object.")
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
-			err = k8s.Create(&binding, k8sClient)
+			err := k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update Status field
@@ -208,14 +197,10 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			By("Create Binding CR in Cluster and it requires to update the Status field of Binding, because it is not updated while creating object.")
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
-			err = k8s.Create(&binding, k8sClient)
+			err := k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update the Status field
@@ -273,14 +258,10 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			By("Create Binding CR in Cluster and it requires to update the Status field of Binding, because it is not updated while creating object.")
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
-			err = k8s.Create(&binding, k8sClient)
+			err := k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update the Status field
@@ -352,13 +333,9 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
 			binding.Spec.Application = strings.Repeat("abcde", 45)
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
-
-			err = k8s.Create(&binding, k8sClient)
+			err := k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update the status field
@@ -397,11 +374,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 				Skip("Skipping this test because of race condition when running on KCP based env")
 			}
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			By("creating second managed environment Secret")
 			secret := corev1.Secret{
@@ -414,7 +387,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 					"kubeconfig": ([]byte)("{}"),
 				},
 			}
-			err = k8s.Create(&secret, k8sClient)
+			err := k8s.Create(&secret, k8sClient)
 			Expect(err).To(BeNil())
 
 			err = k8s.Get(&environment, k8sClient)
@@ -469,15 +442,11 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 		It("Should append ASEB labels with key `appstudio.openshift.io` to GitopsDeployment label", func() {
 			By("Create SnapshotEnvironmentBindingResource")
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
 			binding.ObjectMeta.Labels = map[string]string{"appstudio.openshift.io": "testing"}
-			err = k8s.Create(&binding, k8sClient)
+			err := k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Update Status field of SnapshotEnvironmentBindingResource")
@@ -513,14 +482,10 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 		It("Should not append ASEB label without appstudio.openshift.io label into the GitopsDeployment Label", func() {
 			By("Create SnapshotEnvironmentBindingResource")
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
-			err = k8s.Create(&binding, k8sClient)
+			err := k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Update Status field of SnapshotEnvironmentBindingResource")
@@ -556,14 +521,10 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 			By("Create SnapshotEnvironmentBindingResource")
 			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
 
-			config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
-			Expect(err).To(BeNil())
-
-			k8sClient, err := fixture.GetKubeClient(config)
-			Expect(err).To(BeNil())
+			k8sClient := GetE2ETestUserWorkspaceKubeClient()
 
 			binding.ObjectMeta.Labels = map[string]string{"appstudio.openshift.io": "testing"}
-			err = k8s.Create(&binding, k8sClient)
+			err := k8s.Create(&binding, k8sClient)
 			Expect(err).To(Succeed())
 
 			// Update the status field

--- a/tests-e2e/core/snapshotenvironmentbinding_test.go
+++ b/tests-e2e/core/snapshotenvironmentbinding_test.go
@@ -28,7 +28,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 		var environment appstudiosharedv1.Environment
 		BeforeEach(func() {
-			Expect(EnsureCleanSlate()).To(Succeed())
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			By("creating the 'staging' Environment")
 			environment = appstudiosharedv1.Environment{

--- a/tests-e2e/fixture/application/fixture.go
+++ b/tests-e2e/fixture/application/fixture.go
@@ -21,7 +21,11 @@ func expectedCondition(f func(app appv1alpha1.Application) bool) matcher.GomegaM
 
 	return WithTransform(func(app appv1alpha1.Application) bool {
 
-		k8sClient, err := fixture.GetKubeClient()
+		// this assumes that service is running on non aware kcp client
+		config, err := fixture.GetKubeConfig()
+		Expect(err).To(BeNil())
+
+		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			fmt.Println(k8sFixture.K8sClientError, err)
 			return false
@@ -54,7 +58,11 @@ func HaveAutomatedSyncPolicy(syncPolicy appv1alpha1.SyncPolicyAutomated) matcher
 
 	return WithTransform(func(app appv1alpha1.Application) bool {
 
-		k8sClient, err := fixture.GetKubeClient()
+		// this assumes that service is running on non aware kcp client
+		config, err := fixture.GetKubeConfig()
+		Expect(err).To(BeNil())
+
+		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			fmt.Println(k8sFixture.K8sClientError, err)
 			return false
@@ -81,8 +89,11 @@ func HaveAutomatedSyncPolicy(syncPolicy appv1alpha1.SyncPolicyAutomated) matcher
 func HaveHealthStatusCode(status appv1alpha1.ApplicationStatus) matcher.GomegaMatcher {
 
 	return WithTransform(func(app appv1alpha1.Application) bool {
+		// this assumes that service is running on non aware kcp client
+		config, err := fixture.GetKubeConfig()
+		Expect(err).To(BeNil())
 
-		k8sClient, err := fixture.GetKubeClient()
+		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			fmt.Println(k8sFixture.K8sClientError, err)
 			return false
@@ -106,8 +117,11 @@ func HaveHealthStatusCode(status appv1alpha1.ApplicationStatus) matcher.GomegaMa
 func HaveSyncStatusCode(status appv1alpha1.ApplicationStatus) matcher.GomegaMatcher {
 
 	return WithTransform(func(app appv1alpha1.Application) bool {
+		// this assumes that service is running on non aware kcp client
+		config, err := fixture.GetKubeConfig()
+		Expect(err).To(BeNil())
 
-		k8sClient, err := fixture.GetKubeClient()
+		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			fmt.Println(k8sFixture.K8sClientError, err)
 			return false
@@ -130,8 +144,11 @@ func HaveSyncStatusCode(status appv1alpha1.ApplicationStatus) matcher.GomegaMatc
 func HaveApplicationSyncError(syncError appv1alpha1.ApplicationStatus) matcher.GomegaMatcher {
 
 	return WithTransform(func(app appv1alpha1.Application) bool {
+		// this assumes that service is running on non aware kcp client
+		config, err := fixture.GetKubeConfig()
+		Expect(err).To(BeNil())
 
-		k8sClient, err := fixture.GetKubeClient()
+		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			fmt.Println(k8sFixture.K8sClientError, err)
 			return false

--- a/tests-e2e/fixture/application/fixture.go
+++ b/tests-e2e/fixture/application/fixture.go
@@ -21,8 +21,7 @@ func expectedCondition(f func(app appv1alpha1.Application) bool) matcher.GomegaM
 
 	return WithTransform(func(app appv1alpha1.Application) bool {
 
-		// this assumes that service is running on non aware kcp client
-		config, err := fixture.GetKubeConfig()
+		config, err := fixture.GetServiceProviderWorkspaceKubeConfig()
 		Expect(err).To(BeNil())
 
 		k8sClient, err := fixture.GetKubeClient(config)
@@ -58,8 +57,7 @@ func HaveAutomatedSyncPolicy(syncPolicy appv1alpha1.SyncPolicyAutomated) matcher
 
 	return WithTransform(func(app appv1alpha1.Application) bool {
 
-		// this assumes that service is running on non aware kcp client
-		config, err := fixture.GetKubeConfig()
+		config, err := fixture.GetServiceProviderWorkspaceKubeConfig()
 		Expect(err).To(BeNil())
 
 		k8sClient, err := fixture.GetKubeClient(config)
@@ -89,8 +87,7 @@ func HaveAutomatedSyncPolicy(syncPolicy appv1alpha1.SyncPolicyAutomated) matcher
 func HaveHealthStatusCode(status appv1alpha1.ApplicationStatus) matcher.GomegaMatcher {
 
 	return WithTransform(func(app appv1alpha1.Application) bool {
-		// this assumes that service is running on non aware kcp client
-		config, err := fixture.GetKubeConfig()
+		config, err := fixture.GetServiceProviderWorkspaceKubeConfig()
 		Expect(err).To(BeNil())
 
 		k8sClient, err := fixture.GetKubeClient(config)
@@ -117,8 +114,7 @@ func HaveHealthStatusCode(status appv1alpha1.ApplicationStatus) matcher.GomegaMa
 func HaveSyncStatusCode(status appv1alpha1.ApplicationStatus) matcher.GomegaMatcher {
 
 	return WithTransform(func(app appv1alpha1.Application) bool {
-		// this assumes that service is running on non aware kcp client
-		config, err := fixture.GetKubeConfig()
+		config, err := fixture.GetServiceProviderWorkspaceKubeConfig()
 		Expect(err).To(BeNil())
 
 		k8sClient, err := fixture.GetKubeClient(config)
@@ -144,8 +140,7 @@ func HaveSyncStatusCode(status appv1alpha1.ApplicationStatus) matcher.GomegaMatc
 func HaveApplicationSyncError(syncError appv1alpha1.ApplicationStatus) matcher.GomegaMatcher {
 
 	return WithTransform(func(app appv1alpha1.Application) bool {
-		// this assumes that service is running on non aware kcp client
-		config, err := fixture.GetKubeConfig()
+		config, err := fixture.GetServiceProviderWorkspaceKubeConfig()
 		Expect(err).To(BeNil())
 
 		k8sClient, err := fixture.GetKubeClient(config)

--- a/tests-e2e/fixture/binding/fixture.go
+++ b/tests-e2e/fixture/binding/fixture.go
@@ -73,7 +73,11 @@ func HaveStatusGitOpsDeployments(gitOpsDeployments []appstudiosharedv1.BindingSt
 
 	return WithTransform(func(binding appstudiosharedv1.SnapshotEnvironmentBinding) bool {
 
-		k8sClient, err := fixture.GetKubeClient()
+		// this assumes that service is running on non aware kcp client
+		config, err := fixture.GetKubeConfig()
+		Expect(err).To(BeNil())
+
+		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			fmt.Println(k8sFixture.K8sClientError, err)
 			return false

--- a/tests-e2e/fixture/binding/fixture.go
+++ b/tests-e2e/fixture/binding/fixture.go
@@ -73,8 +73,7 @@ func HaveStatusGitOpsDeployments(gitOpsDeployments []appstudiosharedv1.BindingSt
 
 	return WithTransform(func(binding appstudiosharedv1.SnapshotEnvironmentBinding) bool {
 
-		// this assumes that service is running on non aware kcp client
-		config, err := fixture.GetKubeConfig()
+		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
 		Expect(err).To(BeNil())
 
 		k8sClient, err := fixture.GetKubeClient(config)

--- a/tests-e2e/fixture/fixture.go
+++ b/tests-e2e/fixture/fixture.go
@@ -896,3 +896,17 @@ func EnsureCleanSlate() error {
 		return err
 	}
 }
+
+func GetE2ETestUserWorkspaceKubeClient() (client.Client, error) {
+	config, err := GetE2ETestUserWorkspaceKubeConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	k8sClient, err := GetKubeClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return k8sClient, nil
+}

--- a/tests-e2e/fixture/fixture.go
+++ b/tests-e2e/fixture/fixture.go
@@ -885,3 +885,14 @@ func EnsureCleanSlateKCPVirtualWorkspace() error {
 
 	return nil
 }
+
+func EnsureCleanSlate() error {
+
+	if !sharedutil.IsKCPVirtualWorkspaceDisabled() {
+		err := EnsureCleanSlateNonKCPVirtualWorkspace()
+		return err
+	} else {
+		err := EnsureCleanSlateNonKCPVirtualWorkspace()
+		return err
+	}
+}

--- a/tests-e2e/fixture/gitopsdeployment/fixture.go
+++ b/tests-e2e/fixture/gitopsdeployment/fixture.go
@@ -24,8 +24,8 @@ import (
 func HaveHealthStatusCode(status managedgitopsv1alpha1.HealthStatusCode) matcher.GomegaMatcher {
 
 	return WithTransform(func(gitopsDepl managedgitopsv1alpha1.GitOpsDeployment) bool {
-		// this assumes that service is running on non aware kcp client
-		config, err := fixture.GetKubeConfig()
+
+		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
 		Expect(err).To(BeNil())
 
 		k8sClient, err := fixture.GetKubeClient(config)
@@ -55,8 +55,8 @@ func HaveHealthStatusCode(status managedgitopsv1alpha1.HealthStatusCode) matcher
 func HaveSyncStatusCode(status managedgitopsv1alpha1.SyncStatusCode) matcher.GomegaMatcher {
 
 	return WithTransform(func(gitopsDepl managedgitopsv1alpha1.GitOpsDeployment) bool {
-		// this assumes that service is running on non aware kcp client
-		config, err := fixture.GetKubeConfig()
+
+		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
 		Expect(err).To(BeNil())
 
 		k8sClient, err := fixture.GetKubeClient(config)
@@ -81,8 +81,8 @@ func HaveSyncStatusCode(status managedgitopsv1alpha1.SyncStatusCode) matcher.Gom
 // HaveResources checks if the .status.resources field of GitOpsDeployment have the required resources
 func HaveResources(resourceStatusList []managedgitopsv1alpha1.ResourceStatus) matcher.GomegaMatcher {
 	return WithTransform(func(gitopsDeployment managedgitopsv1alpha1.GitOpsDeployment) bool {
-		// this assumes that service is running on non aware kcp client
-		config, err := fixture.GetKubeConfig()
+
+		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
 		Expect(err).To(BeNil())
 
 		k8sClient, err := fixture.GetKubeClient(config)
@@ -128,8 +128,8 @@ func HaveResources(resourceStatusList []managedgitopsv1alpha1.ResourceStatus) ma
 func HaveSpecSource(source managedgitopsv1alpha1.ApplicationSource) matcher.GomegaMatcher {
 
 	return WithTransform(func(gitopsDepl managedgitopsv1alpha1.GitOpsDeployment) bool {
-		// this assumes that service is running on non aware kcp client
-		config, err := fixture.GetKubeConfig()
+
+		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
 		Expect(err).To(BeNil())
 
 		k8sClient, err := fixture.GetKubeClient(config)
@@ -218,8 +218,7 @@ func HaveConditions(conditions []managedgitopsv1alpha1.GitOpsDeploymentCondition
 func HaveReconciledState(reconciledState managedgitopsv1alpha1.ReconciledState) matcher.GomegaMatcher {
 
 	return WithTransform(func(gitopsDepl managedgitopsv1alpha1.GitOpsDeployment) bool {
-		// this assumes that service is running on non aware kcp client
-		config, err := fixture.GetKubeConfig()
+		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
 		Expect(err).To(BeNil())
 
 		k8sClient, err := fixture.GetKubeClient(config)

--- a/tests-e2e/fixture/gitopsdeployment/fixture.go
+++ b/tests-e2e/fixture/gitopsdeployment/fixture.go
@@ -24,8 +24,11 @@ import (
 func HaveHealthStatusCode(status managedgitopsv1alpha1.HealthStatusCode) matcher.GomegaMatcher {
 
 	return WithTransform(func(gitopsDepl managedgitopsv1alpha1.GitOpsDeployment) bool {
+		// this assumes that service is running on non aware kcp client
+		config, err := fixture.GetKubeConfig()
+		Expect(err).To(BeNil())
 
-		k8sClient, err := fixture.GetKubeClient()
+		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			fmt.Println(k8sFixture.K8sClientError, err)
 			return false
@@ -52,8 +55,11 @@ func HaveHealthStatusCode(status managedgitopsv1alpha1.HealthStatusCode) matcher
 func HaveSyncStatusCode(status managedgitopsv1alpha1.SyncStatusCode) matcher.GomegaMatcher {
 
 	return WithTransform(func(gitopsDepl managedgitopsv1alpha1.GitOpsDeployment) bool {
+		// this assumes that service is running on non aware kcp client
+		config, err := fixture.GetKubeConfig()
+		Expect(err).To(BeNil())
 
-		k8sClient, err := fixture.GetKubeClient()
+		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			fmt.Println(k8sFixture.K8sClientError, err)
 			return false
@@ -75,7 +81,11 @@ func HaveSyncStatusCode(status managedgitopsv1alpha1.SyncStatusCode) matcher.Gom
 // HaveResources checks if the .status.resources field of GitOpsDeployment have the required resources
 func HaveResources(resourceStatusList []managedgitopsv1alpha1.ResourceStatus) matcher.GomegaMatcher {
 	return WithTransform(func(gitopsDeployment managedgitopsv1alpha1.GitOpsDeployment) bool {
-		k8sClient, err := fixture.GetKubeClient()
+		// this assumes that service is running on non aware kcp client
+		config, err := fixture.GetKubeConfig()
+		Expect(err).To(BeNil())
+
+		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			fmt.Println(k8sFixture.K8sClientError, err)
 			return false
@@ -118,8 +128,11 @@ func HaveResources(resourceStatusList []managedgitopsv1alpha1.ResourceStatus) ma
 func HaveSpecSource(source managedgitopsv1alpha1.ApplicationSource) matcher.GomegaMatcher {
 
 	return WithTransform(func(gitopsDepl managedgitopsv1alpha1.GitOpsDeployment) bool {
+		// this assumes that service is running on non aware kcp client
+		config, err := fixture.GetKubeConfig()
+		Expect(err).To(BeNil())
 
-		k8sClient, err := fixture.GetKubeClient()
+		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			fmt.Println(k8sFixture.K8sClientError, err)
 			return false
@@ -158,8 +171,11 @@ func HaveConditions(conditions []managedgitopsv1alpha1.GitOpsDeploymentCondition
 	}
 
 	return WithTransform(func(gitopsDeployment managedgitopsv1alpha1.GitOpsDeployment) bool {
+		// this assumes that service is running on non aware kcp client
+		config, err := fixture.GetKubeConfig()
+		Expect(err).To(BeNil())
 
-		k8sClient, err := fixture.GetKubeClient()
+		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			fmt.Println(k8sFixture.K8sClientError, err)
 			return false
@@ -202,8 +218,11 @@ func HaveConditions(conditions []managedgitopsv1alpha1.GitOpsDeploymentCondition
 func HaveReconciledState(reconciledState managedgitopsv1alpha1.ReconciledState) matcher.GomegaMatcher {
 
 	return WithTransform(func(gitopsDepl managedgitopsv1alpha1.GitOpsDeployment) bool {
+		// this assumes that service is running on non aware kcp client
+		config, err := fixture.GetKubeConfig()
+		Expect(err).To(BeNil())
 
-		k8sClient, err := fixture.GetKubeClient()
+		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			fmt.Println(k8sFixture.K8sClientError, err)
 			return false

--- a/tests-e2e/fixture/gitopsdeployment/fixture.go
+++ b/tests-e2e/fixture/gitopsdeployment/fixture.go
@@ -171,8 +171,8 @@ func HaveConditions(conditions []managedgitopsv1alpha1.GitOpsDeploymentCondition
 	}
 
 	return WithTransform(func(gitopsDeployment managedgitopsv1alpha1.GitOpsDeployment) bool {
-		// this assumes that service is running on non aware kcp client
-		config, err := fixture.GetKubeConfig()
+
+		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
 		Expect(err).To(BeNil())
 
 		k8sClient, err := fixture.GetKubeClient(config)

--- a/tests-e2e/fixture/k8s/fixture.go
+++ b/tests-e2e/fixture/k8s/fixture.go
@@ -22,8 +22,11 @@ const (
 
 // Create creates the given K8s resource, returning an error on failure, or nil otherwise.
 func Create(obj client.Object) error {
+	// this assumes that service is running on non aware kcp client
+	config, err := fixture.GetKubeConfig()
+	Expect(err).To(BeNil())
 
-	k8sClient, err := fixture.GetKubeClient()
+	k8sClient, err := fixture.GetKubeClient(config)
 	if err != nil {
 		return err
 	}
@@ -38,8 +41,11 @@ func Create(obj client.Object) error {
 
 // Get the given K8s resource, returning an error on failure, or nil otherwise.
 func Get(obj client.Object) error {
+	// this assumes that service is running on non aware kcp client
+	config, err := fixture.GetKubeConfig()
+	Expect(err).To(BeNil())
 
-	k8sClient, err := fixture.GetKubeClient()
+	k8sClient, err := fixture.GetKubeClient(config)
 	if err != nil {
 		return err
 	}
@@ -54,8 +60,11 @@ func Get(obj client.Object) error {
 
 // List instances of a given K8s resource, returning an error on failure, or nil otherwise.
 func List(obj client.ObjectList, namespace string) error {
+	// this assumes that service is running on non aware kcp client
+	config, err := fixture.GetKubeConfig()
+	Expect(err).To(BeNil())
 
-	k8sClient, err := fixture.GetKubeClient()
+	k8sClient, err := fixture.GetKubeClient(config)
 	if err != nil {
 		return err
 	}
@@ -75,8 +84,11 @@ func List(obj client.ObjectList, namespace string) error {
 func ExistByName() matcher.GomegaMatcher {
 
 	return WithTransform(func(k8sObject client.Object) bool {
+		// this assumes that service is running on non aware kcp client
+		config, err := fixture.GetKubeConfig()
+		Expect(err).To(BeNil())
 
-		k8sClient, err := fixture.GetKubeClient()
+		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			return false
 		}
@@ -93,8 +105,11 @@ func ExistByName() matcher.GomegaMatcher {
 
 // Delete deletes a K8s object from the namespace; it returns an error on failure, or nil otherwise.
 func Delete(obj client.Object) error {
+	// this assumes that service is running on non aware kcp client
+	config, err := fixture.GetKubeConfig()
+	Expect(err).To(BeNil())
 
-	k8sClient, err := fixture.GetKubeClient()
+	k8sClient, err := fixture.GetKubeClient(config)
 	if err != nil {
 		return err
 	}
@@ -145,7 +160,11 @@ func UntilSuccess(f func(k8sClient client.Client) error) error {
 //
 // UpdateStatus updates the status of a K8s resource using the provided object.
 func UpdateStatus(obj client.Object) error {
-	k8sClient, err := fixture.GetKubeClient()
+	// this assumes that service is running on non aware kcp client
+	config, err := fixture.GetKubeConfig()
+	Expect(err).To(BeNil())
+
+	k8sClient, err := fixture.GetKubeClient(config)
 	if err != nil {
 		return err
 	}
@@ -159,7 +178,11 @@ func UpdateStatus(obj client.Object) error {
 }
 
 func Update(obj client.Object) error {
-	k8sClient, err := fixture.GetKubeClient()
+	// this assumes that service is running on non aware kcp client
+	config, err := fixture.GetKubeConfig()
+	Expect(err).To(BeNil())
+
+	k8sClient, err := fixture.GetKubeClient(config)
 	if err != nil {
 		return err
 	}

--- a/tests-e2e/fixture/k8s/fixture.go
+++ b/tests-e2e/fixture/k8s/fixture.go
@@ -42,7 +42,7 @@ func Get(obj client.Object, k8sClient client.Client) error {
 }
 
 // List instances of a given K8s resource, returning an error on failure, or nil otherwise.
-func List(obj client.ObjectList, k8sClient client.Client, namespace string) error {
+func List(obj client.ObjectList, namespace string, k8sClient client.Client) error {
 
 	if err := k8sClient.List(context.Background(), obj, &client.ListOptions{
 		Namespace: namespace,

--- a/tests-e2e/fixture/promotionrun/fixture.go
+++ b/tests-e2e/fixture/promotionrun/fixture.go
@@ -19,7 +19,7 @@ import (
 func HaveStatusComplete(expectedPromotionRunStatus appstudiosharedv1.PromotionRunStatus) matcher.GomegaMatcher {
 	return WithTransform(func(promotionRun appstudiosharedv1.PromotionRun) bool {
 
-		k8sClient, err := fixture.GetKubeClient()
+		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			fmt.Println(k8sFixture.K8sClientError, err)
 			return false
@@ -57,7 +57,7 @@ func HaveStatusComplete(expectedPromotionRunStatus appstudiosharedv1.PromotionRu
 func HaveStatusConditions(expectedPromotionRunStatusConditions appstudiosharedv1.PromotionRunStatus) matcher.GomegaMatcher {
 	return WithTransform(func(promotionRun appstudiosharedv1.PromotionRun) bool {
 
-		k8sClient, err := fixture.GetKubeClient()
+		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			fmt.Println(k8sFixture.K8sClientError, err)
 			return false

--- a/tests-e2e/fixture/promotionrun/fixture.go
+++ b/tests-e2e/fixture/promotionrun/fixture.go
@@ -19,6 +19,9 @@ import (
 func HaveStatusComplete(expectedPromotionRunStatus appstudiosharedv1.PromotionRunStatus) matcher.GomegaMatcher {
 	return WithTransform(func(promotionRun appstudiosharedv1.PromotionRun) bool {
 
+		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+		Expect(err).To(BeNil())
+
 		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {
 			fmt.Println(k8sFixture.K8sClientError, err)
@@ -56,6 +59,9 @@ func HaveStatusComplete(expectedPromotionRunStatus appstudiosharedv1.PromotionRu
 
 func HaveStatusConditions(expectedPromotionRunStatusConditions appstudiosharedv1.PromotionRunStatus) matcher.GomegaMatcher {
 	return WithTransform(func(promotionRun appstudiosharedv1.PromotionRun) bool {
+
+		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+		Expect(err).To(BeNil())
 
 		k8sClient, err := fixture.GetKubeClient(config)
 		if err != nil {


### PR DESCRIPTION
#### Description:
-  new `EnsureCleanSlateKCPVirtualWorkspace` function (based on the existing EnsureCleanSlate function), and updating the tests to call this function when running on KCP virtual workspace.

```
// EnsureCleanSlateKCPVirtualWorkspace should be called before every E2E tests:
// it ensures that in KCP Virtual workspace the state of the GitOpsServiceE2ENamespace namespace
//	(and other resources on the cluster) is reset to scratch before each test, including:
// - In user workspace, the function will:
// 		- Deleting any old namespaces that exists within the user-workspace
// 		- Deleting any cluster role/rolebindings existing within the user-workspace
// 		// EnsureCleanSlateKCPVirtualWorkspace should be called before every E2E tests:
// it ensures that in KCP Virtual workspace the state of the GitOpsServiceE2ENamespace namespace
//	(and other resources on the cluster) is reset to scratch before each test, including:
// - In user workspace, the function will:
// 		- Deleting any old namespaces that exists within the user-workspace
// 		- Deleting any cluster role/rolebindings existing within the user-workspace
// 		- Delete the e2e namespaces, and create a new e2e namespace for testing
//		- Clean up old kube system resources from the workspace
// - In the gitops-service-provider workspace, the function will:
//		- Delete all Argo CD Cluster Secrets from the Argo CD Namespace
//		- Clean up old argo cd applications targetting the e2e namespace
//
// Need two different client ===> client virtual workspace enabled for workspace
//
// This ensures that previous E2E tests runs do not interfere with the results of current test runs.
// This function can also be called after a test, in order to clean up any resources it creates in respective workspaces.- Delete the e2e namespaces, and create a new e2e namespace for testing
//		- Clean up old kube system resources from the workspace
// - In the gitops-service-provider workspace, the function will:
//		- Delete all Argo CD Cluster Secrets from the Argo CD Namespace
//		- Clean up old argo cd applications targetting the e2e namespace
//
// Need two different client ===> client virtual workspace enabled for workspace
//
// This ensures that previous E2E tests runs do not interfere with the results of current test runs.
// This function can also be called after a test, in order to clean up any resources it creates in respective workspaces.
```

~~NOTE: This is still in WIP!!!!!!!~~

#### Link to JIRA Story (if applicable): [GITOPSRVCE-213](https://issues.redhat.com/browse/GITOPSRVCE-213)
