### PR TITLE
Add support for syncing/terminating sync of an Argo CD Application to cluster-agent

### DIFF
--- a/backend-shared/util/task_retry_loop.go
+++ b/backend-shared/util/task_retry_loop.go
@@ -21,19 +21,19 @@ import (
 //
 // Imagine that we are implementing a task that deletes all the objects in a namespace.
 //
-// taskRetryLoop := NewTaskRetry("")
+// taskRetryLoop := NewTaskRetryLoop("(...)")
 //
 // deleteAllObjs := DeleteAllObjectsInNamespaceTask{}
 //
-// // 1) This will cause the 'DeleteAllObjects' task to start running, on namespace a
-// taskRetryLoopAddTaskIfNotPresent("delete-namespace-A", deleteAllObjs, ...)
+// // 1) This will cause the 'DeleteAllObjects' task to start running, on namespace 'a'
+// taskRetryLoop.AddTaskIfNotPresent("delete-namespace-A", deleteAllObjs, ...)
 //
-// // 2) This will cause the 'DeleteAllObjects' task to start running, on namespace b
-// taskRetryLoopAddTaskIfNotPresent("delete-namespace-B", deleteAllObjs, ...)
+// // 2) This will cause the 'DeleteAllObjects' task to start running, on namespace 'b'
+// taskRetryLoop.AddTaskIfNotPresent("delete-namespace-B", deleteAllObjs, ...)
 //
-// Both the tasks in step 1 and step 2 will run concurrently, because the task name if
+// Both the tasks in step 1 and step 2 will run concurrently, because the task name is
 // different ("delete-namespace-A" vs "delete-namespace-B"). If the task name was the
-// same, only one task would be allows to run concurrently.
+// same, only one task would be allowed to run concurrently.
 //
 // In order to run code as a task, the calling function must implement the 'RetryableTask' interface.
 //
@@ -46,13 +46,13 @@ import (
 // deleteAllObjs := DeleteAllObjectsInNamespaceTask{}
 //
 // // 1) This will cause the 'DeleteAllObjects' task to start running, on namespace a
-// AddTaskIfNotPresent("delete-namespace-A", deleteAllObjs, ...)
+// taskRetryLoop.AddTaskIfNotPresent("delete-namespace-A", deleteAllObjs, ...)
 //
 // // 2) This will cause the 'DeleteAllObjects' task to start running, on namespace B
-// AddTaskIfNotPresent("delete-namespace-B", deleteAllObjs, ...)
+// taskRetryLoop.AddTaskIfNotPresent("delete-namespace-B", deleteAllObjs, ...)
 
 // // 3) But what if AddTaskIfNotPresent is called on namespace A, before the task has finished with namespace A?
-// AddTaskIfNotPresent("delete-namespace-A", deleteAllObjs, ...)
+// taskRetryLoop.AddTaskIfNotPresent("delete-namespace-A", deleteAllObjs, ...)
 //
 // In this case, if 'delete-namespace-A' from step 1 has not started yet, then the task from step 3) will
 // not run (it will be de-duplicated/ignored).

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
@@ -113,7 +113,8 @@ func operationEventLoopRouter(input chan operationEventLoopEvent) {
 				return nil
 			}
 
-			// Only concurrently process one Application/SyncOperation at a time
+			// If multiple operations exist that target the same Application/SyncOperation, we should only process those
+			// operations one at a time (i.e. non-concurrently)
 			mapKey = dbOperation.Instance_id + "-" + string(dbOperation.Resource_type) + "-" + dbOperation.Resource_id
 
 			return nil

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
@@ -559,16 +559,16 @@ outer:
 		dbSyncOperation := &db.SyncOperation{
 			SyncOperation_id: dbOperation.Resource_id,
 		}
-		if err := dbQueries.GetSyncOperationById(ctx, dbSyncOperation); err != nil {
+		if innerErr := dbQueries.GetSyncOperationById(ctx, dbSyncOperation); innerErr != nil {
 
 			// If the DB entry no longer exists, then no more work is to be done
-			if db.IsResultNotFoundError(err) {
+			if db.IsResultNotFoundError(innerErr) {
 				log.V(sharedutil.LogLevel_Debug).Info("SyncOperation '" + dbSyncOperation.SyncOperation_id + "' DB entry was no longer available, during AppSync.")
 				shouldRetry = shouldRetryFalse
 				err = nil
 				break outer
 			} else {
-				log.Error(err, "Unable to retrieve SyncOperation '"+dbSyncOperation.SyncOperation_id+"', during AppSync.")
+				log.Error(innerErr, "Unable to retrieve SyncOperation '"+dbSyncOperation.SyncOperation_id+"', during AppSync.")
 			}
 		}
 

--- a/cluster-agent/utils/argocd_terminate_app_command.go
+++ b/cluster-agent/utils/argocd_terminate_app_command.go
@@ -51,7 +51,7 @@ func terminateOperation(ctx context.Context, appName string, argocdNamespace cor
 
 	expireTime := time.Now().Add(expireDuration)
 
-	backoff := sharedutil.ExponentialBackoff{Factor: 2, Min: time.Duration(100 * time.Microsecond), Max: time.Duration(5 * time.Second), Jitter: true}
+	backoff := sharedutil.ExponentialBackoff{Factor: 2, Min: time.Duration(500 * time.Microsecond), Max: time.Duration(5 * time.Second), Jitter: true}
 	for {
 
 		if time.Now().After(expireTime) {


### PR DESCRIPTION
#### Description:
- Ensure that only one operation is running at a time for a particular resource (Application/SyncOperation/etc)
- Sugar: `true/false` -> `shouldRetryTrue/False` for functions returning a should retry value 
- Add processing of SyncOperation resource, which will cause Argo CD to do a manual sync (or to terminate a manual sync), based on the contents of the SyncOperation resource in the DB.
- Unit/E2E tests to be worked on elsewhere, this is being pushed to unblock team members

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-82

