### PR TITLE
chore: Bump setup-go to v3.4.0

### DIFF
--- a/.github/workflows/schema-sync.yml
+++ b/.github/workflows/schema-sync.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Setup Go
-      uses: actions/setup-go@v3.2.0
+      uses: actions/setup-go@v3.4.0
       with:
         go-version-file: './backend/go.mod'
     - name: Run script file

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup Golang
-        uses: actions/setup-go@v3.2.0
+        uses: actions/setup-go@v3.4.0
         with:
           go-version-file: './backend/go.mod'
       - name: "Run make fmt and then 'git diff' to see if anything changed: to fix this check, run make fmt and then commit the changes."
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup Golang
-        uses: actions/setup-go@v3.2.0
+        uses: actions/setup-go@v3.4.0
         with:
           go-version-file: './backend/go.mod'
       - name: "Install dupimport"
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup Golang
-        uses: actions/setup-go@v3.2.0
+        uses: actions/setup-go@v3.4.0
         with:
           go-version-file: './backend/go.mod'
       - name: "Install gosec"
@@ -120,7 +120,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Golang
-        uses: actions/setup-go@v3.2.0
+        uses: actions/setup-go@v3.4.0
         with:
           go-version-file: './backend/go.mod'
 
@@ -171,7 +171,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v3.4.0
         with:
           go-version-file: './backend/go.mod'
       - name: "Install go modules for migration"
@@ -185,7 +185,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v3.4.0
         with:
           go-version-file: './backend/go.mod'
       - name: "Install go modules for migration"
@@ -199,7 +199,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Golang
-        uses: actions/setup-go@v3.2.0
+        uses: actions/setup-go@v3.4.0
         with:
           go-version-file: './backend/go.mod'
       - name: "Start PostgreSQL"


### PR DESCRIPTION
#### Description:

Main reason: it gives us the option to use Go Workspaces in the GitHub Actions as well

Bumps [actions/setup-go](https://github.com/actions/setup-go) from 3.2.0 to 3.4.0.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/actions/setup-go/releases">actions/setup-go's releases</a>.</em></p>
<blockquote>
<h2>Add support for go.work and pass the token input through on GHES</h2>
<p>In scope of this release we added <a href="https://github-redirect.dependabot.com/actions/setup-go/pull/283">support for go.work file to pass it in go-version-file input</a>.</p>
<pre lang="yaml"><code>steps:
  - uses: actions/checkout@v3
  - uses: actions/setup-go@v3
    with:
      go-version-file: go.work
  - run: go run hello.go
</code></pre>
<p>Besides, we added support to <a href="https://github-redirect.dependabot.com/actions/setup-go/pull/277">pass the token input through on GHES</a>.</p>
<h2>Fix cache issues and update dependencies</h2>
<p>In scope of this release we fixed the issue with the correct generation of the cache key when the <code>go-version-file</code> input is set (<a href="https://github-redirect.dependabot.com/actions/setup-go/pull/267">actions/setup-go#267</a>). Moreover, we fixed an issue when <a href="https://github-redirect.dependabot.com/actions/setup-go/pull/264">the cache folder was not found</a>. Besides, we updated <code>actions/core</code> to 1.10.0 version (<a href="https://github-redirect.dependabot.com/actions/setup-go/pull/273">actions/setup-go#273</a>).</p>
<h2>Support architecture input and fix Expand-Archive issue</h2>
<p>This release introduces support for architecture input for <code>setup-go</code> action <a href="https://github-redirect.dependabot.com/actions/setup-go/issues/253">#253</a>. It also adds support for arm32 architecture for self-hosted runners. If architecture is not provided action will use default runner architecture.
Example of usage:</p>
<pre lang="yaml"><code>steps:
- uses: actions/checkout@v3
- uses: actions/setup-go@v3
  with:
   go-version: '1.16'
   architecture: arm
</code></pre>
<p>This release also provides fix for issue <a href="https://github-redirect.dependabot.com/actions/setup-go/issues/241">#241</a>. <a href="https://github-redirect.dependabot.com/actions/setup-go/issues/250">#250</a> adds support for using explicit filename for Windows which is necessary to satisfy Expand-Archive's requirement on .zip extension.</p>
<h2>Update actions/cache version to 3.0.0</h2>
<p>In scope of this release we updated <code>actions/cache</code> package as the new version contains fixes for <a href="https://github-redirect.dependabot.com/actions/setup-go/pull/238">caching error handling</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/actions/setup-go/commit/d0a58c1c4d2b25278816e339b944508c875f3613"><code>d0a58c1</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/actions/setup-go/issues/294">#294</a> from JamesMGreene/patch-1</li>
<li><a href="https://github.com/actions/setup-go/commit/3dcd9d6eb339e94c0879d6d7e8fb170515ae48aa"><code>3dcd9d6</code></a> Update to latest <code>actions/publish-action</code></li>
<li><a href="https://github.com/actions/setup-go/commit/e983b65a44843e966b4f802da5afe51c501fed7c"><code>e983b65</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/actions/setup-go/issues/283">#283</a> from koba1t/add_support_gowork_for_go-version-file</li>
<li><a href="https://github.com/actions/setup-go/commit/27b43e1b0d324a64f8fcc14f931e45ae178f6b19"><code>27b43e1</code></a> Pass the token input through on GHES (<a href="https://github-redirect.dependabot.com/actions/setup-go/issues/277">#277</a>)</li>
<li><a href="https://github.com/actions/setup-go/commit/7678c83214c8f844360ea3f399163b0010119bf9"><code>7678c83</code></a> add support gowork for go-version-file</li>
<li><a href="https://github.com/actions/setup-go/commit/c4a742cab115ed795e34d4513e2cf7d472deb55f"><code>c4a742c</code></a> fix(): cache resolve version input (<a href="https://github-redirect.dependabot.com/actions/setup-go/issues/267">#267</a>)</li>
<li><a href="https://github.com/actions/setup-go/commit/f556e5b7e01141ed7cf0a83664ed24417b8aa9a5"><code>f556e5b</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/actions/setup-go/issues/273">#273</a> from rentziass/rentziass/update-actions-core</li>
<li><a href="https://github.com/actions/setup-go/commit/514ae57904bc71e20360773eba2940911af33b02"><code>514ae57</code></a> Update <code>@​actions/core</code> to 1.10.0</li>
<li><a href="https://github.com/actions/setup-go/commit/30b9ddff1180797dbf0efc06837929f98bdf7af7"><code>30b9ddf</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/actions/setup-go/issues/264">#264</a> from e-korolevskii/258-not-throw-err-no-cache-folders</li>
<li><a href="https://github.com/actions/setup-go/commit/c4e169859f5fb9f3f78b83a0064bc91bc3d31ca9"><code>c4e1698</code></a> prettier format</li>
<li>Additional commits viewable in <a href="https://github.com/actions/setup-go/compare/v3.2.0...v3.4.0">compare view</a></li>
</ul>
</details>
<br />




#### Link to JIRA Story (if applicable):

Nope
