### PR TITLE
Upgrade & Fix CKCP to v0.9.0 (Solves: #GITOPSRVCE-252)

### DIFF
--- a/kcp/ckcp/config.yaml
+++ b/kcp/ckcp/config.yaml
@@ -2,17 +2,17 @@
 # This YAML file allows openshift_dev_setup.sh to fetch values of certain variables.
 # Usage - to be used for overwriting defaults
 
-# CLUSTER_TYPE can only be "openshift" for now.
-CLUSTER_TYPE: openshift
+# cluster_type can only be "openshift" for now.
+cluster_type: openshift
 
-# GIT_URL refers to a git repo to be considered as the source of truth for Argo CD applications.
-GIT_URL: https://github.com/openshift-pipelines/pipeline-service.git
+# git_url refers to a git repo to be considered as the source of truth for Argo CD applications.
+git_url: https://github.com/openshift-pipelines/pipeline-service.git
 
-# GIT_REF refers to the git repo's ref to be considered as the source of truth for Argo CD applications.
-GIT_REF: main
+# git_ref refers to the git repo's ref to be considered as the source of truth for Argo CD applications.
+git_ref: main
 
-# CR_TO_SYNC is a list of the CRs which need to be synced.
-CR_TO_SYNC:
+# crs_to_sync is a list of the CRs which need to be synced.
+crs_to_sync:
   - deployments.apps
   - services
   - ingresses.networking.k8s.io
@@ -21,5 +21,9 @@ CR_TO_SYNC:
   - routes.route.openshift.io
 
 # Applications to be deployed on the cluster
-APPS:
+apps:
   - pipeline_service # pipeline_service sets up Pipeline Service on the cluster.
+
+# versions
+version:
+  kcp: v0.9.0

--- a/kcp/ckcp/config.yaml
+++ b/kcp/ckcp/config.yaml
@@ -11,14 +11,17 @@ git_url: https://github.com/openshift-pipelines/pipeline-service.git
 # git_ref refers to the git repo's ref to be considered as the source of truth for Argo CD applications.
 git_ref: main
 
-# crs_to_sync is a list of the CRs which need to be synced.
-crs_to_sync:
-  - deployments.apps
-  - services
-  - ingresses.networking.k8s.io
-  - networkpolicies.networking.k8s.io
-  - statefulsets.apps
-  - routes.route.openshift.io
+kcp:
+  # crs_to_sync is a list of the CRs which need to be synced.
+  crs_to_sync:
+    - deployments.apps
+    - services
+    - ingresses.networking.k8s.io
+    - networkpolicies.networking.k8s.io
+    - statefulsets.apps
+    - routes.route.openshift.io
+  version: v0.9.1
+  workspace: root:default:managed-gitops-compute
 
 # Applications to be deployed on the cluster
 apps:

--- a/kcp/ckcp/config.yaml
+++ b/kcp/ckcp/config.yaml
@@ -22,8 +22,13 @@ crs_to_sync:
 
 # Applications to be deployed on the cluster
 apps:
-  - pipeline_service # pipeline_service sets up Pipeline Service on the cluster.
+ - pipeline_service # pipeline_service sets up Pipeline Service on the cluster.
 
 # versions
 version:
   kcp: v0.9.0
+
+# Tekton results database credentials
+tekton_results_db:
+  user:
+  password:

--- a/kcp/ckcp/openshift_dev_setup.sh
+++ b/kcp/ckcp/openshift_dev_setup.sh
@@ -8,18 +8,20 @@ SCRIPT_DIR="$(
   pwd
 )"
 
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
 # shellcheck source=ckcp/hack/util/update-git-reference.sh
-source "$SCRIPT_DIR/hack/util/update-git-reference.sh"
+source "$PROJECT_DIR/images/cluster-setup/bin/utils.sh"
 
 # shellcheck source=images/cluster-setup/bin/utils.sh
 source "$SCRIPT_DIR/../images/cluster-setup/bin/utils.sh"
 
-GITOPS_DIR="$(dirname "$SCRIPT_DIR")/gitops"
-CKCP_DIR="$(dirname "$SCRIPT_DIR")/ckcp"
-CONFIG="$CKCP_DIR/config.yaml"
+GITOPS_DIR="$PROJECT_DIR/gitops"
+CKCP_DIR="$PROJECT_DIR/ckcp"
+CONFIG="$PROJECT_DIR/config/config.yaml"
 
 KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config}
-# CR_TO_SYNC=(
+# CRS_TO_SYNC=(
 #             deployments.apps
 #             services
 #             ingresses.networking.k8s.io
@@ -62,6 +64,7 @@ parse_args() {
       ;;
     -d | --debug)
       set -x
+      DEBUG="--debug"
       ;;
     -h | --help)
       usage
@@ -99,7 +102,7 @@ init() {
            )
 
   # get the list of APPS to be installed
-  read -ra APPS <<< "$(yq eval '.APPS | join(" ")' "$CONFIG")"
+  read -ra APPS <<< "$(yq eval '.apps | join(" ")' "$CONFIG")"
   for app in  "${APPS[@]}"
   do
     APP_LIST+=("$app")
@@ -108,13 +111,13 @@ init() {
   # get cluster type
   cluster_type=$(yq '.CLUSTER_TYPE // "openshift"' "$CONFIG")
 
-  GIT_URL=$(yq '.GIT_URL // "https://github.com/openshift-pipelines/pipeline-service.git"' "$CONFIG")
-  GIT_REF=$(yq '.GIT_REF // "main"' "$CONFIG")
+  GIT_URL=$(yq '.git_url // "https://github.com/openshift-pipelines/pipeline-service.git"' "$CONFIG")
+  GIT_REF=$(yq '.git_ref // "main"' "$CONFIG")
 
   # get list of CRs to sync
-  read -ra CR_TO_SYNC <<< "$(yq eval '.CR_TO_SYNC | join(" ")' "$CONFIG")"
-  if (( "${#CR_TO_SYNC[@]}" <= 0 )); then
-    CR_TO_SYNC=(
+  read -ra CRS_TO_SYNC <<< "$(yq eval '.crs_to_sync | join(" ")' "$CONFIG")"
+  if (( "${#CRS_TO_SYNC[@]}" <= 0 )); then
+    CRS_TO_SYNC=(
             "deployments.apps"
             "services"
             "ingresses.networking.k8s.io"
@@ -145,13 +148,19 @@ init() {
   export KUBECONFIG
   kcp_org="root:default"
   kcp_workspace="managed-gitops-compute"
-  kcp_version="$(yq '.images[] | select(.name == "kcp") | .newTag' "$SCRIPT_DIR/openshift/overlays/dev/kustomization.yaml")"
+  kcp_version="$(yq '.version.kcp' "$CONFIG")"
 }
 
 # To ensure that dependencies are satisfied
 precheck() {
   if [ "$(kubectl plugin list | grep -c 'kubectl-kcp')" -eq 0 ]; then
     printf "kcp plugin could not be found\n"
+    exit 1
+  fi
+  kubectl_kcp_version=$(kubectl-kcp --version | cut -d '-' -f 2)
+  if [ "${kubectl_kcp_version}" != "${kcp_version}" ]; then
+    printf "[ERROR] kcp plugin version mismatch: expected '%s', got '%s'\n" "$kcp_version" "$kubectl_kcp_version" >&2
+    printf "Please install kcp plugin with version '%s'\n" "$kcp_version"
     exit 1
   fi
 }
@@ -173,14 +182,14 @@ install_openshift_gitops() {
   #############################################################################
   # Install the gitops operator
   #############################################################################
-  echo -n "  - OpenShift-GitOps: "
+  echo -n "- OpenShift-GitOps: "
   kubectl apply -k "$CKCP_DIR/openshift-operators/$APP" >/dev/null
   echo "OK"
 
   #############################################################################
   # Wait for the URL to be available
   #############################################################################
-  echo -n "  - Argo CD dashboard: "
+  echo -n "- Argo CD dashboard: "
   test_cmd="kubectl get route/openshift-gitops-server --ignore-not-found -n $ns -o jsonpath={.spec.host}"
   ARGOCD_HOSTNAME="$(${test_cmd})"
   until curl --fail --insecure --output /dev/null --silent "https://$ARGOCD_HOSTNAME"; do
@@ -189,13 +198,13 @@ install_openshift_gitops() {
     ARGOCD_HOSTNAME="$(${test_cmd})"
   done
   echo "OK"
-  echo "  - Argo CD URL: https://$ARGOCD_HOSTNAME"
+  echo "- Argo CD URL: https://$ARGOCD_HOSTNAME"
 
   #############################################################################
   # Post install
   #############################################################################
   # Log into Argo CD
-  echo -n "  - Argo CD Login: "
+  echo -n "- Argo CD Login: "
   local argocd_password
   argocd_password="$(kubectl get secret openshift-gitops-cluster -n $ns -o jsonpath="{.data.admin\.password}" | base64 --decode)"
   argocd login "$ARGOCD_HOSTNAME" --grpc-web --insecure --username admin --password "$argocd_password" >/dev/null
@@ -205,16 +214,19 @@ install_openshift_gitops() {
   local cluster_name="plnsvc"
   echo -n "  - Register host cluster to Argo CD as '$cluster_name': "
   if ! KUBECONFIG="$KUBECONFIG_MERGED" argocd cluster get "$cluster_name" >/dev/null 2>&1; then
+    echo "- Register host cluster to ArgoCD as '$cluster_name': "
     argocd cluster add "$(yq e ".current-context" <"$KUBECONFIG")" --name="$cluster_name" --upsert --yes >/dev/null
-  fi
-  echo "OK"
+    echo "  OK"
+	else
+    echo "- Register host cluster to ArgoCD as '$cluster_name': OK"
+	fi
 }
 
 install_cert_manager(){
   APP="cert-manager-operator"
-  echo "  - OpenShift-Cert-Manager: "
+  echo "- OpenShift-Cert-Manager: "
   kubectl apply -f "$GITOPS_DIR/argocd/argo-apps/$APP.yaml" >/dev/null
-  check_cert_manager
+  check_cert_manager | indent 2
 }
 
 check_cert_manager() {
@@ -270,7 +282,7 @@ patches:
         description: This value refers to the hostAddress defined in the Route.
         value: $ckcp_route " >>"$ckcp_temp_dir/kustomization.yaml"
 
-  echo -n "  - kcp $kcp_version: "
+  echo -n "- kcp $kcp_version: "
   # Deploy ckcp until all resources are successfully appied to OCP cluster 
   local i=0
   while ! error_msg=$(kubectl apply -k "$ckcp_temp_dir" 2>&1 1>/dev/null); do
@@ -301,7 +313,7 @@ patches:
   echo "OK"
 
   # Check if external ip is assigned and replace kcp's external IP in the kubeconfig file
-  echo -n "  - Route: "
+  echo -n "- Route: "
   if grep -q "ckcp-ckcp.apps.domain.org" "$KUBECONFIG_KCP"; then
     yq e -i "(.clusters[].cluster.server) |= sub(\"ckcp-ckcp.apps.domain.org:6443\", \"$ckcp_route:443\")" "$KUBECONFIG_KCP"
   fi
@@ -310,70 +322,86 @@ patches:
   # Workaround to prevent the creation of a new workspace until KCP is ready.
   # This fixes `error: creating a workspace under a Universal type workspace is not supported`.
   ws_name=$(echo "$kcp_org" | cut -d: -f2)
-  while ! KUBECONFIG="$KUBECONFIG_KCP" kubectl kcp workspace create "$ws_name" --type root:organization --ignore-existing >/dev/null; do
+  local sec=0
+  while ! KUBECONFIG="$KUBECONFIG_KCP" kubectl kcp workspace create "$ws_name" --type root:organization --ignore-existing &>/dev/null; do
+    if  [ "$sec" -gt 100 ]; then
+      exit 1
+    fi
     sleep 5
+    sec=$((sec + 5))
   done
   KUBECONFIG="$KUBECONFIG_KCP" kubectl kcp workspace use "$ws_name"
 
- echo "  - Setup kcp access:"
-  "$SCRIPT_DIR/../images/access-setup/content/bin/setup_kcp.sh" \
+ echo "- Setup kcp access:"
+  "$PROJECT_DIR/images/access-setup/content/bin/setup_kcp.sh" \
+    ${DEBUG:+"$DEBUG"} \
     --kubeconfig "$KUBECONFIG_KCP" \
     --kcp-org "$kcp_org" \
     --kcp-workspace "$kcp_workspace" \
     --work-dir "$WORK_DIR" \
-    --kustomization "$GIT_URL/gitops/kcp/pac-manager?ref=$GIT_REF"
+    --kustomization "$GIT_URL/gitops/kcp/pac-manager?ref=$GIT_REF" | 
+    indent 2
   KUBECONFIG_KCP="$WORK_DIR/credentials/kubeconfig/kcp/ckcp-ckcp.${ws_name}.${kcp_workspace}.kubeconfig"
   cp $WORK_DIR/credentials/kubeconfig/kcp/ckcp-ckcp.${ws_name}.${kcp_workspace}.kubeconfig ${TMP_DIR}
 }
 
 install_pipeline_service() {
-  echo "  - Setup compute access:"
-  "$SCRIPT_DIR/../images/access-setup/content/bin/setup_compute.sh" \
+  echo "- Setup compute access:"
+  "$PROJECT_DIR/images/access-setup/content/bin/setup_compute.sh" \
+    ${DEBUG:+"$DEBUG"} \
     --kubeconfig "$KUBECONFIG" \
     --work-dir "$WORK_DIR" \
     --kustomization "$GIT_URL/gitops/compute/pac-manager?ref=$GIT_REF" \
     --git-remote-url "$GIT_URL" \
-    --git-remote-ref "$GIT_REF"
+    --git-remote-ref "$GIT_REF" 2>&1 | 
+    indent 2
 
-  echo "  - Deploy compute:"
-  "$SCRIPT_DIR/../images/cluster-setup/bin/install.sh" --workspace-dir "$WORK_DIR"
+  echo "- Deploy compute:"
+  KUBECONFIG="" "$PROJECT_DIR/images/cluster-setup/bin/install.sh" \
+    ${DEBUG:+"$DEBUG"} \
+    --workspace-dir "$WORK_DIR" | indent 2
 
-  echo "  - Install Pipelines as Code:"
+  echo "- Install Pipelines as Code:"
   # Passing dummy values to the parameters of the pac/setup.sh script
   # because we only want to install the runner side of resources.
   GITOPS_REPO="https://example.git.com/my/repo" GIT_TOKEN="placeholder_token" \
     WEBHOOK_SECRET="placeholder_webhook" \
-    "$GITOPS_DIR/pac/setup.sh"
+    "$GITOPS_DIR/pac/setup.sh" | indent 4
 
 }
 
 register_compute() {
-  echo "  - Register compute to KCP"
-  "$(dirname "$SCRIPT_DIR")/images/kcp-registrar/register.sh" \
+  resources="$(printf '%s,' "${CRS_TO_SYNC[@]}")"
+  resources=${resources%,}
+  echo "- Register compute to KCP"
+  "$PROJECT_DIR/images/kcp-registrar/bin/register.sh" \
+    ${DEBUG:+"$DEBUG"} \
     --kcp-org "root:default" \
     --kcp-workspace "$kcp_workspace" \
     --kcp-sync-tag "$kcp_version" \
-    --workspace-dir "$WORK_DIR"
+    --workspace-dir "$WORK_DIR" \
+    --crs-to-sync "$(IFS=,; echo "${CRS_TO_SYNC[*]}")" |
+    indent 4
 
   check_cr_sync
 }
 
 check_cr_sync() {
   # Wait until CRDs are synced to KCP
-  echo -n "  - Sync CRDs to KCP: "
+  echo -n "- Sync CRDs to KCP: "
   local cr_regexp
   cr_regexp="$(
     IFS=\|
-    echo "${CR_TO_SYNC[*]}"
+    echo "${CRS_TO_SYNC[*]}"
   )"
   local wait_period=0
-  while [[ "$(KUBECONFIG="$KUBECONFIG_KCP" kubectl api-resources -o name 2>&1 | grep -Ewc "$cr_regexp")" -ne ${#CR_TO_SYNC[@]} ]]; do
+  while [[ "$(KUBECONFIG="$KUBECONFIG_KCP" kubectl api-resources -o name 2>&1 | grep -Ewc "$cr_regexp")" -ne ${#CRS_TO_SYNC[@]} ]]; do
     wait_period=$((wait_period + 10))
     #when timeout, print out the CR resoures that is not synced to KCP
-    if [ $wait_period -gt 300 ]; then
+    if [ "$wait_period" -gt 300 ]; then
       echo "Failed to sync following resources to KCP: "
       cr_synced=$(KUBECONFIG="$KUBECONFIG_KCP" kubectl api-resources -o name)
-      for cr in "${CR_TO_SYNC[@]}"; do
+      for cr in "${CRS_TO_SYNC[@]}"; do
         if [ "$(echo "$cr_synced" | grep -wc "$cr")" -eq 0 ]; then
           echo "    * $cr"
         fi
@@ -394,10 +422,18 @@ main() {
   check_cluster_role
   for APP in "${APP_LIST[@]}"; do
     echo "[$APP]"
-    install_"$(echo "$APP" | tr '-' '_')"
+    install_"$(echo "$APP" | tr '-' '_')" | indent 2
     echo
   done
+  echo [sync]
   register_compute
+  printf "\nUse the below KUBECONFIG to get access to the kcp workspace and compute cluster respectively.\n"
+  printf "KUBECONFIG_KCP: %s\n" "$KUBECONFIG_KCP"
+  printf "KUBECONFIG: %s\n" "$KUBECONFIG"
+
+  printf "\nYou can also set the following aliases to access the kcp workspace and compute cluster respectively.\n"
+  printf "alias kkcp='KUBECONFIG=%s kubectl'\n" "$KUBECONFIG_KCP"
+  printf "alias kcompute='KUBECONFIG=%s kubectl'\n" "$KUBECONFIG"
 }
 
 if [ "${BASH_SOURCE[0]}" == "$0" ]; then

--- a/kcp/ckcp/openshift_dev_setup.sh
+++ b/kcp/ckcp/openshift_dev_setup.sh
@@ -133,7 +133,7 @@ init() {
   GIT_REF=$(yq '.git_ref // "main"' "$CONFIG")
 
   # get list of CRs to sync
-  read -ra CRS_TO_SYNC <<< "$(yq eval '.crs_to_sync | join(" ")' "$CONFIG")"
+  read -ra CRS_TO_SYNC <<< "$(yq eval '.kcp.crs_to_sync | join(" ")' "$CONFIG")"
   if (( "${#CRS_TO_SYNC[@]}" <= 0 )); then
     CRS_TO_SYNC=(
             "deployments.apps"
@@ -144,6 +144,13 @@ init() {
             "routes.route.openshift.io"
             )
   fi
+
+  # Get kcp workspace
+  kcp_org=$(yq '.kcp.workspace' "$CONFIG" | sed 's/:[^:]*$//')
+  kcp_workspace=$(yq '.kcp.workspace' "$CONFIG" | sed 's/^.*://')
+
+  # Get kcp version
+  kcp_version="$(yq '.kcp.version' "$CONFIG")"
 
   # Create SRE repository folder
   WORK_DIR="${WORK_DIR:-}"
@@ -409,7 +416,7 @@ register_compute() {
   echo "- Register compute to KCP"
   "$PROJECT_DIR/operator/images/kcp-registrar/bin/register.sh" \
     ${DEBUG:+"$DEBUG"} \
-    --kcp-org "root:default" \
+    --kcp-org "$kcp_org" \
     --kcp-workspace "$kcp_workspace" \
     --kcp-sync-tag "$kcp_version" \
     --workspace-dir "$WORK_DIR" \

--- a/kcp/ckcp/setup-ckcp-on-openshift.sh
+++ b/kcp/ckcp/setup-ckcp-on-openshift.sh
@@ -61,7 +61,7 @@ clone-and-setup-ckcp() {
     pushd "${TMP_DIR}"
     git clone https://github.com/openshift-pipelines/pipeline-service.git
     pushd pipeline-service
-    git checkout 52403fe66fe531b836236774d14b67b69cae7978
+    git checkout feb7a522e7e47af3670bde9a58ddef958e9bff1e
     cp "${SCRIPT_DIR}"/openshift_dev_setup.sh ./developer/ckcp/openshift_dev_setup.sh
     cp "${SCRIPT_DIR}"/config.yaml ./developer/ckcp/config.yaml
 
@@ -231,13 +231,13 @@ OPENSHIFT_CI="${OPENSHIFT_CI:-false}"
 if [[ $OPENSHIFT_CI != "" ]]
 then
     echo "running tests in openshift ci mode"
-    test-gitops-service-e2e-in-kcp-in-ci ${TMP_DIR} ${SCRIPT_DIR}
+    test-gitops-service-e2e-in-kcp-in-ci "${TMP_DIR}" "${SCRIPT_DIR}"
 else
     echo "running tests in non openshift-ci mode"
-    test-gitops-service-e2e-in-kcp ${TMP_DIR} ${SCRIPT_DIR}
+    test-gitops-service-e2e-in-kcp "${TMP_DIR}" "${SCRIPT_DIR}"
 fi
 
 # clean the tmp directory created for the local setup
 echo "e2e tests on kcp ran successfully, cleanup initiated ..."
-rm -rf ${TMP_DIR}
+rm -rf "${TMP_DIR}"
 cleanup

--- a/kcp/ckcp/setup-ckcp-on-openshift.sh
+++ b/kcp/ckcp/setup-ckcp-on-openshift.sh
@@ -61,16 +61,15 @@ clone-and-setup-ckcp() {
     pushd "${TMP_DIR}"
     git clone https://github.com/openshift-pipelines/pipeline-service.git
     pushd pipeline-service
-    git checkout freeze
-    git checkout e6c308664f817354ea158f1dffd5f62d3d101ec1
-    cp "${SCRIPT_DIR}"/openshift_dev_setup.sh ./ckcp/openshift_dev_setup.sh
-    cp "${SCRIPT_DIR}"/config.yaml ./config/config.yaml
+    git checkout 52403fe66fe531b836236774d14b67b69cae7978
+    cp "${SCRIPT_DIR}"/openshift_dev_setup.sh ./developer/ckcp/openshift_dev_setup.sh
+    cp "${SCRIPT_DIR}"/config.yaml ./developer/ckcp/config.yaml
 
-    sed -i 's/\--resources deployments.apps,services,ingresses.networking.k8s.io,pipelines.tekton.dev,pipelineruns.tekton.dev,tasks.tekton.dev,runs.tekton.dev,networkpolicies.networking.k8s.io/\--resources deployments.apps,services,ingresses.networking.k8s.io,networkpolicies.networking.k8s.io,statefulsets.apps,routes.route.openshift.io/' ./images/kcp-registrar/bin/register.sh
+    sed -i 's/\--resources deployments.apps,services,ingresses.networking.k8s.io,pipelines.tekton.dev,pipelineruns.tekton.dev,tasks.tekton.dev,runs.tekton.dev,networkpolicies.networking.k8s.io/\--resources deployments.apps,services,ingresses.networking.k8s.io,networkpolicies.networking.k8s.io,statefulsets.apps,routes.route.openshift.io/' ./operator/images/kcp-registrar/bin/register.sh
     printf "\nUpdated the resources to sync as needed for gitops-service and ckcp to run...\n\n"
     
     printf "Setting up ckcp in the cluster"
-    ./ckcp/openshift_dev_setup.sh
+    ./developer/ckcp/openshift_dev_setup.sh
     popd
     popd
 


### PR DESCRIPTION
#### Description:
For now, the CI for KCP-based e2e is running on v0.7.0, and since the setup, we have two major KCP releases that CKCP has also adopted.

Thus, to keep up and mitigate the differences with the CKCP we need to upgrade the version to the latest as shipped by the pipelines team. This might also involve fixing some issues with the script.

#### Link to JIRA Story (if applicable): [GITOPSRVCE-252](https://issues.redhat.com/browse/GITOPSRVCE-252)
