### PR TITLE
Periodic job to clean up orphan DeploymentToApplicationMappings.

### DIFF
--- a/backend-shared/config/db/deploymenttoapplicationmapping.go
+++ b/backend-shared/config/db/deploymenttoapplicationmapping.go
@@ -329,3 +329,15 @@ func (obj *DeploymentToApplicationMapping) GetAsLogKeyValues() []interface{} {
 		"dtamNamespace", obj.DeploymentNamespace, "dtamUID", obj.Deploymenttoapplicationmapping_uid_id,
 		"dtamNamespaceUID", obj.NamespaceUID}
 }
+
+// Get deploymentToApplicationMappings in a batch. Batch size defined by 'limit' and starting point of batch is defined by 'offSet'.
+// For example if you want deploymentToApplicationMappings starting from 51-150 then set the limit to 100 and offset to 50.
+func (dbq *PostgreSQLDatabaseQueries) GetDeploymentToApplicationMappingBatch(ctx context.Context, deploymentToApplicationMappings *[]DeploymentToApplicationMapping, limit, offSet int) error {
+	return dbq.dbConnection.
+		Model(deploymentToApplicationMappings).
+		Order("seq_id ASC").
+		Limit(limit).   // Batch size
+		Offset(offSet). // offset+1 is starting point of batch
+		Context(ctx).
+		Select()
+}

--- a/backend-shared/config/db/deploymenttoapplicationmapping_test.go
+++ b/backend-shared/config/db/deploymenttoapplicationmapping_test.go
@@ -13,46 +13,58 @@ func generateUuid() string {
 	return uuid.New().String()
 }
 
+// Create entry for Application and DeploymentToApplicationMapping tables
+func createAppAndDtamEntry(ctx context.Context, dbq db.AllDatabaseQueries, application *db.Application, deploymentToApplicationMapping *db.DeploymentToApplicationMapping) {
+	application.Application_id = "test-app-" + generateUuid()
+	application.Name = "test-app-" + generateUuid()
+	err := dbq.CreateApplication(ctx, application)
+	Expect(err).To(BeNil())
+
+	deploymentToApplicationMapping.Deploymenttoapplicationmapping_uid_id = "test-" + generateUuid()
+	deploymentToApplicationMapping.Application_id = application.Application_id
+	err = dbq.CreateDeploymentToApplicationMapping(ctx, deploymentToApplicationMapping)
+	Expect(err).To(BeNil())
+}
+
 var _ = Describe("DeploymentToApplicationMapping Tests", func() {
 	Context("It should execute all DeploymentToApplicationMapping Functions", func() {
-		It("Should execute all DeploymentToApplicationMapping Functions", func() {
+		var ctx context.Context
+		var dbq db.AllDatabaseQueries
+		var application *db.Application
+		var deploymentToApplicationMapping *db.DeploymentToApplicationMapping
+
+		BeforeEach(func() {
 			err := db.SetupForTestingDBGinkgo()
 			Expect(err).To(BeNil())
 
-			ctx := context.Background()
-			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
+			ctx = context.Background()
+			dbq, err = db.NewUnsafePostgresDBQueries(true, true)
 			Expect(err).To(BeNil())
-			defer dbq.CloseDatabase()
 
 			_, managedEnvironment, _, gitopsEngineInstance, _, err := db.CreateSampleData(dbq)
 			Expect(err).To(BeNil())
 
-			application := &db.Application{
-				Application_id:          "test-my-application",
-				Name:                    "my-application",
+			application = &db.Application{
 				Spec_field:              "{}",
 				Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
 				Managed_environment_id:  managedEnvironment.Managedenvironment_id,
 			}
 
-			err = dbq.CreateApplication(ctx, application)
-
-			Expect(err).To(BeNil())
-
-			deploymentToApplicationMapping := &db.DeploymentToApplicationMapping{
-				Deploymenttoapplicationmapping_uid_id: "test-" + generateUuid(),
-				Application_id:                        application.Application_id,
-				DeploymentName:                        "test-deployment",
-				DeploymentNamespace:                   "test-namespace",
-				NamespaceUID:                          "demo-namespace",
+			deploymentToApplicationMapping = &db.DeploymentToApplicationMapping{
+				DeploymentName:      "test-deployment",
+				DeploymentNamespace: "test-namespace",
+				NamespaceUID:        "demo-namespace",
 			}
 
-			err = dbq.CreateDeploymentToApplicationMapping(ctx, deploymentToApplicationMapping)
-			Expect(err).To(BeNil())
+			createAppAndDtamEntry(ctx, dbq, application, deploymentToApplicationMapping)
+		})
+
+		It("Should execute all DeploymentToApplicationMapping Functions", func() {
+			defer dbq.CloseDatabase()
 			fetchRow := &db.DeploymentToApplicationMapping{
 				Deploymenttoapplicationmapping_uid_id: deploymentToApplicationMapping.Deploymenttoapplicationmapping_uid_id,
 			}
-			err = dbq.GetDeploymentToApplicationMappingByDeplId(ctx, fetchRow)
+			err := dbq.GetDeploymentToApplicationMappingByDeplId(ctx, fetchRow)
 			Expect(err).To(BeNil())
 			Expect(fetchRow).To(Equal(deploymentToApplicationMapping))
 
@@ -65,46 +77,15 @@ var _ = Describe("DeploymentToApplicationMapping Tests", func() {
 			err = dbq.GetDeploymentToApplicationMappingByDeplId(ctx, fetchRow)
 			Expect(true).To(Equal(db.IsResultNotFoundError(err)))
 		})
+
 		It("Should Successfully Test ListAll Function", func() {
-			err := db.SetupForTestingDBGinkgo()
-			Expect(err).To(BeNil())
-
-			ctx := context.Background()
-			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
-			Expect(err).To(BeNil())
 			defer dbq.CloseDatabase()
-
-			_, managedEnvironment, _, gitopsEngineInstance, _, err := db.CreateSampleData(dbq)
-			Expect(err).To(BeNil())
-
-			application := &db.Application{
-				Application_id:          "test-my-application",
-				Name:                    "my-application",
-				Spec_field:              "{}",
-				Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
-				Managed_environment_id:  managedEnvironment.Managedenvironment_id,
-			}
-
-			err = dbq.CreateApplication(ctx, application)
-
-			Expect(err).To(BeNil())
-
-			deploymentToApplicationMapping := &db.DeploymentToApplicationMapping{
-				Deploymenttoapplicationmapping_uid_id: "test-" + generateUuid(),
-				Application_id:                        application.Application_id,
-				DeploymentName:                        "test-deployment",
-				DeploymentNamespace:                   "test-namespace",
-				NamespaceUID:                          "demo-namespace",
-			}
-
-			err = dbq.CreateDeploymentToApplicationMapping(ctx, deploymentToApplicationMapping)
-			Expect(err).To(BeNil())
 			var dbResults []db.DeploymentToApplicationMapping
 			dbResult := &db.DeploymentToApplicationMapping{
 				Deploymenttoapplicationmapping_uid_id: deploymentToApplicationMapping.Deploymenttoapplicationmapping_uid_id,
 			}
 
-			err = dbq.ListDeploymentToApplicationMappingByNamespaceUID(ctx, "demo-namespace", &dbResults)
+			err := dbq.ListDeploymentToApplicationMappingByNamespaceUID(ctx, "demo-namespace", &dbResults)
 			Expect(err).To(BeNil())
 			Expect(len(dbResults)).Should(Equal(1))
 			Expect(dbResults[0]).Should(Equal(*deploymentToApplicationMapping))
@@ -128,6 +109,24 @@ var _ = Describe("DeploymentToApplicationMapping Tests", func() {
 			}
 			err = dbq.GetDeploymentToApplicationMappingByDeplId(ctx, fetchRow)
 			Expect(true).To(Equal(db.IsResultNotFoundError(err)))
+		})
+
+		It("Should Get DeploymentToApplicationMapping in batch.", func() {
+			defer dbq.CloseDatabase()
+			// Create multiple entries in table
+			for i := 0; i < 6; i++ {
+				createAppAndDtamEntry(ctx, dbq, application, deploymentToApplicationMapping)
+			}
+
+			// Fetch entries in batches
+			var listOfDeploymentToApplicationMappingFromDB []db.DeploymentToApplicationMapping
+			err := dbq.GetDeploymentToApplicationMappingBatch(ctx, &listOfDeploymentToApplicationMappingFromDB, 2, 0)
+			Expect(err).To(BeNil())
+			Expect(len(listOfDeploymentToApplicationMappingFromDB)).To(Equal(2))
+
+			err = dbq.GetDeploymentToApplicationMappingBatch(ctx, &listOfDeploymentToApplicationMappingFromDB, 3, 1)
+			Expect(err).To(BeNil())
+			Expect(len(listOfDeploymentToApplicationMappingFromDB)).To(Equal(3))
 		})
 	})
 })

--- a/backend-shared/config/db/queries.go
+++ b/backend-shared/config/db/queries.go
@@ -114,6 +114,9 @@ type DatabaseQueries interface {
 
 	GetDeploymentToApplicationMappingByApplicationId(ctx context.Context, deplToAppMappingParam *DeploymentToApplicationMapping) error
 
+	// Get DeploymentToApplicationMappings in a batch. Batch size defined by 'limit' and starting point of batch is defined by 'offSet'.
+	GetDeploymentToApplicationMappingBatch(ctx context.Context, deploymentToApplicationMappings *[]DeploymentToApplicationMapping, limit, offSet int) error
+
 	UpdateManagedEnvironment(ctx context.Context, obj *ManagedEnvironment) error
 	DeleteGitopsEngineInstanceById(ctx context.Context, id string) (int, error)
 

--- a/backend/eventloop/db_reconciler test.go
+++ b/backend/eventloop/db_reconciler test.go
@@ -1,0 +1,216 @@
+package eventloop
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/tests"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
+	db "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logger "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var _ = Describe("DB Reconciler Test", func() {
+	Context("Tests for DB Reconciler functions.", func() {
+
+		var log logr.Logger
+		var ctx context.Context
+		var dbq db.AllDatabaseQueries
+		var k8sClient client.WithWatch
+		var application db.Application
+		var syncOperation db.SyncOperation
+		var applicationState db.ApplicationState
+		var managedEnvironment *db.ManagedEnvironment
+		var gitopsEngineInstance *db.GitopsEngineInstance
+		var gitopsDepl managedgitopsv1alpha1.GitOpsDeployment
+		var deploymentToApplicationMapping db.DeploymentToApplicationMapping
+
+		// Start the workspace event loop using single ApplicationEventLoopFactory object,
+		// this way all tests can keep track of number of event loops created by other tests.
+		BeforeEach(func() {
+			scheme,
+				argocdNamespace,
+				kubesystemNamespace,
+				apiNamespace,
+				err := tests.GenericTestSetup()
+			Expect(err).To(BeNil())
+
+			// Create fake client
+			k8sClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(apiNamespace, argocdNamespace, kubesystemNamespace).
+				Build()
+
+			err = db.SetupForTestingDBGinkgo()
+			Expect(err).To(BeNil())
+
+			ctx = context.Background()
+			log = logger.FromContext(ctx)
+			dbq, err = db.NewUnsafePostgresDBQueries(true, true)
+			Expect(err).To(BeNil())
+
+			_, managedEnvironment, _, gitopsEngineInstance, _, err = db.CreateSampleData(dbq)
+			Expect(err).To(BeNil())
+
+			// Create Application entry
+			application = db.Application{
+				Application_id:          "test-my-application",
+				Name:                    "my-application",
+				Spec_field:              "{}",
+				Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
+				Managed_environment_id:  managedEnvironment.Managedenvironment_id,
+			}
+			err = dbq.CreateApplication(ctx, &application)
+			Expect(err).To(BeNil())
+
+			// Create ApplicationState entry
+			applicationState = db.ApplicationState{
+				Applicationstate_application_id: application.Application_id,
+				Health:                          "Healthy",
+				Sync_Status:                     "Synced",
+				ReconciledState:                 "Healthy",
+			}
+			err = dbq.CreateApplicationState(ctx, &applicationState)
+			Expect(err).To(BeNil())
+
+			// Create DeploymentToApplicationMapping entry
+			deploymentToApplicationMapping = db.DeploymentToApplicationMapping{
+				Deploymenttoapplicationmapping_uid_id: "test-" + uuid.New().String(),
+				Application_id:                        application.Application_id,
+				DeploymentName:                        "test-deployment",
+				DeploymentNamespace:                   "test-namespace",
+				NamespaceUID:                          "demo-namespace",
+			}
+			err = dbq.CreateDeploymentToApplicationMapping(ctx, &deploymentToApplicationMapping)
+			Expect(err).To(BeNil())
+
+			// Create GitOpsDeployment CR in cluster
+			gitopsDepl = managedgitopsv1alpha1.GitOpsDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      deploymentToApplicationMapping.DeploymentName,
+					Namespace: deploymentToApplicationMapping.DeploymentNamespace,
+					UID:       types.UID(uuid.New().String()),
+				},
+				Spec: managedgitopsv1alpha1.GitOpsDeploymentSpec{
+					Source: managedgitopsv1alpha1.ApplicationSource{},
+					Type:   managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated,
+				},
+			}
+			err = k8sClient.Create(context.Background(), &gitopsDepl)
+			Expect(err).To(BeNil())
+
+			// Create SyncOperation entry
+			syncOperation = db.SyncOperation{
+				SyncOperation_id:    "test-syncOperation",
+				Application_id:      application.Application_id,
+				Revision:            "master",
+				DeploymentNameField: deploymentToApplicationMapping.DeploymentName,
+				DesiredState:        "Synced",
+			}
+			err = dbq.CreateSyncOperation(ctx, &syncOperation)
+			Expect(err).To(BeNil())
+		})
+
+		var _ = Describe("Tests Database Reconciler utility function.", func() {
+			Context("It tests Database Reconciler utility function databaseReconcile().", func() {
+
+				It("Should not delete any of the database entries as GitOpsDeployment CR is present in cluster.", func() {
+					defer dbq.CloseDatabase()
+
+					By("Call databaseReconcile function to check/delete DB entries depending on existence of GitOpsDeployment CR in cluster.")
+
+					databaseReconcile(ctx, dbq, k8sClient, log)
+
+					By("Verify that no entry is deleted from DB.")
+					err := dbq.GetApplicationStateById(ctx, &applicationState)
+					Expect(err).To(BeNil())
+
+					err = dbq.GetSyncOperationById(ctx, &syncOperation)
+					Expect(err).To(BeNil())
+					Expect(syncOperation.Application_id).NotTo(BeEmpty())
+
+					err = dbq.GetDeploymentToApplicationMappingByApplicationId(ctx, &deploymentToApplicationMapping)
+					Expect(err).To(BeNil())
+
+					err = dbq.GetApplicationById(ctx, &application)
+					Expect(err).To(BeNil())
+				})
+
+				It("Should delete related database entries from DB, as some GitOpsDeployment CRs are not present in cluster. ", func() {
+					defer dbq.CloseDatabase()
+
+					// Create another Application entry
+					applicationOne := application
+					applicationOne.Application_id = "test-my-application-1"
+					applicationOne.Name = "my-application-1"
+					err := dbq.CreateApplication(ctx, &applicationOne)
+					Expect(err).To(BeNil())
+
+					// Create another DeploymentToApplicationMapping entry
+					deploymentToApplicationMappingOne := deploymentToApplicationMapping
+					deploymentToApplicationMappingOne.Deploymenttoapplicationmapping_uid_id = "test-" + uuid.New().String()
+					deploymentToApplicationMappingOne.Application_id = applicationOne.Application_id
+					deploymentToApplicationMappingOne.DeploymentName = "test-deployment-1"
+					err = dbq.CreateDeploymentToApplicationMapping(ctx, &deploymentToApplicationMappingOne)
+					Expect(err).To(BeNil())
+
+					// Create another ApplicationState entry
+					applicationStateOne := applicationState
+					applicationStateOne.Applicationstate_application_id = applicationOne.Application_id
+					err = dbq.CreateApplicationState(ctx, &applicationStateOne)
+					Expect(err).To(BeNil())
+
+					// Create another SyncOperation entry
+					syncOperationOne := syncOperation
+					syncOperationOne.SyncOperation_id = "test-syncOperation-1"
+					syncOperationOne.Application_id = applicationOne.Application_id
+					syncOperationOne.DeploymentNameField = deploymentToApplicationMappingOne.DeploymentName
+					err = dbq.CreateSyncOperation(ctx, &syncOperationOne)
+					Expect(err).To(BeNil())
+
+					By("Call databaseReconcile function to check/delete DB entries depending on existence of GitOpsDeployment CR in cluster.")
+
+					databaseReconcile(ctx, dbq, k8sClient, log)
+
+					By("Verify that entries for the GitOpsDeployment which is available in cluster, are not deleted from DB.")
+
+					err = dbq.GetApplicationStateById(ctx, &applicationState)
+					Expect(err).To(BeNil())
+
+					err = dbq.GetSyncOperationById(ctx, &syncOperation)
+					Expect(err).To(BeNil())
+					Expect(syncOperation.Application_id).To(Equal(application.Application_id))
+
+					err = dbq.GetDeploymentToApplicationMappingByApplicationId(ctx, &deploymentToApplicationMapping)
+					Expect(err).To(BeNil())
+
+					err = dbq.GetApplicationById(ctx, &application)
+					Expect(err).To(BeNil())
+
+					By("Verify that entries for the GitOpsDeployment which is not available in cluster, are deleted from DB.")
+
+					err = dbq.GetApplicationStateById(ctx, &applicationStateOne)
+					Expect(err).NotTo(BeNil())
+
+					err = dbq.GetSyncOperationById(ctx, &syncOperationOne)
+					Expect(err).To(BeNil())
+					Expect(syncOperationOne.Application_id).To(BeEmpty())
+
+					err = dbq.GetDeploymentToApplicationMappingByApplicationId(ctx, &deploymentToApplicationMappingOne)
+					Expect(err).NotTo(BeNil())
+
+					err = dbq.GetApplicationById(ctx, &applicationOne)
+					Expect(err).NotTo(BeNil())
+				})
+			})
+		})
+	})
+})

--- a/backend/eventloop/db_reconciler.go
+++ b/backend/eventloop/db_reconciler.go
@@ -1,0 +1,195 @@
+package eventloop
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
+	db "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
+	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	appRowBatchSize            = 50               // Number of rows needs to be fetched in each batch.
+	databaseReconcilerInterval = 30 * time.Minute // Interval in Minutes to reconcile Database.
+	sleepIntervalsOfBatches    = 1 * time.Second  // Interval in Millisecond between each batch.
+)
+
+// DatabaseReconciler reconciles Database entries
+type DatabaseReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	DB     db.DatabaseQueries
+}
+
+// This function iterates through each entry present of DeploymentToApplicationMapping table in DB and ensures that the required GitOpsDeployment CR is present in cluster.
+func (r *DatabaseReconciler) StartDatabaseReconciler() {
+	r.startTimerForNextCycle()
+}
+
+func (r *DatabaseReconciler) startTimerForNextCycle() {
+	go func() {
+		// Timer to trigger Reconciler
+		timer := time.NewTimer(time.Duration(databaseReconcilerInterval))
+		<-timer.C
+
+		ctx := context.Background()
+		log := log.FromContext(ctx).WithValues("component", "database-reconciler")
+
+		_, _ = sharedutil.CatchPanic(func() error {
+			databaseReconcile(ctx, r.DB, r.Client, log)
+			return nil
+		})
+
+		// Kick off the timer again, once the old task runs.
+		// This ensures that at least 'databaseReconcilerInterval' time elapses from the end of one run to the beginning of another.
+		r.startTimerForNextCycle()
+	}()
+
+}
+
+func databaseReconcile(ctx context.Context, dbQueries db.DatabaseQueries, client client.Client, log logr.Logger) {
+	offSet := 0
+
+	// Continuously iterate and fetch batches until all entries of DeploymentToApplicationMapping table are processed.
+	for {
+		if offSet != 0 {
+			time.Sleep(sleepIntervalsOfBatches)
+		}
+
+		var listOfdeplToAppMapping []db.DeploymentToApplicationMapping
+
+		// Fetch DeploymentToApplicationMapping table entries in batch size as configured above.​
+		if err := dbQueries.GetDeploymentToApplicationMappingBatch(ctx, &listOfdeplToAppMapping, appRowBatchSize, offSet); err != nil {
+			log.Error(err, fmt.Sprintf("Error occurred in Database Reconcile while fetching batch from Offset: %d to %d: ",
+				offSet, offSet+appRowBatchSize))
+			break
+		}
+
+		// Break the loop if no entries are left in table to be processed.
+		if len(listOfdeplToAppMapping) == 0 {
+			log.Info("All DeploymentToApplicationMapping entries are processed by Database Reconciler.")
+			break
+		}
+
+		// Iterate over batch received above.
+		for i := range listOfdeplToAppMapping {
+			deplToAppMappingFromDB := listOfdeplToAppMapping[i] // To avoid "Implicit memory aliasing in for loop." error.
+			gitOpsDeployment := managedgitopsv1alpha1.GitOpsDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      deplToAppMappingFromDB.DeploymentName,
+					Namespace: deplToAppMappingFromDB.DeploymentNamespace,
+				},
+			}
+
+			if err := client.Get(ctx, types.NamespacedName{Name: deplToAppMappingFromDB.DeploymentName, Namespace: deplToAppMappingFromDB.DeploymentNamespace}, &gitOpsDeployment); err != nil {
+				if apierr.IsNotFound(err) {
+					log.Info("GitOpsDeployment " + gitOpsDeployment.Name + " not found in Cluster, probably user deleted it, " +
+						"but it still exists in DB, hence deleting related database entries.")
+
+					// If GitOpsDeployment CR is not found in cluster, delete related entries from table
+					err = cleanEntriesFromDb(ctx, &deplToAppMappingFromDB, dbQueries, log)
+					if err != nil {
+						log.Error(err, "Error occurred in Database Reconciler while cleaning GitOpsDeployment entries from DB: "+gitOpsDeployment.Name)
+					}
+				} else {
+					log.Error(err, "Error occurred in Database Reconciler while fetching GitOpsDeployment from cluster: "+gitOpsDeployment.Name)
+				}
+			}
+
+			log.Info("Database Reconcile processed deploymentToApplicationMapping entry: " + deplToAppMappingFromDB.Deploymenttoapplicationmapping_uid_id)
+		}
+
+		// Skip processed entries in next iteration
+		offSet += appRowBatchSize
+	}
+}
+
+// Delete database entries related to a GitOpsDeployment
+func cleanEntriesFromDb(ctx context.Context, deplToAppMapping *db.DeploymentToApplicationMapping,
+	dbQueries db.ApplicationScopedQueries, logger logr.Logger) error {
+	dbApplicationFound := true
+
+	// If the gitopsdepl CR doesn't exist, but database row does, then the CR has been deleted, so handle it.
+	dbApplication := db.Application{
+		Application_id: deplToAppMapping.Application_id,
+	}
+
+	if err := dbQueries.GetApplicationById(ctx, &dbApplication); err != nil {
+		logger.Error(err, "unable to get application by id", "id", deplToAppMapping.Application_id)
+
+		if db.IsResultNotFoundError(err) {
+			dbApplicationFound = false
+			// Log the error, but continue.
+		} else {
+			return err
+		}
+	}
+
+	log := logger.WithValues("applicationID", deplToAppMapping.Application_id)
+
+	// 1) Remove the ApplicationState from the database
+	rowsDeleted, err := dbQueries.DeleteApplicationStateById(ctx, deplToAppMapping.Application_id)
+	if err != nil {
+		log.V(sharedutil.LogLevel_Warn).Error(err, "unable to delete application state by id")
+		return err
+	} else if rowsDeleted == 0 {
+		// Log the warning, but continue
+		log.Info("No ApplicationState rows were found, while cleaning up after deleted GitOpsDeployment", "rowsDeleted", rowsDeleted)
+	} else {
+		log.Info("ApplicationState rows were successfully deleted, while cleaning up after deleted GitOpsDeployment", "rowsDeleted", rowsDeleted)
+	}
+
+	// 2) Set the application field of SyncOperations to nil, for all SyncOperations that point to this Application
+	// - this ensures that the foreign key constraint of SyncOperation doesn't prevent us from deletion the Application
+	rowsUpdated, err := dbQueries.UpdateSyncOperationRemoveApplicationField(ctx, deplToAppMapping.Application_id)
+	if err != nil {
+		log.Error(err, "unable to update old sync operations", "applicationId", deplToAppMapping.Application_id)
+		return err
+	} else if rowsUpdated == 0 {
+		log.Info("no SyncOperation rows updated, for updating old syncoperations on GitOpsDeployment deletion")
+	} else {
+		log.Info("Removed references to Application from all SyncOperations that reference it")
+	}
+
+	// 3) Delete DeplToAppMapping row that points to this Application
+	rowsDeleted, err = dbQueries.DeleteDeploymentToApplicationMappingByDeplId(ctx, deplToAppMapping.Deploymenttoapplicationmapping_uid_id)
+	if err != nil {
+		log.Error(err, "unable to delete deplToAppMapping by id", "deplToAppMapUid", deplToAppMapping.Deploymenttoapplicationmapping_uid_id)
+		return err
+	} else if rowsDeleted == 0 {
+		// Log the warning, but continue
+		log.V(sharedutil.LogLevel_Warn).Error(nil, "unexpected number of rows deleted for deplToAppMapping", "rowsDeleted", rowsDeleted)
+	} else {
+		log.Info("While cleaning up after deleted GitOpsDeployment, deleted deplToAppMapping", "deplToAppMapUid", deplToAppMapping.Deploymenttoapplicationmapping_uid_id)
+	}
+
+	if !dbApplicationFound {
+		log.Info("While cleaning up old gitopsdepl entries, the Application row wasn't found. No more work to do.")
+		// If the Application CR no longer exists, then our work is done.
+		return nil
+	}
+
+	// If the Application table entry still exists, finish the cleanup...
+
+	// 4) Remove the Application from the database
+	log.Info("GitOpsDeployment was deleted, so deleting Application row from database")
+	rowsDeleted, err = dbQueries.DeleteApplicationById(ctx, deplToAppMapping.Application_id)
+	if err != nil {
+		// Log the error, but continue
+		log.Error(err, "unable to delete application by id")
+	} else if rowsDeleted == 0 {
+		// Log the error, but continue
+		log.V(sharedutil.LogLevel_Warn).Error(nil, "unexpected number of rows deleted for application", "rowsDeleted", rowsDeleted)
+	}
+	return nil
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/golang/mock v1.6.0
 	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/uuid v1.3.0
 	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3
 	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.1
@@ -55,7 +56,6 @@ require (
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/backend/main.go
+++ b/backend/main.go
@@ -161,24 +161,7 @@ func main() {
 	}
 	//+kubebuilder:scaffold:builder
 
-	//==============================================
-	// Process to trigger Database Reconciler
-
-	dbQueries, err := db.NewSharedProductionPostgresDBQueries(false)
-	if err != nil {
-		setupLog.Error(err, "never able to connect to database")
-		os.Exit(1)
-	}
-
-	databaseReconciler := eventloop.DatabaseReconciler{
-		DB:     dbQueries,
-		Client: mgr.GetClient(),
-	}
-
-	// Trigger goroutine for database reconciler
-	databaseReconciler.StartDatabaseReconciler()
-	//==============================================
-
+	startDBReconciler(mgr)
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
@@ -199,6 +182,23 @@ func main() {
 		os.Exit(1)
 	}
 
+}
+
+func startDBReconciler(mgr ctrl.Manager) {
+
+	dbQueries, err := db.NewSharedProductionPostgresDBQueries(false)
+	if err != nil {
+		setupLog.Error(err, "never able to connect to database")
+		os.Exit(1)
+	}
+
+	databaseReconciler := eventloop.DatabaseReconciler{
+		DB:     dbQueries,
+		Client: mgr.GetClient(),
+	}
+
+	// Start goroutine for database reconciler
+	databaseReconciler.StartDatabaseReconciler()
 }
 
 func initializeRoutes() {

--- a/utilities/db-migration/go.mod
+++ b/utilities/db-migration/go.mod
@@ -46,7 +46,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/onsi/ginkgo/v2 v2.1.4 // indirect
 	github.com/onsi/gomega v1.20.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect

--- a/utilities/db-migration/go.sum
+++ b/utilities/db-migration/go.sum
@@ -919,7 +919,6 @@ github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.1.4 h1:GNapqRSid3zijZ9H77KrgVG4/8KqiyRsxcSxe+7ApXY=
-github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=


### PR DESCRIPTION
## Description
This PR is to add a Periodic job (DatabaseReconciler) which will run in background to detect such DeploymentToApplicationMappings entries which don't have respective GitOpsDeployment CR present in cluster and delete all related entries from DB.

## Jira Ticket
https://issues.redhat.com/browse/GITOPSRVCE-286
