### PR TITLE
PromotionRun should create a SnapshotEnvironmentBinding (for app/env) if it doesn't already exist

### DIFF
--- a/appstudio-controller/config/rbac/role.yaml
+++ b/appstudio-controller/config/rbac/role.yaml
@@ -34,6 +34,32 @@ rules:
 - apiGroups:
   - appstudio.redhat.com
   resources:
+  - components
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - components/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - components/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
   - environments
   verbs:
   - create

--- a/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
@@ -18,7 +18,7 @@ package appstudioredhatcom
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/md5" //#nosec G501 -- not used for cryptographic purposes
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -470,7 +470,7 @@ func createBindingName(promotionRun *appstudioshared.PromotionRun) string {
 	name := strings.ToLower(promotionRun.Spec.Application + "-" + promotionRun.Spec.ManualPromotion.TargetEnvironment + "-generated-binding")
 	if len(name) > 250 {
 		// 'suffix' will have a length of 32
-		hash := md5.Sum([]byte(name))
+		hash := md5.Sum([]byte(name)) //#nosec G401 -- not used for cryptographic purposes
 		suffix := hex.EncodeToString(hash[:])
 		name = "generated-environment-binding-" + suffix
 	}

--- a/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
@@ -18,7 +18,7 @@ package appstudioredhatcom
 
 import (
 	"context"
-	"crypto/md5" //#nosec G501 -- not used for cryptographic purposes
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -469,8 +469,8 @@ func locateOrCreateTargetManualBinding(ctx context.Context, promotionRun appstud
 func createBindingName(promotionRun *appstudioshared.PromotionRun) string {
 	name := strings.ToLower(promotionRun.Spec.Application + "-" + promotionRun.Spec.ManualPromotion.TargetEnvironment + "-generated-binding")
 	if len(name) > 250 {
-		// 'suffix' will have a length of 32
-		hash := md5.Sum([]byte(name)) //#nosec G401 -- not used for cryptographic purposes
+		// 'suffix' will have a length of 64
+		hash := sha256.Sum256([]byte(name))
 		suffix := hex.EncodeToString(hash[:])
 		name = "generated-environment-binding-" + suffix
 	}

--- a/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
@@ -406,7 +406,7 @@ func checkForExistingActivePromotions(ctx context.Context, reconciledPromotionRu
 	return nil
 }
 
-func locateOrCreateTargetManualBinding(ctx context.Context, promotionRun appstudioshared.PromotionRun, k8sClient client.Client, log logr.Logger) (appstudioshared.SnapshotEnvironmentBinding, error) {
+func locateOrCreateTargetManualBinding(ctx context.Context, promotionRun appstudioshared.PromotionRun, k8sClient client.Client, logger logr.Logger) (appstudioshared.SnapshotEnvironmentBinding, error) {
 
 	// Locate the corresponding binding
 
@@ -458,8 +458,8 @@ func locateOrCreateTargetManualBinding(ctx context.Context, promotionRun appstud
 	if err != nil {
 		return appstudioshared.SnapshotEnvironmentBinding{}, err
 	}
-	sharedutil.LogAPIResourceChangeEvent(binding.Namespace, binding.Name, &binding, sharedutil.ResourceCreated, log)
-	log.Info("Created SnapshotEnvironmentBinding",
+	sharedutil.LogAPIResourceChangeEvent(binding.Namespace, binding.Name, &binding, sharedutil.ResourceCreated, logger)
+	logger.Info("Created SnapshotEnvironmentBinding",
 		"application", promotionRun.Spec.Application,
 		"environment", promotionRun.Spec.ManualPromotion.TargetEnvironment)
 

--- a/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
@@ -133,7 +133,7 @@ func (r *PromotionRunReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// 1) Locate or create the binding that this PromotionRun is targeting
 	binding, err := locateOrCreateTargetManualBinding(ctx, *promotionRun, r.Client)
 	if err != nil {
-		log.Error(err, "error locating Binding for PromotionRun: "+promotionRun.Name)
+		log.Error(err, "error locating or creating Binding for PromotionRun: "+promotionRun.Name)
 		return ctrl.Result{}, nil
 	}
 
@@ -436,10 +436,9 @@ func locateOrCreateTargetManualBinding(ctx context.Context, promotionRun appstud
 	if len(components) == 0 {
 		return appstudioshared.SnapshotEnvironmentBinding{}, fmt.Errorf("unable to find components for application: %s", promotionRun.Spec.Application)
 	}
-	bindingName := strings.ToLower(promotionRun.Spec.Application + "-" + promotionRun.Spec.ManualPromotion.TargetEnvironment + "-generated-binding")
 	binding := appstudioshared.SnapshotEnvironmentBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      bindingName,
+			Name:      createBindingName(&promotionRun),
 			Namespace: promotionRun.Namespace,
 			Labels: map[string]string{
 				"appstudio.application": promotionRun.Spec.Application,
@@ -459,6 +458,10 @@ func locateOrCreateTargetManualBinding(ctx context.Context, promotionRun appstud
 	}
 
 	return binding, nil
+}
+
+func createBindingName(promotionRun *appstudioshared.PromotionRun) string {
+	return strings.ToLower(promotionRun.Spec.Application + "-" + promotionRun.Spec.ManualPromotion.TargetEnvironment + "-generated-binding")
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
@@ -433,6 +433,9 @@ func locateOrCreateTargetManualBinding(ctx context.Context, promotionRun appstud
 			})
 		}
 	}
+	if len(components) == 0 {
+		return appstudioshared.SnapshotEnvironmentBinding{}, fmt.Errorf("unable to find components for application: %s", promotionRun.Spec.Application)
+	}
 	bindingName := strings.ToLower(promotionRun.Spec.Application + "-" + promotionRun.Spec.ManualPromotion.TargetEnvironment + "-generated-binding")
 	binding := appstudioshared.SnapshotEnvironmentBinding{
 		ObjectMeta: metav1.ObjectMeta{

--- a/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
@@ -18,6 +18,8 @@ package appstudioredhatcom
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -131,7 +133,7 @@ func (r *PromotionRunReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// 1) Locate or create the binding that this PromotionRun is targeting
-	binding, err := locateOrCreateTargetManualBinding(ctx, *promotionRun, r.Client)
+	binding, err := locateOrCreateTargetManualBinding(ctx, *promotionRun, r.Client, log)
 	if err != nil {
 		log.Error(err, "error locating or creating Binding for PromotionRun: "+promotionRun.Name)
 		return ctrl.Result{}, nil
@@ -404,12 +406,12 @@ func checkForExistingActivePromotions(ctx context.Context, reconciledPromotionRu
 	return nil
 }
 
-func locateOrCreateTargetManualBinding(ctx context.Context, promotionRun appstudioshared.PromotionRun, k8sClient client.Client) (appstudioshared.SnapshotEnvironmentBinding, error) {
+func locateOrCreateTargetManualBinding(ctx context.Context, promotionRun appstudioshared.PromotionRun, k8sClient client.Client, log logr.Logger) (appstudioshared.SnapshotEnvironmentBinding, error) {
 
 	// Locate the corresponding binding
 
 	bindingList := appstudioshared.SnapshotEnvironmentBindingList{}
-	if err := k8sClient.List(ctx, &bindingList); err != nil {
+	if err := k8sClient.List(ctx, &bindingList, &client.ListOptions{Namespace: promotionRun.Namespace}); err != nil {
 		return appstudioshared.SnapshotEnvironmentBinding{}, fmt.Errorf("unable to list bindings: %v", err)
 	}
 
@@ -423,7 +425,7 @@ func locateOrCreateTargetManualBinding(ctx context.Context, promotionRun appstud
 	// Binding not found, so create it
 	components := []appstudioshared.BindingComponent{}
 	componentList := appstudioshared.ComponentList{}
-	if err := k8sClient.List(ctx, &componentList); err != nil {
+	if err := k8sClient.List(ctx, &componentList, &client.ListOptions{Namespace: promotionRun.Namespace}); err != nil {
 		return appstudioshared.SnapshotEnvironmentBinding{}, fmt.Errorf("unable to list components: %v", err)
 	}
 	for _, component := range componentList.Items {
@@ -456,12 +458,23 @@ func locateOrCreateTargetManualBinding(ctx context.Context, promotionRun appstud
 	if err != nil {
 		return appstudioshared.SnapshotEnvironmentBinding{}, err
 	}
+	sharedutil.LogAPIResourceChangeEvent(binding.Namespace, binding.Name, &binding, sharedutil.ResourceCreated, log)
+	log.Info("Created SnapshotEnvironmentBinding",
+		"application", promotionRun.Spec.Application,
+		"environment", promotionRun.Spec.ManualPromotion.TargetEnvironment)
 
 	return binding, nil
 }
 
 func createBindingName(promotionRun *appstudioshared.PromotionRun) string {
-	return strings.ToLower(promotionRun.Spec.Application + "-" + promotionRun.Spec.ManualPromotion.TargetEnvironment + "-generated-binding")
+	name := strings.ToLower(promotionRun.Spec.Application + "-" + promotionRun.Spec.ManualPromotion.TargetEnvironment + "-generated-binding")
+	if len(name) > 250 {
+		// 'suffix' will have a length of 32
+		hash := md5.Sum([]byte(name))
+		suffix := hex.EncodeToString(hash[:])
+		name = "generated-environment-binding-" + suffix
+	}
+	return name
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller_test.go
@@ -3,7 +3,6 @@ package appstudioredhatcom
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -281,9 +280,8 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			Expect(err).To(BeNil())
 
 			binding := &appstudiosharedv1.SnapshotEnvironmentBinding{}
-			bindingName := strings.ToLower(promotionRun.Spec.Application + "-" + promotionRun.Spec.ManualPromotion.TargetEnvironment + "-generated-binding")
 			err = promotionRunReconciler.Get(ctx, types.NamespacedName{
-				Name:      bindingName,
+				Name:      createBindingName(promotionRun),
 				Namespace: promotionRun.Namespace,
 			}, binding)
 			Expect(err).To(BeNil())
@@ -328,9 +326,8 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			Expect(err).To(BeNil())
 
 			binding := &appstudiosharedv1.SnapshotEnvironmentBinding{}
-			bindingName := strings.ToLower(promotionRun.Spec.Application + "-" + promotionRun.Spec.ManualPromotion.TargetEnvironment + "-generated-binding")
 			err = promotionRunReconciler.Get(ctx, types.NamespacedName{
-				Name:      bindingName,
+				Name:      createBindingName(promotionRun),
 				Namespace: promotionRun.Namespace,
 			}, binding)
 			Expect(err).To(Not(BeNil()))
@@ -364,9 +361,8 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			Expect(err).To(BeNil())
 
 			binding := &appstudiosharedv1.SnapshotEnvironmentBinding{}
-			bindingName := strings.ToLower(promotionRun.Spec.Application + "-" + promotionRun.Spec.ManualPromotion.TargetEnvironment + "-generated-binding")
 			err = promotionRunReconciler.Get(ctx, types.NamespacedName{
-				Name:      bindingName,
+				Name:      createBindingName(promotionRun),
 				Namespace: promotionRun.Namespace,
 			}, binding)
 			Expect(err).To(BeNil())
@@ -409,9 +405,8 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			Expect(err).To(BeNil())
 
 			binding := &appstudiosharedv1.SnapshotEnvironmentBinding{}
-			bindingName := strings.ToLower(promotionRun.Spec.Application + "-" + promotionRun.Spec.ManualPromotion.TargetEnvironment + "-generated-binding")
 			err = promotionRunReconciler.Get(ctx, types.NamespacedName{
-				Name:      bindingName,
+				Name:      createBindingName(promotionRun),
 				Namespace: promotionRun.Namespace,
 			}, binding)
 			Expect(err).To(BeNil())

--- a/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller_test.go
@@ -300,7 +300,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 		It("Should create a binding name no greater than 250 characters.", func() {
 			promotionRun.Spec.Application = strings.Repeat("a", 126)
 			promotionRun.Spec.ManualPromotion.TargetEnvironment = strings.Repeat("b", 126)
-			expectedBindingName := "generated-environment-binding-c0eb15050e88ad19f905700798974cca"
+			expectedBindingName := "generated-environment-binding-593debab8b0260a4eff2338aa1a896f3f44db24e586378168ab62536e5732fe1"
 
 			By("Testing createBindingName explicitly")
 

--- a/tests-e2e/core/promotionrun_controller_seb_test.go
+++ b/tests-e2e/core/promotionrun_controller_seb_test.go
@@ -3,8 +3,7 @@ package core
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	applicationv1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
-	appstudiosharedv1 "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
+	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -143,13 +142,13 @@ func generatedBindingName(promotionRun *appstudiosharedv1.PromotionRun) string {
 	return strings.ToLower(promotionRun.Spec.Application + "-" + promotionRun.Spec.ManualPromotion.TargetEnvironment + "-generated-binding")
 }
 
-func buildComponentResource(name, componentName, appName string) applicationv1alpha1.Component {
-	return applicationv1alpha1.Component{
+func buildComponentResource(name, componentName, appName string) appstudiosharedv1.Component {
+	return appstudiosharedv1.Component{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      name,
 			Namespace: fixture.GitOpsServiceE2ENamespace,
 		},
-		Spec: applicationv1alpha1.ComponentSpec{
+		Spec: appstudiosharedv1.ComponentSpec{
 			ComponentName: componentName,
 			Application:   appName,
 		},

--- a/tests-e2e/core/promotionrun_controller_seb_test.go
+++ b/tests-e2e/core/promotionrun_controller_seb_test.go
@@ -1,0 +1,142 @@
+package core
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	applicationv1alpha1 "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	appstudiosharedv1 "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
+	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
+	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+)
+
+var _ = Describe("Promotion Run Creation of SnapshotEnvironmentBinding E2E Tests.", func() {
+	Context("Testing Promotion Run Creation of SnapshotEnvironmentBinding.", func() {
+		var environmentProd appstudiosharedv1.Environment
+		var promotionRun appstudiosharedv1.PromotionRun
+
+		BeforeEach(func() {
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+
+			By("Create Staging Environment.")
+			environmentStage := buildEnvironmentResource("staging", "Staging Environment", "staging", appstudiosharedv1.EnvironmentType_POC)
+			err := k8s.Create(&environmentStage)
+			Expect(err).To(Succeed())
+
+			By("Create Production Environment.")
+			environmentProd = buildEnvironmentResource("prod", "Production Environment", "prod", appstudiosharedv1.EnvironmentType_POC)
+			err = k8s.Create(&environmentProd)
+			Expect(err).To(Succeed())
+
+			By("Create Snapshot.")
+			snapshot := buildSnapshotResource("my-snapshot", "new-demo-app", "Staging Snapshot", "Staging Snapshot", "component-a", "quay.io/jgwest-redhat/sample-workload:latest")
+			err = k8s.Create(&snapshot)
+			Expect(err).To(Succeed())
+
+			By("Create Component.")
+			component := buildComponentResource("comp1", "component-a", "new-demo-app")
+			err = k8s.Create(&component)
+			Expect(err).To(Succeed())
+
+			By("Create PromotionRun CR.")
+			promotionRun = buildPromotionRunResource("new-demo-app-manual-promotion", "new-demo-app", "my-snapshot", "prod")
+		})
+
+		It("Creates a SnapshotEnvironmentBinding if one doesn't exist that targets the application/environment.", func() {
+			By("Create PromotionRun CR.")
+			err := k8s.Create(&promotionRun)
+			Expect(err).To(Succeed())
+
+			By("Check binding was created.")
+			bindingName := generatedBindingName(&promotionRun)
+			binding := &appstudiosharedv1.SnapshotEnvironmentBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      bindingName,
+					Namespace: promotionRun.Namespace,
+				},
+			}
+			Eventually(binding, "60s", "5s").Should(k8s.ExistByName())
+		})
+
+		It("Creates a SnapshotEnvironmentBinding if one exists that targets the application, but NOT the environment.", func() {
+			By("Create binding targeting the application but not the environment.")
+			bindingStage := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
+			err := k8s.Create(&bindingStage)
+			Expect(err).To(Succeed())
+
+			By("Create PromotionRun CR.")
+			err = k8s.Create(&promotionRun)
+			Expect(err).To(Succeed())
+
+			By("Check binding was created.")
+			bindingName := generatedBindingName(&promotionRun)
+			binding := &appstudiosharedv1.SnapshotEnvironmentBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      bindingName,
+					Namespace: promotionRun.Namespace,
+				},
+			}
+			Eventually(binding, "60s", "5s").Should(k8s.ExistByName())
+		})
+
+		It("Creates a SnapshotEnvironmentBinding if one exists that targets the environment, but NOT the application.", func() {
+			By("Create binding targeting the environment but not the application.")
+			bindingApp := buildSnapshotEnvironmentBindingResource("appx-prod-binding", "app-x", "prod", "my-snapshot", 3, []string{"component-a"})
+			err := k8s.Create(&bindingApp)
+			Expect(err).To(Succeed())
+
+			By("Create PromotionRun CR.")
+			err = k8s.Create(&promotionRun)
+			Expect(err).To(Succeed())
+
+			By("Check binding was created.")
+			bindingName := generatedBindingName(&promotionRun)
+			binding := &appstudiosharedv1.SnapshotEnvironmentBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      bindingName,
+					Namespace: promotionRun.Namespace,
+				},
+			}
+			Eventually(binding, "60s", "5s").Should(k8s.ExistByName())
+		})
+
+		It("Does not create a SnapshotEnvironmentBinding if one exists that targets the environment and the application.", func() {
+			By("Create binding targeting the environment but not the application.")
+			bindingProd := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "prod", "my-snapshot", 3, []string{"component-a"})
+			err := k8s.Create(&bindingProd)
+			Expect(err).To(Succeed())
+
+			By("Create PromotionRun CR.")
+			err = k8s.Create(&promotionRun)
+			Expect(err).To(Succeed())
+
+			By("Check no binding was created.")
+			bindingName := generatedBindingName(&promotionRun)
+			binding := &appstudiosharedv1.SnapshotEnvironmentBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      bindingName,
+					Namespace: promotionRun.Namespace,
+				},
+			}
+			Consistently(binding, "60s", "5s").ShouldNot(k8s.ExistByName())
+		})
+	})
+})
+
+func generatedBindingName(promotionRun *appstudiosharedv1.PromotionRun) string {
+	return strings.ToLower(promotionRun.Spec.Application + "-" + promotionRun.Spec.ManualPromotion.TargetEnvironment + "-generated-binding")
+}
+
+func buildComponentResource(name, componentName, appName string) applicationv1alpha1.Component {
+	return applicationv1alpha1.Component{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: fixture.GitOpsServiceE2ENamespace,
+		},
+		Spec: applicationv1alpha1.ComponentSpec{
+			ComponentName: componentName,
+			Application:   appName,
+		},
+	}
+}

--- a/tests-e2e/core/promotionrun_controller_seb_test.go
+++ b/tests-e2e/core/promotionrun_controller_seb_test.go
@@ -19,24 +19,27 @@ var _ = Describe("Promotion Run Creation of SnapshotEnvironmentBinding E2E Tests
 		BeforeEach(func() {
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
+
 			By("Create Staging Environment.")
 			environmentStage := buildEnvironmentResource("staging", "Staging Environment", "staging", appstudiosharedv1.EnvironmentType_POC)
-			err := k8s.Create(&environmentStage)
+			err = k8s.Create(&environmentStage, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Create Production Environment.")
 			environmentProd = buildEnvironmentResource("prod", "Production Environment", "prod", appstudiosharedv1.EnvironmentType_POC)
-			err = k8s.Create(&environmentProd)
+			err = k8s.Create(&environmentProd, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Create Snapshot.")
 			snapshot := buildSnapshotResource("my-snapshot", "new-demo-app", "Staging Snapshot", "Staging Snapshot", "component-a", "quay.io/jgwest-redhat/sample-workload:latest")
-			err = k8s.Create(&snapshot)
+			err = k8s.Create(&snapshot, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Create Component.")
 			component := buildComponentResource("comp1", "component-a", "new-demo-app")
-			err = k8s.Create(&component)
+			err = k8s.Create(&component, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Create PromotionRun CR.")
@@ -44,8 +47,11 @@ var _ = Describe("Promotion Run Creation of SnapshotEnvironmentBinding E2E Tests
 		})
 
 		It("Creates a SnapshotEnvironmentBinding if one doesn't exist that targets the application/environment.", func() {
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
+
 			By("Create PromotionRun CR.")
-			err := k8s.Create(&promotionRun)
+			err = k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Check binding was created.")
@@ -56,17 +62,20 @@ var _ = Describe("Promotion Run Creation of SnapshotEnvironmentBinding E2E Tests
 					Namespace: promotionRun.Namespace,
 				},
 			}
-			Eventually(binding, "60s", "5s").Should(k8s.ExistByName())
+			Eventually(binding, "60s", "5s").Should(k8s.ExistByName(k8sClient))
 		})
 
 		It("Creates a SnapshotEnvironmentBinding if one exists that targets the application, but NOT the environment.", func() {
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
+
 			By("Create binding targeting the application but not the environment.")
 			bindingStage := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
-			err := k8s.Create(&bindingStage)
+			err = k8s.Create(&bindingStage, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Create PromotionRun CR.")
-			err = k8s.Create(&promotionRun)
+			err = k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Check binding was created.")
@@ -77,17 +86,20 @@ var _ = Describe("Promotion Run Creation of SnapshotEnvironmentBinding E2E Tests
 					Namespace: promotionRun.Namespace,
 				},
 			}
-			Eventually(binding, "60s", "5s").Should(k8s.ExistByName())
+			Eventually(binding, "60s", "5s").Should(k8s.ExistByName(k8sClient))
 		})
 
 		It("Creates a SnapshotEnvironmentBinding if one exists that targets the environment, but NOT the application.", func() {
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
+
 			By("Create binding targeting the environment but not the application.")
 			bindingApp := buildSnapshotEnvironmentBindingResource("appx-prod-binding", "app-x", "prod", "my-snapshot", 3, []string{"component-a"})
-			err := k8s.Create(&bindingApp)
+			err = k8s.Create(&bindingApp, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Create PromotionRun CR.")
-			err = k8s.Create(&promotionRun)
+			err = k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Check binding was created.")
@@ -98,17 +110,20 @@ var _ = Describe("Promotion Run Creation of SnapshotEnvironmentBinding E2E Tests
 					Namespace: promotionRun.Namespace,
 				},
 			}
-			Eventually(binding, "60s", "5s").Should(k8s.ExistByName())
+			Eventually(binding, "60s", "5s").Should(k8s.ExistByName(k8sClient))
 		})
 
 		It("Does not create a SnapshotEnvironmentBinding if one exists that targets the environment and the application.", func() {
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
+
 			By("Create binding targeting the environment but not the application.")
 			bindingProd := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "prod", "my-snapshot", 3, []string{"component-a"})
-			err := k8s.Create(&bindingProd)
+			err = k8s.Create(&bindingProd, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Create PromotionRun CR.")
-			err = k8s.Create(&promotionRun)
+			err = k8s.Create(&promotionRun, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Check no binding was created.")
@@ -119,7 +134,7 @@ var _ = Describe("Promotion Run Creation of SnapshotEnvironmentBinding E2E Tests
 					Namespace: promotionRun.Namespace,
 				},
 			}
-			Consistently(binding, "60s", "5s").ShouldNot(k8s.ExistByName())
+			Consistently(binding, "60s", "5s").ShouldNot(k8s.ExistByName(k8sClient))
 		})
 	})
 })

--- a/tests-e2e/fixture/fixture.go
+++ b/tests-e2e/fixture/fixture.go
@@ -601,11 +601,6 @@ func GetKubeClient(config *rest.Config) (client.Client, error) {
 		return nil, err
 	}
 
-	err = appstudiosharedv1.AddToScheme(scheme)
-	if err != nil {
-		return nil, err
-	}
-
 	k8sClient, err := client.New(config, client.Options{Scheme: scheme})
 	if err != nil {
 		return nil, err

--- a/tests-e2e/fixture/fixture.go
+++ b/tests-e2e/fixture/fixture.go
@@ -601,6 +601,11 @@ func GetKubeClient(config *rest.Config) (client.Client, error) {
 		return nil, err
 	}
 
+	err = appstudiosharedv1.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+
 	k8sClient, err := client.New(config, client.Options{Scheme: scheme})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### Description:

- Updated the PromotionRun reconciliation to always create a SnapshotEnvironmentBinding (SEB) for the target application/environment, if that SEB doesn't already exist.
- Created unit tests for the new function
- Created e2e tests for the new function

#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-239
