### PR TITLE
Add secrets resources to the appstudio controller

### DIFF
--- a/appstudio-controller/config/rbac/role.yaml
+++ b/appstudio-controller/config/rbac/role.yaml
@@ -136,6 +136,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - managed-gitops.redhat.com
   resources:
   - gitopsdeployments

--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
@@ -44,6 +44,7 @@ type EnvironmentReconciler struct {
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=environments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=environments/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=environments/finalizers,verbs=update
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/manifests/appstudio-controller-rbac/appstudio-controller-rbac.yaml
+++ b/manifests/appstudio-controller-rbac/appstudio-controller-rbac.yaml
@@ -49,6 +49,14 @@ metadata:
   name: appstudio-controller-manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - appstudio.redhat.com
   resources:
   - promotionruns


### PR DESCRIPTION
#### Description:
- This PR add secrets resources to the appstudio controller. The controller right now is not able to list the environment secrets in the cluster.

![image](https://user-images.githubusercontent.com/59865209/204777618-9126e84b-6156-4135-abeb-51d16214b60f.png)


#### Link to JIRA Story (if applicable):

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
