### PR TITLE
Check if the APIs are synced in a workspace

### DIFF
--- a/kcp/virtual-workspace.sh
+++ b/kcp/virtual-workspace.sh
@@ -38,6 +38,8 @@ echo "Creating APIBindings in workspace $USER_WS"
 createAPIBinding gitopsrvc-backend-shared "" $SERVICE_WS
 createAPIBinding gitopsrvc-appstudio-shared "" $SERVICE_WS
 
+registerSyncTarget "user"
+
 # Checking if the bindings are in Ready state
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl wait --for=condition=Ready apibindings/gitopsrvc-appstudio-shared
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl wait --for=condition=Ready apibindings/gitopsrvc-backend-shared
@@ -45,7 +47,7 @@ KUBECONFIG="${CPS_KUBECONFIG}" kubectl wait --for=condition=Ready apibindings/gi
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws
 KUBECONFIG="${CPS_KUBECONFIG}" kubectl kcp ws use $SERVICE_WS
 
-registerSyncTarget
+registerSyncTarget "service"
 
 # Install Argo CD and GitOps Service components in service provider workspace
 installArgoCD


### PR DESCRIPTION
#### Description:
- Create SyncTarget for a user workspace.
- Currently, we check if a SyncTarget is ready by waiting until the deployment is in the `Ready` state. But the APIs may not be synced yet leading to an error when applying argocd resources. Add a step to check whether the required CRDs are synced by the Syncer.

