### PR TITLE
[WIP] Reconcile a GitOpsDeploymentManagedEnvironment that references a KCP subworkspace secret

### DIFF
--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_types.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_types.go
@@ -22,8 +22,9 @@ import (
 
 // GitOpsDeploymentManagedEnvironmentSpec defines the desired state of GitOpsDeploymentManagedEnvironment
 type GitOpsDeploymentManagedEnvironmentSpec struct {
-	APIURL                   string `json:"apiURL"`
-	ClusterCredentialsSecret string `json:"credentialsSecret"`
+	APIURL                   string `json:"apiURL,omitempty"`
+	ClusterCredentialsSecret string `json:"credentialsSecret,omitempty"`
+	SubWorkspace             string `json:"subWorkspace,omitempty"`
 }
 
 // GitOpsDeploymentManagedEnvironmentStatus defines the observed state of GitOpsDeploymentManagedEnvironment

--- a/backend-shared/config/crd/bases/managed-gitops.redhat.com_gitopsdeploymentmanagedenvironments.yaml
+++ b/backend-shared/config/crd/bases/managed-gitops.redhat.com_gitopsdeploymentmanagedenvironments.yaml
@@ -42,9 +42,8 @@ spec:
                 type: string
               credentialsSecret:
                 type: string
-            required:
-            - apiURL
-            - credentialsSecret
+              subWorkspace:
+                type: string
             type: object
           status:
             description: GitOpsDeploymentManagedEnvironmentStatus defines the observed

--- a/backend-shared/config/kcp/apiexport_gitopsrvc_backendshared.yaml
+++ b/backend-shared/config/kcp/apiexport_gitopsrvc_backendshared.yaml
@@ -12,8 +12,8 @@ spec:
   - group: ""
     resource: "namespaces"
   latestResourceSchemas:
-    - v202208100611.gitopsdeploymentmanagedenvironments.managed-gitops.redhat.com
-    - v202208100611.gitopsdeploymentrepositorycredentials.managed-gitops.redhat.com
-    - v202208100611.gitopsdeployments.managed-gitops.redhat.com
-    - v202208100611.gitopsdeploymentsyncruns.managed-gitops.redhat.com
-    - v202208100611.operations.managed-gitops.redhat.com
+    - v202211140612.gitopsdeploymentmanagedenvironments.managed-gitops.redhat.com
+    - v202211140612.gitopsdeploymentrepositorycredentials.managed-gitops.redhat.com
+    - v202211140612.gitopsdeployments.managed-gitops.redhat.com
+    - v202211140612.gitopsdeploymentsyncruns.managed-gitops.redhat.com
+    - v202211140612.operations.managed-gitops.redhat.com

--- a/backend-shared/config/kcp/apiresourceschema_gitopsrvc_backendshared.yaml
+++ b/backend-shared/config/kcp/apiresourceschema_gitopsrvc_backendshared.yaml
@@ -5,7 +5,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202208100611.gitopsdeploymentmanagedenvironments.managed-gitops.redhat.com
+  name: v202211140612.gitopsdeploymentmanagedenvironments.managed-gitops.redhat.com
 spec:
   group: managed-gitops.redhat.com
   names:
@@ -40,9 +40,8 @@ spec:
               type: string
             credentialsSecret:
               type: string
-          required:
-          - apiURL
-          - credentialsSecret
+            subWorkspace:
+              type: string
           type: object
         status:
           description: GitOpsDeploymentManagedEnvironmentStatus defines the observed
@@ -59,7 +58,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202208100611.gitopsdeploymentrepositorycredentials.managed-gitops.redhat.com
+  name: v202211140612.gitopsdeploymentrepositorycredentials.managed-gitops.redhat.com
 spec:
   group: managed-gitops.redhat.com
   names:
@@ -119,7 +118,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202208100611.gitopsdeployments.managed-gitops.redhat.com
+  name: v202211140612.gitopsdeployments.managed-gitops.redhat.com
 spec:
   group: managed-gitops.redhat.com
   names:
@@ -247,6 +246,42 @@ spec:
                     resource
                   type: string
               type: object
+            reconciledState:
+              description: ReconciledState lists last deployment of ArgoCD Application
+              properties:
+                destination:
+                  description: GitOpsDeploymentDestination contains the information
+                    of .status.Sync.CompareTo.Destination field of ArgoCD Application
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                source:
+                  description: GitOpsDeploymentSource contains the information of
+                    .status.Sync.CompareTo.Source field of ArgoCD Application
+                  properties:
+                    branch:
+                      type: string
+                    path:
+                      description: Path contains path from .status.Sync.CompareTo
+                        field of ArgoCD Application
+                      type: string
+                    repoURL:
+                      type: string
+                  required:
+                  - branch
+                  - path
+                  - repoURL
+                  type: object
+              required:
+              - destination
+              - source
+              type: object
             resources:
               description: List of Resource created by a deployment
               items:
@@ -296,6 +331,8 @@ spec:
               required:
               - status
               type: object
+          required:
+          - reconciledState
           type: object
       type: object
     served: true
@@ -308,7 +345,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202208100611.gitopsdeploymentsyncruns.managed-gitops.redhat.com
+  name: v202211140612.gitopsdeploymentsyncruns.managed-gitops.redhat.com
 spec:
   group: managed-gitops.redhat.com
   names:
@@ -392,7 +429,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202208100611.operations.managed-gitops.redhat.com
+  name: v202211140612.operations.managed-gitops.redhat.com
 spec:
   group: managed-gitops.redhat.com
   names:


### PR DESCRIPTION
#### Description:
- Add a new field `subWorkspace` to GitOpsDeploymentManagedEnvironment CR
- Create cluster credentials based on the workspace secret created in the service provider workspace
- unit tests

#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-232
