### PR TITLE
Refactor and add unit tests for GitOpsDeploymentSyncRun 

### DIFF
--- a/backend-shared/config/db/queries.go
+++ b/backend-shared/config/db/queries.go
@@ -180,6 +180,7 @@ type ApplicationScopedQueries interface {
 	CreateSyncOperation(ctx context.Context, obj *SyncOperation) error
 	GetSyncOperationById(ctx context.Context, syncOperation *SyncOperation) error
 	DeleteSyncOperationById(ctx context.Context, id string) (int, error)
+	UpdateSyncOperation(ctx context.Context, obj *SyncOperation) error
 
 	CreateApplication(ctx context.Context, obj *Application) error
 	CheckedCreateApplication(ctx context.Context, obj *Application, ownerId string) error

--- a/backend-shared/config/db/syncoperation.go
+++ b/backend-shared/config/db/syncoperation.go
@@ -110,6 +110,34 @@ func (dbq *PostgreSQLDatabaseQueries) DeleteSyncOperationById(ctx context.Contex
 	return deleteResult.RowsAffected(), nil
 }
 
+func (dbq *PostgreSQLDatabaseQueries) UpdateSyncOperation(ctx context.Context, obj *SyncOperation) error {
+
+	if err := validateQueryParamsEntity(obj, dbq); err != nil {
+		return err
+	}
+
+	if err := isEmptyValues("UpdateSyncOperation",
+		"syncoperation_id", obj.SyncOperation_id,
+		"application_id", obj.Application_id,
+		"deployment_name", obj.DeploymentNameField,
+		"revision", obj.Revision,
+		"desired_state", obj.DesiredState,
+	); err != nil {
+		return err
+	}
+
+	result, err := dbq.dbConnection.Model(obj).WherePK().Context(ctx).Update()
+	if err != nil {
+		return fmt.Errorf("error on updating SyncOperation: %v, %v", err, obj.SyncOperation_id)
+	}
+
+	if result.RowsAffected() != 1 {
+		return fmt.Errorf("unexpected number of rows affected: %d, %v", result.RowsAffected(), obj.SyncOperation_id)
+	}
+
+	return nil
+}
+
 // UpdateSyncOperationRemoveApplicationField locates any SyncOperations that reference 'applicationID', and sets the
 // applicationID field to nil.
 func (dbq *PostgreSQLDatabaseQueries) UpdateSyncOperationRemoveApplicationField(ctx context.Context, applicationId string) (int, error) {

--- a/backend-shared/config/db/syncoperation_test.go
+++ b/backend-shared/config/db/syncoperation_test.go
@@ -71,6 +71,16 @@ var _ = Describe("SyncOperation Tests", func() {
 			Expect(err).To(BeNil())
 			Expect(fetchRow).Should(Equal(insertRow))
 
+			updatedSyncOperation := insertRow
+			updatedSyncOperation.DesiredState = "Running"
+
+			err = dbq.UpdateSyncOperation(ctx, &updatedSyncOperation)
+			Expect(err).To(BeNil())
+
+			err = dbq.GetSyncOperationById(ctx, &fetchRow)
+			Expect(err).To(BeNil())
+			Expect(fetchRow.DesiredState).Should(Equal(updatedSyncOperation.DesiredState))
+
 			rowCount, err := dbq.DeleteSyncOperationById(ctx, insertRow.SyncOperation_id)
 			Expect(err).To(BeNil())
 			Expect(rowCount).Should(Equal(1))

--- a/backend-shared/config/db/types.go
+++ b/backend-shared/config/db/types.go
@@ -196,6 +196,7 @@ type Operation struct {
 	// * GitopsEngineInstance (specified to CRUD an Argo instance, for example to create a new namespace and put Argo CD in it, then signal when it's done)
 	// * Application (user creates a new Application via service/web UI)
 	// * RepositoryCredentials (user provides private repository credentials via web UI)
+	// * SyncOperation (specified when user wants to sync an Argo CD Application)
 	Resource_type OperationResourceType `pg:"resource_type"`
 
 	// -- When the operation was created. Used for garbage collection, as operations should be short lived.

--- a/backend/eventloop/application_event_loop/application_event_runner.go
+++ b/backend/eventloop/application_event_loop/application_event_runner.go
@@ -159,7 +159,7 @@ func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent
 				} else if newEvent.EventType == eventlooptypes.SyncRunModified {
 
 					// Handle all SyncRun related events
-					_, err = action.applicationEventRunner_handleSyncRunModified(ctx, scopedDBQueries)
+					signalledShutdown, err = action.applicationEventRunner_handleSyncRunModified(ctx, scopedDBQueries)
 
 				} else if newEvent.EventType == eventlooptypes.UpdateDeploymentStatusTick {
 					err = action.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDeploymentName, gitopsDeploymentNamespace, scopedDBQueries)

--- a/backend/eventloop/application_event_loop/application_event_runner.go
+++ b/backend/eventloop/application_event_loop/application_event_runner.go
@@ -159,7 +159,7 @@ func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent
 				} else if newEvent.EventType == eventlooptypes.SyncRunModified {
 
 					// Handle all SyncRun related events
-					signalledShutdown, err = action.applicationEventRunner_handleSyncRunModified(ctx, scopedDBQueries)
+					err = action.applicationEventRunner_handleSyncRunModified(ctx, scopedDBQueries)
 
 				} else if newEvent.EventType == eventlooptypes.UpdateDeploymentStatusTick {
 					err = action.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDeploymentName, gitopsDeploymentNamespace, scopedDBQueries)

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
@@ -459,6 +459,18 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleSyncRun
 
 }
 
+func (a *applicationEventLoopRunner_Action) handleDeletedGitOpsDeplSynRunEvent(ctx context.Context) {
+
+}
+
+func (a *applicationEventLoopRunner_Action) handleNewGitOpsDeplSynRunEvent(ctx context.Context) {
+
+}
+
+func (a *applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplSynRunEvent(ctx context.Context) {
+
+}
+
 func (a *applicationEventLoopRunner_Action) cleanupOldSyncDBEntry(ctx context.Context, apiCRToDB *db.APICRToDatabaseMapping,
 	clusterUser db.ClusterUser, dbQueries db.ApplicationScopedQueries) error {
 

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
@@ -39,8 +39,6 @@ func (action *applicationEventLoopRunner_Action) applicationEventRunner_handleSy
 func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleSyncRunModifiedInternal(ctx context.Context,
 	dbQueries db.ApplicationScopedQueries) (bool, gitopserrors.UserError) {
 
-	// TODO: GITOPSRVCE-166: This function can likely be broken up into a few smaller function, for readability/maintainability.
-
 	log := a.log
 
 	namespace := corev1.Namespace{}
@@ -81,6 +79,12 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleSyncRun
 	var apiCRToDBList []db.APICRToDatabaseMapping
 	dbEntryExists := false
 	if syncRunCRExists {
+
+		if syncRunCR == (&managedgitopsv1alpha1.GitOpsDeploymentSyncRun{}) {
+			err := fmt.Errorf("SEVERE - sync run cr is empty")
+			log.Error(err, err.Error())
+			return false, gitopserrors.NewDevOnlyError(err)
+		}
 
 		mapping := db.APICRToDatabaseMapping{
 			APIResourceType: db.APICRToDatabaseMapping_ResourceType_GitOpsDeploymentSyncRun,
@@ -136,6 +140,35 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleSyncRun
 		return true, nil
 	}
 
+	// Get the SyncOperation table entry pointed to by the resource
+	var syncOperation db.SyncOperation
+
+	if dbEntryExists {
+
+		if len(apiCRToDBList) != 1 {
+			err := fmt.Errorf("SEVERE - Update only supports one operation parameter")
+			log.Error(err, err.Error())
+			return false, gitopserrors.NewDevOnlyError(err)
+		}
+
+		apiCRToDBMapping := apiCRToDBList[0]
+
+		if apiCRToDBMapping.DBRelationType != db.APICRToDatabaseMapping_DBRelationType_SyncOperation {
+			err := fmt.Errorf("SEVERE - db relation type should be syncoperation")
+			log.Error(err, err.Error())
+			return false, gitopserrors.NewDevOnlyError(err)
+		}
+
+		syncOperation = db.SyncOperation{SyncOperation_id: apiCRToDBMapping.DBRelationKey}
+
+		if err := dbQueries.GetSyncOperationById(ctx, &syncOperation); err != nil {
+
+			log.Error(err, "unable to retrieve sync operation by id on modified", "operationID", syncOperation.SyncOperation_id)
+			return false, gitopserrors.NewDevOnlyError(err)
+		}
+
+	}
+
 	// The applications and gitopsengineinstance pointed to by the gitopsdeployment (if they are non-nil)
 	var application *db.Application
 	var gitopsEngineInstance *db.GitopsEngineInstance
@@ -143,9 +176,6 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleSyncRun
 	// TODO: GITOPSRVCE-166: Make sure that the GitOpsDeployment UID doesn't change on us, vs what is in SyncOperation in the database.
 
 	if syncRunCRExists {
-
-		// TODO: GITOPSRVCE-166: It seems like this needs to change: we should retrieve the SyncOperation associated with the GitOpsDeploymentSyncRun, and sanity check it is equal. This can be handled while refactoring this function.
-
 		// Sanity check that the gitopsdeployment resource exists, which is referenced by the syncrun resource
 		gitopsDepl := &managedgitopsv1alpha1.GitOpsDeployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -193,282 +223,251 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleSyncRun
 			return false, gitopserrors.NewDevOnlyError(err)
 		}
 
-	}
+		if dbEntryExists {
+			// Handle update:
+			// If both GitOpsDeploymentSyncRun CR and the DB entry exists, then the CR is being updated.
+			// Validate and return an error if the immutable fields are updated.
+			return a.handleUpdatedGitOpsDeplSynRunEvent(ctx, syncRunCR, dbQueries, syncOperation)
+		} else {
+			// Handle create:
+			// If the gitopsdeplsyncrun CR exists, but the database entry doesn't, then this is the first time we
+			// have seen the GitOpsDeplSyncRun CR.
+			// Create it in the DB and create the operation.
 
-	// Create a gitOpsDeploymentAdapter to plug any conditions
-	gitopsDeployment := &managedgitopsv1alpha1.GitOpsDeployment{}
-	gitopsDeploymentKey := client.ObjectKey{Namespace: syncRunCR.Namespace, Name: syncRunCR.Spec.GitopsDeploymentName}
-
-	// Retrieve latest version of GitOpsDeployment object to set status.condition.
-	if clientErr := a.workspaceClient.Get(ctx, gitopsDeploymentKey, gitopsDeployment); clientErr != nil {
-		log.Error(err, "unable to retrieve gitopsDeployment.")
-	}
-
-	if syncRunCRExists && !dbEntryExists {
-		// Handle create:
-		// If the gitopsdeplsyncrun CR exists, but the database entry doesn't, then this is the first time we
-		// have seen the GitOpsDeplSyncRun CR.
-		// Create it in the DB and create the operation.
-
-		if application == nil || gitopsEngineInstance == nil {
-			err := fmt.Errorf("app or engine instance were nil in handleSyncRunModified app: %v, instance: %v", application, gitopsEngineInstance)
-			log.Error(err, "unexpected nil value of required objects")
-			return false, gitopserrors.NewDevOnlyError(err)
+			return a.handleNewGitOpsDeplSynRunEvent(ctx, syncRunCR, dbQueries, application, gitopsEngineInstance, namespace, *clusterUser)
 		}
 
-		// createdResources is a list of database entries created in this function; if an error occurs, we delete them
-		// in reverse order.
-		var createdResources []db.AppScopedDisposableResource
-
-		// Create sync operation
-		syncOperation := &db.SyncOperation{
-			Application_id:      application.Application_id,
-			DeploymentNameField: syncRunCR.Spec.GitopsDeploymentName,
-			Revision:            syncRunCR.Spec.RevisionID,
-			DesiredState:        db.SyncOperation_DesiredState_Running,
-		}
-		if err := dbQueries.CreateSyncOperation(ctx, syncOperation); err != nil {
-			log.Error(err, "unable to create sync operation in database")
-
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-		createdResources = append(createdResources, syncOperation)
-		log.Info("Created a Sync Operation: " + syncOperation.SyncOperation_id)
-
-		newApiCRToDBMapping := db.APICRToDatabaseMapping{
-			APIResourceType: db.APICRToDatabaseMapping_ResourceType_GitOpsDeploymentSyncRun,
-			APIResourceUID:  string(syncRunCR.UID),
-			DBRelationType:  db.APICRToDatabaseMapping_DBRelationType_SyncOperation,
-			DBRelationKey:   syncOperation.SyncOperation_id,
-
-			APIResourceName:      syncRunCR.Name,
-			APIResourceNamespace: syncRunCR.Namespace,
-			NamespaceUID:         eventlooptypes.GetWorkspaceIDFromNamespaceID(namespace),
-		}
-		if err := dbQueries.CreateAPICRToDatabaseMapping(ctx, &newApiCRToDBMapping); err != nil {
-			log.Error(err, "unable to create api to db mapping in database")
-
-			// If we were unable to retrieve the client, delete the resources we created in the previous steps
-			dbutil.DisposeApplicationScopedResources(ctx, createdResources, dbQueries, log)
-
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-		log.Info(fmt.Sprintf("Created a ApiCRToDBMapping: (APIResourceType: %s, APIResourceUID: %s, DBRelationType: %s)", newApiCRToDBMapping.APIResourceType, newApiCRToDBMapping.APIResourceUID, newApiCRToDBMapping.DBRelationType))
-		createdResources = append(createdResources, &newApiCRToDBMapping)
-
-		operationClient, err := a.getK8sClientForGitOpsEngineInstance(ctx, gitopsEngineInstance)
-		if err != nil {
-			log.Error(err, "unable to retrieve gitopsengine instance from handleSyncRunModified")
-
-			// If we were unable to retrieve the client, delete the resources we created in the previous steps
-			dbutil.DisposeApplicationScopedResources(ctx, createdResources, dbQueries, log)
-
-			// Return the original error
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		dbOperationInput := db.Operation{
-			Instance_id:   gitopsEngineInstance.Gitopsengineinstance_id,
-			Resource_id:   syncOperation.SyncOperation_id,
-			Resource_type: db.OperationResourceType_SyncOperation,
-		}
-
-		k8sOperation, dbOperation, err := operations.CreateOperation(ctx, false && !a.testOnlySkipCreateOperation, dbOperationInput, clusterUser.Clusteruser_id,
-			dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, operationClient, log)
-		if err != nil {
-			log.Error(err, "could not create operation", "namespace", dbutil.GetGitOpsEngineSingleInstanceNamespace())
-
-			// If we were unable to create the operation, delete the resources we created in the previous steps
-			dbutil.DisposeApplicationScopedResources(ctx, createdResources, dbQueries, log)
-
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		// TODO: GITOPSRVCE-82 - STUB - Remove the 'false' in createOperation above, once cluster agent handling of operation is implemented.
-		log.Info("STUB: Not waiting for create Sync Run operation to complete, in handleNewSyncRunModified")
-
-		if err := operations.CleanupOperation(ctx, *dbOperation, *k8sOperation, dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, operationClient, log); err != nil {
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		return false, nil
 	}
 
 	if !syncRunCRExists && dbEntryExists {
 		// Handle delete:
 		// If the gitopsdeplsyncrun CR doesn't exist, but database row does, then the CR has been deleted, so handle it.
 
-		// Deleting the CR should terminate a sync operation, if it was previously in progress.
-
-		if len(apiCRToDBList) != 1 {
-			err := fmt.Errorf("SEVERE - Update only supports one operation parameter")
-			log.Error(err, err.Error())
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		// 1) Get the SyncOperation table entry pointed to by the resource
-		apiCRToDBMapping := apiCRToDBList[0]
-
-		if apiCRToDBMapping.DBRelationType != db.APICRToDatabaseMapping_DBRelationType_SyncOperation {
-			err := fmt.Errorf("SEVERE - db relation type should be syncoperation")
-			log.Error(err, err.Error())
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		syncOperation := db.SyncOperation{SyncOperation_id: apiCRToDBMapping.DBRelationKey}
-
-		if err := dbQueries.GetSyncOperationById(ctx, &syncOperation); err != nil {
-			log.Error(err, "unable to retrieve sync operation by id on deleted", "operationID", syncOperation.SyncOperation_id)
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		// 2) Update the state of the SyncOperation DB table to say that we want to terminate it, if it is runing
-		syncOperation.DesiredState = db.SyncOperation_DesiredState_Terminated
-		if err := dbQueries.UpdateSyncOperation(ctx, &syncOperation); err != nil {
-			log.Error(err, "unable to update the sync operation as terminated", "syncOperationID", syncOperation.SyncOperation_id)
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		application = &db.Application{Application_id: syncOperation.Application_id}
-		if err := dbQueries.GetApplicationById(ctx, application); err != nil {
-			log.Error(err, "unable to retrieve application, on sync run modified", "applicationId", string(syncOperation.Application_id))
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		if gitopsEngineInstance, err = a.sharedResourceEventLoop.GetGitopsEngineInstanceById(ctx, application.Engine_instance_inst_id,
-			a.workspaceClient, namespace, a.log); err != nil {
-
-			log.Error(err, "unable to retrieve gitopsengineinstance, on sync run modified", "instanceId", string(application.Engine_instance_inst_id))
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		dbOperationInput := db.Operation{
-			Instance_id:   gitopsEngineInstance.Gitopsengineinstance_id,
-			Resource_id:   syncOperation.SyncOperation_id,
-			Resource_type: db.OperationResourceType_SyncOperation,
-		}
-
-		// 3) Create the operation, in order to inform the cluster agent it needs to cancel the sync operation
-		operationClient, err := a.getK8sClientForGitOpsEngineInstance(ctx, gitopsEngineInstance)
-		if err != nil {
-			log.Error(err, "unable to retrieve gitopsengine instance from handleSyncRunModified, when resource was deleted")
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		waitForOperation := !a.testOnlySkipCreateOperation // if it's for a unit test, we don't wait for the operation
-		k8sOperation, dbOperation, err := operations.CreateOperation(ctx, waitForOperation, dbOperationInput, clusterUser.Clusteruser_id,
-			dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, operationClient, log)
-		if err != nil {
-			log.Error(err, "could not create operation, when resource was deleted", "namespace", dbutil.GetGitOpsEngineSingleInstanceNamespace())
-
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		// 4) Clean up the operation and database table entries
-		if err := operations.CleanupOperation(ctx, *dbOperation, *k8sOperation, dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, operationClient, log); err != nil {
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		// TODO: GITOPSRVCE-82 - STUB - need to implement support for sync operation in cluster agent
-		log.Info("STUB: need to implement sync on cluster side")
-
-		if _, err := dbQueries.DeleteSyncOperationById(ctx, syncOperation.SyncOperation_id); err != nil {
-			log.Error(err, "could not delete sync operation, when resource was deleted", "namespace", dbutil.GetGitOpsEngineSingleInstanceNamespace())
-			return false, gitopserrors.NewDevOnlyError(err)
-		} else {
-			log.Info("Sync Operation deleted", "syncOperationID", syncOperation.SyncOperation_id)
-		}
-
-		var allErrors error
-
-		// Remove the mappings
-		for idx := range apiCRToDBList {
-
-			apiCRToDB := apiCRToDBList[idx]
-
-			err := a.cleanupOldSyncDBEntry(ctx, &apiCRToDB, *clusterUser, dbQueries)
-			if err != nil {
-				if allErrors == nil {
-					allErrors = err
-				} else {
-					allErrors = fmt.Errorf("error: %v error: %v", err, allErrors)
-				}
-			}
-		}
-
-		if allErrors != nil {
-			return false, gitopserrors.NewDevOnlyError(allErrors)
-		}
-
-		// Success: the CR no longer exists, and we have completed cleanup, so signal that the goroutine may be terminated.
-		return true, nil
-	}
-
-	if syncRunCRExists && dbEntryExists {
-
-		// Sanity checks
-		if syncRunCR == (&managedgitopsv1alpha1.GitOpsDeploymentSyncRun{}) {
-			err := fmt.Errorf("SEVERE - vsync run cr is empty")
-			log.Error(err, err.Error())
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		if len(apiCRToDBList) != 1 {
-			err := fmt.Errorf("SEVERE - Update only supports one operation parameter")
-			log.Error(err, err.Error())
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		// Get the SyncOperation table entry pointed to by the resource
-		apiCRToDBMapping := apiCRToDBList[0]
-
-		if apiCRToDBMapping.DBRelationType != db.APICRToDatabaseMapping_DBRelationType_SyncOperation {
-			err := fmt.Errorf("SEVERE - db relation type should be syncoperation")
-			log.Error(err, err.Error())
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		syncOperation := db.SyncOperation{SyncOperation_id: apiCRToDBMapping.DBRelationKey}
-
-		if err := dbQueries.GetSyncOperationById(ctx, &syncOperation); err != nil {
-
-			log.Error(err, "unable to retrieve sync operation by id on modified", "operationID", syncOperation.SyncOperation_id)
-			return false, gitopserrors.NewDevOnlyError(err)
-		}
-
-		if syncOperation.DeploymentNameField != syncRunCR.Spec.GitopsDeploymentName {
-			userErrorText := "deployment name field is immutable: changing it from its initial value is not supported"
-			err := fmt.Errorf(userErrorText)
-			log.Error(err, userErrorText)
-			return false, gitopserrors.NewUserDevError(userErrorText, err)
-		}
-
-		if syncOperation.Revision != syncRunCR.Spec.RevisionID {
-			userErrorText := "revision change is not supported: changing it from its initial value is not supported"
-			err := fmt.Errorf(userErrorText)
-			log.Error(err, "revision field change is not supported")
-			return false, gitopserrors.NewUserDevError(userErrorText, err)
-		}
-
-		// TODO: GITOPSRVCE-166 - DEBT - Include test case to check that the various goroutines are terminated when the CR is deleted.
-
-		return false, nil
+		return a.handleDeletedGitOpsDeplSynRunEvent(ctx, dbQueries, syncOperation, apiCRToDBList, namespace, clusterUser)
 	}
 
 	return false, nil
 
 }
 
-func (a *applicationEventLoopRunner_Action) handleDeletedGitOpsDeplSynRunEvent(ctx context.Context) {
+// handleDeletedGitOpsDeplSynRunEvent handles GitOpsDeploymentSyncRun events where the user has just deleted a GitOpsDeploymentSyncRun resource.
+// In this case, we need to update the state of the SyncOperation DB row to 'Terminated' and inform the cluster-agent component to cancel the sync operation.
+//
+// Finally, delete the SyncOperation and APICRToDBMapping rows in the database for this resource.
+//
+// Returns:
+// - true if the goroutine responsible for this GitOpsDeploymentSyncRun can shutdown (e.g. because the GitOpsDeploymentSyncRun no longer exists, so no longer needs to be processed), false otherwise.
+// - error is non-nil, if an error occurred
+func (a *applicationEventLoopRunner_Action) handleDeletedGitOpsDeplSynRunEvent(ctx context.Context, dbQueries db.ApplicationScopedQueries, syncOperation db.SyncOperation, apiCRToDBList []db.APICRToDatabaseMapping, namespace corev1.Namespace, clusterUser *db.ClusterUser) (bool, gitopserrors.UserError) {
+
+	// Deleting the CR should terminate a sync operation, if it was previously in progress.
+
+	log := a.log
+
+	// 1) Update the state of the SyncOperation DB table to say that we want to terminate it, if it is runing
+	syncOperation.DesiredState = db.SyncOperation_DesiredState_Terminated
+	if err := dbQueries.UpdateSyncOperation(ctx, &syncOperation); err != nil {
+		log.Error(err, "unable to update the sync operation as terminated", "syncOperationID", syncOperation.SyncOperation_id)
+		return false, gitopserrors.NewDevOnlyError(err)
+	}
+
+	application := &db.Application{Application_id: syncOperation.Application_id}
+	if err := dbQueries.GetApplicationById(ctx, application); err != nil {
+		log.Error(err, "unable to retrieve application, on sync run modified", "applicationId", string(syncOperation.Application_id))
+		return false, gitopserrors.NewDevOnlyError(err)
+	}
+
+	gitopsEngineInstance, err := a.sharedResourceEventLoop.GetGitopsEngineInstanceById(ctx, application.Engine_instance_inst_id,
+		a.workspaceClient, namespace, a.log)
+	if err != nil {
+
+		log.Error(err, "unable to retrieve gitopsengineinstance, on sync run modified", "instanceId", string(application.Engine_instance_inst_id))
+		return false, gitopserrors.NewDevOnlyError(err)
+	}
+
+	dbOperationInput := db.Operation{
+		Instance_id:   gitopsEngineInstance.Gitopsengineinstance_id,
+		Resource_id:   syncOperation.SyncOperation_id,
+		Resource_type: db.OperationResourceType_SyncOperation,
+	}
+
+	// 2) Create the operation, in order to inform the cluster agent it needs to cancel the sync operation
+	operationClient, err := a.getK8sClientForGitOpsEngineInstance(ctx, gitopsEngineInstance)
+	if err != nil {
+		log.Error(err, "unable to retrieve gitopsengine instance from handleSyncRunModified, when resource was deleted")
+		return false, gitopserrors.NewDevOnlyError(err)
+	}
+
+	waitForOperation := !a.testOnlySkipCreateOperation // if it's for a unit test, we don't wait for the operation
+	k8sOperation, dbOperation, err := operations.CreateOperation(ctx, waitForOperation, dbOperationInput, clusterUser.Clusteruser_id,
+		dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, operationClient, log)
+	if err != nil {
+		log.Error(err, "could not create operation, when resource was deleted", "namespace", dbutil.GetGitOpsEngineSingleInstanceNamespace())
+
+		return false, gitopserrors.NewDevOnlyError(err)
+	}
+
+	// 3) Clean up the operation and database table entries
+	if err := operations.CleanupOperation(ctx, *dbOperation, *k8sOperation, dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, operationClient, log); err != nil {
+		return false, gitopserrors.NewDevOnlyError(err)
+	}
+
+	// TODO: GITOPSRVCE-82 - STUB - need to implement support for sync operation in cluster agent
+	log.Info("STUB: need to implement sync on cluster side")
+
+	if _, err := dbQueries.DeleteSyncOperationById(ctx, syncOperation.SyncOperation_id); err != nil {
+		log.Error(err, "could not delete sync operation, when resource was deleted", "namespace", dbutil.GetGitOpsEngineSingleInstanceNamespace())
+		return false, gitopserrors.NewDevOnlyError(err)
+	} else {
+		log.Info("Sync Operation deleted", "syncOperationID", syncOperation.SyncOperation_id)
+	}
+
+	var allErrors error
+
+	// Remove the mappings
+	for idx := range apiCRToDBList {
+
+		apiCRToDB := apiCRToDBList[idx]
+
+		err := a.cleanupOldSyncDBEntry(ctx, &apiCRToDB, *clusterUser, dbQueries)
+		if err != nil {
+			if allErrors == nil {
+				allErrors = err
+			} else {
+				allErrors = fmt.Errorf("error: %v error: %v", err, allErrors)
+			}
+		}
+	}
+
+	if allErrors != nil {
+		return false, gitopserrors.NewDevOnlyError(allErrors)
+	}
+
+	// Success: the CR no longer exists, and we have completed cleanup, so signal that the goroutine may be terminated.
+	return true, nil
 
 }
 
-func (a *applicationEventLoopRunner_Action) handleNewGitOpsDeplSynRunEvent(ctx context.Context) {
+// handleNewGitOpsDeplSynRunEvent handles GitOpsDeploymentSyncRun events where the user has just created a new GitOpsDeploymentSyncRun resource.
+// In this case, we need to create SyncOperation and APICRToDBMapping rows in the database.
+//
+// Finally, we need to inform the cluster-agent component (via Operation), so that it can sync the Argo CD Application.
+//
+// Returns:
+// - true if the goroutine responsible for this GitOpsDeploymentSyncRun can shutdown (e.g. because the GitOpsDeploymentSyncRun no longer exists, so no longer needs to be processed), false otherwise.
+// - error is non-nil, if an error occurred
+func (a *applicationEventLoopRunner_Action) handleNewGitOpsDeplSynRunEvent(ctx context.Context, syncRunCR *managedgitopsv1alpha1.GitOpsDeploymentSyncRun, dbQueries db.ApplicationScopedQueries, application *db.Application, gitopsEngineInstance *db.GitopsEngineInstance, namespace corev1.Namespace, clusterUser db.ClusterUser) (bool, gitopserrors.UserError) {
 
+	log := a.log
+
+	if application == nil || gitopsEngineInstance == nil {
+		err := fmt.Errorf("app or engine instance were nil in handleSyncRunModified app: %v, instance: %v", application, gitopsEngineInstance)
+		log.Error(err, "unexpected nil value of required objects")
+		return false, gitopserrors.NewDevOnlyError(err)
+	}
+
+	// createdResources is a list of database entries created in this function; if an error occurs, we delete them
+	// in reverse order.
+	var createdResources []db.AppScopedDisposableResource
+
+	// Create sync operation
+	syncOperation := &db.SyncOperation{
+		Application_id:      application.Application_id,
+		DeploymentNameField: syncRunCR.Spec.GitopsDeploymentName,
+		Revision:            syncRunCR.Spec.RevisionID,
+		DesiredState:        db.SyncOperation_DesiredState_Running,
+	}
+	if err := dbQueries.CreateSyncOperation(ctx, syncOperation); err != nil {
+		log.Error(err, "unable to create sync operation in database")
+
+		return false, gitopserrors.NewDevOnlyError(err)
+	}
+	createdResources = append(createdResources, syncOperation)
+	log.Info("Created a Sync Operation: " + syncOperation.SyncOperation_id)
+
+	newApiCRToDBMapping := db.APICRToDatabaseMapping{
+		APIResourceType: db.APICRToDatabaseMapping_ResourceType_GitOpsDeploymentSyncRun,
+		APIResourceUID:  string(syncRunCR.UID),
+		DBRelationType:  db.APICRToDatabaseMapping_DBRelationType_SyncOperation,
+		DBRelationKey:   syncOperation.SyncOperation_id,
+
+		APIResourceName:      syncRunCR.Name,
+		APIResourceNamespace: syncRunCR.Namespace,
+		NamespaceUID:         eventlooptypes.GetWorkspaceIDFromNamespaceID(namespace),
+	}
+	if err := dbQueries.CreateAPICRToDatabaseMapping(ctx, &newApiCRToDBMapping); err != nil {
+		log.Error(err, "unable to create api to db mapping in database")
+
+		// If we were unable to retrieve the client, delete the resources we created in the previous steps
+		dbutil.DisposeApplicationScopedResources(ctx, createdResources, dbQueries, log)
+
+		return false, gitopserrors.NewDevOnlyError(err)
+	}
+	log.Info(fmt.Sprintf("Created a ApiCRToDBMapping: (APIResourceType: %s, APIResourceUID: %s, DBRelationType: %s)", newApiCRToDBMapping.APIResourceType, newApiCRToDBMapping.APIResourceUID, newApiCRToDBMapping.DBRelationType))
+	createdResources = append(createdResources, &newApiCRToDBMapping)
+
+	operationClient, err := a.getK8sClientForGitOpsEngineInstance(ctx, gitopsEngineInstance)
+	if err != nil {
+		log.Error(err, "unable to retrieve gitopsengine instance from handleSyncRunModified")
+
+		// If we were unable to retrieve the client, delete the resources we created in the previous steps
+		dbutil.DisposeApplicationScopedResources(ctx, createdResources, dbQueries, log)
+
+		// Return the original error
+		return false, gitopserrors.NewDevOnlyError(err)
+	}
+
+	dbOperationInput := db.Operation{
+		Instance_id:   gitopsEngineInstance.Gitopsengineinstance_id,
+		Resource_id:   syncOperation.SyncOperation_id,
+		Resource_type: db.OperationResourceType_SyncOperation,
+	}
+
+	k8sOperation, dbOperation, err := operations.CreateOperation(ctx, false && !a.testOnlySkipCreateOperation, dbOperationInput, clusterUser.Clusteruser_id,
+		dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, operationClient, log)
+	if err != nil {
+		log.Error(err, "could not create operation", "namespace", dbutil.GetGitOpsEngineSingleInstanceNamespace())
+
+		// If we were unable to create the operation, delete the resources we created in the previous steps
+		dbutil.DisposeApplicationScopedResources(ctx, createdResources, dbQueries, log)
+
+		return false, gitopserrors.NewDevOnlyError(err)
+	}
+
+	// TODO: GITOPSRVCE-82 - STUB - Remove the 'false' in createOperation above, once cluster agent handling of operation is implemented.
+	log.Info("STUB: Not waiting for create Sync Run operation to complete, in handleNewSyncRunModified")
+
+	if err := operations.CleanupOperation(ctx, *dbOperation, *k8sOperation, dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, operationClient, log); err != nil {
+		return false, gitopserrors.NewDevOnlyError(err)
+	}
+
+	return false, nil
 }
 
-func (a *applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplSynRunEvent(ctx context.Context) {
+// handleUpdatedGitOpsDeplSynRunEvent handles GitOpsDeploymentSyncRun events where the user has just updated an existing GitOpsDeploymentSyncRun resource.
+// In this case, we need to ensure that the immutable fields GitOpsDeploymentName and RevisionID are not updated.
+//
+// Returns:
+// - true if the goroutine responsible for this GitOpsDeploymentSyncRun can shutdown (e.g. because the GitOpsDeploymentSyncRun no longer exists, so no longer needs to be processed), false otherwise.
+// - error is non-nil, if an error occurred
+func (a *applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplSynRunEvent(ctx context.Context, syncRunCR *managedgitopsv1alpha1.GitOpsDeploymentSyncRun, dbQueries db.ApplicationScopedQueries, syncOperation db.SyncOperation) (bool, gitopserrors.UserError) {
+	log := a.log
 
+	if syncOperation.DeploymentNameField != syncRunCR.Spec.GitopsDeploymentName {
+		userErrorText := "deployment name field is immutable: changing it from its initial value is not supported"
+		err := fmt.Errorf(userErrorText)
+		log.Error(err, userErrorText)
+		return false, gitopserrors.NewUserDevError(userErrorText, err)
+	}
+
+	if syncOperation.Revision != syncRunCR.Spec.RevisionID {
+		userErrorText := "revision change is not supported: changing it from its initial value is not supported"
+		err := fmt.Errorf(userErrorText)
+		log.Error(err, "revision field change is not supported")
+		return false, gitopserrors.NewUserDevError(userErrorText, err)
+	}
+
+	return false, nil
 }
 
 func (a *applicationEventLoopRunner_Action) cleanupOldSyncDBEntry(ctx context.Context, apiCRToDB *db.APICRToDatabaseMapping,

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
@@ -441,7 +441,12 @@ func (a *applicationEventLoopRunner_Action) handleNewGitOpsDeplSyncRunEvent(ctx 
 outer_for:
 
 	for {
-		if isComplete, err := operations.IsOperationComplete(ctx, &dbOperationInput, dbQueries); err != nil {
+
+		if a.testOnlySkipCreateOperation {
+			break outer_for
+		}
+
+		if isComplete, err := operations.IsOperationComplete(ctx, dbOperation, dbQueries); err != nil {
 			log.Error(err, "an error occurred on retrieving operation status")
 
 			break outer_for

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns_test.go
@@ -1,0 +1,271 @@
+package application_event_loop
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
+	db "github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
+	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
+	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/tests"
+	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/shared_resource_loop"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var _ = Describe("Application Event Runner SyncRuns", func() {
+
+	Context("Handle GitOpsDeploymentSyncRun", func() {
+
+		var (
+			dbQueries         db.AllDatabaseQueries
+			k8sClient         client.Client
+			gitopsDepl        *managedgitopsv1alpha1.GitOpsDeployment
+			applicationAction applicationEventLoopRunner_Action
+			informer          sharedutil.ListEventReceiver
+			gitopsDeplSyncRun *managedgitopsv1alpha1.GitOpsDeploymentSyncRun
+		)
+		ctx := context.Background()
+
+		BeforeEach(func() {
+			scheme, argocdNamespace, kubesystemNamespace, workspace, err := tests.GenericTestSetup()
+			Expect(err).To(BeNil())
+
+			gitopsDepl = &managedgitopsv1alpha1.GitOpsDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-gitops-depl",
+					Namespace: workspace.Name,
+					UID:       uuid.NewUUID(),
+				},
+			}
+
+			gitopsDeplSyncRun = &managedgitopsv1alpha1.GitOpsDeploymentSyncRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gitops-syncrun",
+					Namespace: gitopsDepl.Namespace,
+					UID:       uuid.NewUUID(),
+				},
+				Spec: managedgitopsv1alpha1.GitOpsDeploymentSyncRunSpec{
+					GitopsDeploymentName: gitopsDepl.Name,
+					RevisionID:           "HEAD",
+				},
+			}
+
+			k8sClientOuter := fake.NewClientBuilder().WithScheme(scheme).WithObjects(workspace, argocdNamespace, kubesystemNamespace, gitopsDepl, gitopsDeplSyncRun).Build()
+
+			informer = sharedutil.ListEventReceiver{}
+			k8sClient = &sharedutil.ProxyClient{
+				InnerClient: k8sClientOuter,
+				Informer:    &informer,
+			}
+
+			dbQueries, err = db.NewUnsafePostgresDBQueries(true, false)
+			Expect(err).To(BeNil())
+
+			applicationAction = applicationEventLoopRunner_Action{
+				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
+					return k8sClient, nil
+				},
+				eventResourceName:           gitopsDepl.Name,
+				eventResourceNamespace:      gitopsDepl.Namespace,
+				sharedResourceEventLoop:     shared_resource_loop.NewSharedResourceLoop(),
+				workspaceClient:             k8sClient,
+				log:                         log.FromContext(ctx),
+				workspaceID:                 string(workspace.UID),
+				testOnlySkipCreateOperation: true,
+				k8sClientFactory: MockSRLK8sClientFactory{
+					fakeClient: k8sClient,
+				},
+			}
+
+			_, _, _, _, userDevErr := applicationAction.applicationEventRunner_handleDeploymentModified(ctx, dbQueries)
+			Expect(userDevErr).To(BeNil())
+
+			applicationAction.eventResourceName = "gitops-syncrun"
+			shutdownSignal, userDevErr := applicationAction.applicationEventRunner_handleSyncRunModifiedInternal(ctx, dbQueries)
+			Expect(userDevErr).To(BeNil())
+			Expect(shutdownSignal).To(BeFalse())
+		})
+
+		It("should handle a valid GitOpsDeploymentSyncRun by creating a SyncRun Operation", func() {
+			shutdownSignal, userDevErr := applicationAction.applicationEventRunner_handleSyncRunModifiedInternal(ctx, dbQueries)
+			Expect(userDevErr).To(BeNil())
+			Expect(shutdownSignal).To(BeFalse())
+
+			By("check if the SyncOperation entry is created in the DB")
+			mapping := db.APICRToDatabaseMapping{
+				APIResourceType:      db.APICRToDatabaseMapping_ResourceType_GitOpsDeploymentSyncRun,
+				APIResourceName:      gitopsDeplSyncRun.Name,
+				APIResourceNamespace: gitopsDeplSyncRun.Namespace,
+				APIResourceUID:       string(gitopsDeplSyncRun.UID),
+				DBRelationType:       db.APICRToDatabaseMapping_DBRelationType_SyncOperation,
+			}
+			err := dbQueries.GetDatabaseMappingForAPICR(ctx, &mapping)
+			Expect(err).To(BeNil())
+
+			syncOperation := db.SyncOperation{SyncOperation_id: mapping.DBRelationKey}
+			err = dbQueries.GetSyncOperationById(ctx, &syncOperation)
+			Expect(err).To(BeNil())
+			Expect(syncOperation.DeploymentNameField).Should(Equal(gitopsDeplSyncRun.Spec.GitopsDeploymentName))
+			Expect(syncOperation.Revision).Should(Equal(gitopsDeplSyncRun.Spec.RevisionID))
+
+			By("verify if an Operation CR is created")
+			operationCreated, operationDeleted := false, false
+			for _, event := range informer.Events {
+				if event.Action == sharedutil.Create && event.ObjectTypeOf() == "Operation" {
+					operationCreated = true
+				}
+				if event.Action == sharedutil.Delete && event.ObjectTypeOf() == "Operation" {
+					operationDeleted = true
+				}
+			}
+			Expect(operationCreated).To(BeTrue())
+			Expect(operationDeleted).To(BeTrue())
+		})
+
+		It("should throw an error when users try to update immutable fields", func() {
+			By("create a new GitOpsDeployment that needs to be synced")
+			newGitOpsDepl := managedgitopsv1alpha1.GitOpsDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "new-gitopsdepl",
+					Namespace: gitopsDeplSyncRun.Namespace,
+					UID:       uuid.NewUUID(),
+				},
+			}
+
+			err := k8sClient.Create(ctx, &newGitOpsDepl)
+			Expect(err).To(BeNil())
+
+			newAppAction := applicationAction
+			newAppAction.eventResourceName = newGitOpsDepl.Name
+			_, _, _, _, userDevErr := newAppAction.applicationEventRunner_handleDeploymentModified(ctx, dbQueries)
+			Expect(userDevErr).To(BeNil())
+
+			By("verify if the field .spec.GitOpsDeploymentName of GitOpsDeploymentSyncRun is immutable")
+			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(gitopsDeplSyncRun), gitopsDeplSyncRun)
+			Expect(err).To(BeNil())
+
+			gitopsDeplSyncRun.Spec.GitopsDeploymentName = newGitOpsDepl.Name
+			err = k8sClient.Update(ctx, gitopsDeplSyncRun)
+			Expect(err).To(BeNil())
+
+			expectedErr := "deployment name field is immutable: changing it from its initial value is not supported"
+			shutdownSignal, userDevErr := applicationAction.applicationEventRunner_handleSyncRunModifiedInternal(ctx, dbQueries)
+			Expect(userDevErr.DevError().Error()).Should(Equal(expectedErr))
+			Expect(shutdownSignal).To(BeFalse())
+
+			By("verify if the field .spec.revisionID of GitOpsDeploymentSyncRun is immutable")
+			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(gitopsDeplSyncRun), gitopsDeplSyncRun)
+			Expect(err).To(BeNil())
+
+			gitopsDeplSyncRun.Spec.RevisionID = "main"
+			err = k8sClient.Update(ctx, gitopsDeplSyncRun)
+			Expect(err).To(BeNil())
+
+			expectedErr = "deployment name field is immutable: changing it from its initial value is not supported"
+			shutdownSignal, userDevErr = applicationAction.applicationEventRunner_handleSyncRunModifiedInternal(ctx, dbQueries)
+			Expect(userDevErr.DevError().Error()).Should(Equal(expectedErr))
+			Expect(shutdownSignal).To(BeFalse())
+		})
+
+		It("should terminate the SyncOperation and create an Operation when the SyncRun CR is deleted", func() {
+			mapping := db.APICRToDatabaseMapping{
+				APIResourceType:      db.APICRToDatabaseMapping_ResourceType_GitOpsDeploymentSyncRun,
+				APIResourceName:      gitopsDeplSyncRun.Name,
+				APIResourceNamespace: gitopsDeplSyncRun.Namespace,
+				APIResourceUID:       string(gitopsDeplSyncRun.UID),
+				DBRelationType:       db.APICRToDatabaseMapping_DBRelationType_SyncOperation,
+			}
+			err := dbQueries.GetDatabaseMappingForAPICR(ctx, &mapping)
+			Expect(err).To(BeNil())
+
+			syncOperation := db.SyncOperation{SyncOperation_id: mapping.DBRelationKey}
+			err = dbQueries.GetSyncOperationById(ctx, &syncOperation)
+			Expect(err).To(BeNil())
+
+			By("delete the GitOpsDeploymentSyncRun and check if the SyncOperation is deleted")
+			err = k8sClient.Delete(ctx, gitopsDeplSyncRun)
+			Expect(err).To(BeNil())
+
+			By("check if the application event runner goroutine can be shutdown")
+			shutdownSignal, userDevErr := applicationAction.applicationEventRunner_handleSyncRunModifiedInternal(ctx, dbQueries)
+			Expect(userDevErr).To(BeNil())
+			Expect(shutdownSignal).To(BeTrue())
+
+			By("check if the sync operation row is deleted")
+			err = dbQueries.GetSyncOperationById(ctx, &syncOperation)
+			Expect(db.IsResultNotFoundError(err)).To(BeTrue())
+
+			By("check if a new Operation is created to handle sync termination")
+			operationCreated, operationDeleted := false, false
+			for _, event := range informer.Events {
+				if event.Action == sharedutil.Create && event.ObjectTypeOf() == "Operation" {
+					operationCreated = true
+				}
+				if event.Action == sharedutil.Delete && event.ObjectTypeOf() == "Operation" {
+					operationDeleted = true
+				}
+			}
+			Expect(operationDeleted).To(BeTrue())
+			Expect(operationCreated).To(BeTrue())
+
+			By("check if the APICRToDatabaseMapping row is deleted")
+			err = dbQueries.GetDatabaseMappingForAPICR(ctx, &mapping)
+			Expect(db.IsResultNotFoundError(err)).To(BeTrue())
+		})
+
+		It("should throw an error when a SyncRun points to a GitOpsDeployment that doesn't exist", func() {
+			invalidGitOpsDeplSyncRun := managedgitopsv1alpha1.GitOpsDeploymentSyncRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-gitops-syncrun",
+					Namespace: gitopsDepl.Namespace,
+					UID:       uuid.NewUUID(),
+				},
+				Spec: managedgitopsv1alpha1.GitOpsDeploymentSyncRunSpec{
+					GitopsDeploymentName: "unknown-gitops-depl",
+				},
+			}
+
+			err := k8sClient.Create(ctx, &invalidGitOpsDeplSyncRun)
+			Expect(err).To(BeNil())
+
+			expectedErr := "unable to retrieve gitopsdeployment referenced in syncrun: gitopsdeployments.managed-gitops.redhat.com \"unknown-gitops-depl\" not found"
+
+			applicationAction.eventResourceName = "invalid-gitops-syncrun"
+			shutdownSignal, userDevErr := applicationAction.applicationEventRunner_handleSyncRunModifiedInternal(ctx, dbQueries)
+			Expect(userDevErr.DevError().Error()).Should(Equal(expectedErr))
+			Expect(shutdownSignal).To(BeFalse())
+		})
+
+		It("should return true shutdown signal if neither CR nor DB entry exists", func() {
+			By("delete the SyncRun CR and the relevant DB details")
+			err := k8sClient.Delete(ctx, gitopsDeplSyncRun)
+			Expect(err).To(BeNil())
+
+			shutdownSignal, userDevErr := applicationAction.applicationEventRunner_handleSyncRunModifiedInternal(ctx, dbQueries)
+			Expect(userDevErr).To(BeNil())
+			Expect(shutdownSignal).To(BeTrue())
+
+			By("check if the shutdown signal is true")
+			shutdownSignal, userDevErr = applicationAction.applicationEventRunner_handleSyncRunModifiedInternal(ctx, dbQueries)
+			Expect(userDevErr).To(BeNil())
+			Expect(shutdownSignal).To(BeTrue())
+		})
+
+		It("should throw an error if the namespace doesn't exist", func() {
+			applicationAction.eventResourceNamespace = "unknown-namespace"
+			shutdownSignal, userDevErr := applicationAction.applicationEventRunner_handleSyncRunModifiedInternal(ctx, dbQueries)
+
+			expectedDevError := "unable to retrieve namespace 'unknown-namespace': namespaces \"unknown-namespace\" not found"
+			expectedUserError := "unable to retrieve the contents of the namespace 'unknown-namespace' containing the API resource 'gitops-syncrun'. Does it exist?"
+
+			Expect(userDevErr.DevError().Error()).Should(Equal(expectedDevError))
+			Expect(userDevErr.UserError()).Should(Equal(expectedUserError))
+			Expect(shutdownSignal).To(BeFalse())
+		})
+	})
+})

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns_test.go
@@ -156,6 +156,7 @@ var _ = Describe("Application Event Runner SyncRuns", func() {
 			expectedErr := "deployment name field is immutable: changing it from its initial value is not supported"
 			shutdownSignal, userDevErr := applicationAction.applicationEventRunner_handleSyncRunModifiedInternal(ctx, dbQueries)
 			Expect(userDevErr.DevError().Error()).Should(Equal(expectedErr))
+			Expect(userDevErr.UserError()).Should(Equal(expectedErr))
 			Expect(shutdownSignal).To(BeFalse())
 
 			By("verify if the field .spec.revisionID of GitOpsDeploymentSyncRun is immutable")
@@ -169,6 +170,7 @@ var _ = Describe("Application Event Runner SyncRuns", func() {
 			expectedErr = "deployment name field is immutable: changing it from its initial value is not supported"
 			shutdownSignal, userDevErr = applicationAction.applicationEventRunner_handleSyncRunModifiedInternal(ctx, dbQueries)
 			Expect(userDevErr.DevError().Error()).Should(Equal(expectedErr))
+			Expect(userDevErr.UserError()).Should(Equal(expectedErr))
 			Expect(shutdownSignal).To(BeFalse())
 		})
 

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns_test.go
@@ -153,11 +153,14 @@ var _ = Describe("Application Event Runner SyncRuns", func() {
 			err = k8sClient.Update(ctx, gitopsDeplSyncRun)
 			Expect(err).To(BeNil())
 
-			expectedErr := "deployment name field is immutable: changing it from its initial value is not supported"
 			shutdownSignal, userDevErr := applicationAction.applicationEventRunner_handleSyncRunModifiedInternal(ctx, dbQueries)
-			Expect(userDevErr.DevError().Error()).Should(Equal(expectedErr))
-			Expect(userDevErr.UserError()).Should(Equal(expectedErr))
+			Expect(userDevErr.DevError().Error()).Should(Equal(errDeploymentNameIsImmutable))
+			Expect(userDevErr.UserError()).Should(Equal(errDeploymentNameIsImmutable))
 			Expect(shutdownSignal).To(BeFalse())
+
+			gitopsDeplSyncRun.Spec.GitopsDeploymentName = gitopsDepl.Name
+			err = k8sClient.Update(ctx, gitopsDeplSyncRun)
+			Expect(err).To(BeNil())
 
 			By("verify if the field .spec.revisionID of GitOpsDeploymentSyncRun is immutable")
 			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(gitopsDeplSyncRun), gitopsDeplSyncRun)
@@ -167,10 +170,9 @@ var _ = Describe("Application Event Runner SyncRuns", func() {
 			err = k8sClient.Update(ctx, gitopsDeplSyncRun)
 			Expect(err).To(BeNil())
 
-			expectedErr = "deployment name field is immutable: changing it from its initial value is not supported"
 			shutdownSignal, userDevErr = applicationAction.applicationEventRunner_handleSyncRunModifiedInternal(ctx, dbQueries)
-			Expect(userDevErr.DevError().Error()).Should(Equal(expectedErr))
-			Expect(userDevErr.UserError()).Should(Equal(expectedErr))
+			Expect(userDevErr.DevError().Error()).Should(Equal(errRevisionIsImmutable))
+			Expect(userDevErr.UserError()).Should(Equal(errRevisionIsImmutable))
 			Expect(shutdownSignal).To(BeFalse())
 		})
 

--- a/backend/eventloop/application_event_loop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_test.go
@@ -649,7 +649,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 				},
 				testOnlySkipCreateOperation: true,
 			}
-			_, err = a.applicationEventRunner_handleSyncRunModified(ctx, dbQueries)
+			err = a.applicationEventRunner_handleSyncRunModified(ctx, dbQueries)
 			Expect(err).To(BeNil())
 		})
 
@@ -730,7 +730,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 					fakeClient: k8sClient,
 				},
 			}
-			_, err = a.applicationEventRunner_handleSyncRunModified(ctx, dbQueries)
+			err = a.applicationEventRunner_handleSyncRunModified(ctx, dbQueries)
 			Expect(err).NotTo(BeNil())
 
 		})

--- a/backend/eventloop/application_event_loop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_test.go
@@ -647,6 +647,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 				k8sClientFactory: MockSRLK8sClientFactory{
 					fakeClient: k8sClient,
 				},
+				testOnlySkipCreateOperation: true,
 			}
 			_, err = a.applicationEventRunner_handleSyncRunModified(ctx, dbQueries)
 			Expect(err).To(BeNil())

--- a/backend/eventloop/workspace_event_loop.go
+++ b/backend/eventloop/workspace_event_loop.go
@@ -396,8 +396,8 @@ func getDBSyncOperationFromAPIMapping(ctx context.Context, dbQueries db.Database
 		return db.SyncOperation{}, fmt.Errorf("failed to list APICRToDBMapping by namespace and name: %v", err)
 	}
 
-	if len(apiCRToDBMappingList) == 0 {
-		return db.SyncOperation{}, fmt.Errorf("no database entry found for GitOpsDeploymentSyncRun %s", syncRunCR.Name)
+	if len(apiCRToDBMappingList) != 1 {
+		return db.SyncOperation{}, fmt.Errorf("SEVERE: unexpected number of APICRToDBMappings for GitOpsDeploymentSyncRun %s: %d", syncRunCR.Name, len(apiCRToDBMappingList))
 	}
 
 	apiCRToDBMapping := apiCRToDBMappingList[0]

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop_test.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop_test.go
@@ -803,8 +803,37 @@ var _ = Describe("Operation Controller", func() {
 
 			var (
 				applicationDB          *db.Application
-				createOperationDBAndCR func(resourceID string)
+				gitopsEngineInstanceID string
 			)
+
+			createOperationDBAndCR := func(resourceID, gitopsEngineInstanceID string) {
+				By("creating new operation row of type SyncOperation in the database")
+				operationDB := &db.Operation{
+					Operation_id:            "test-operation",
+					Instance_id:             gitopsEngineInstanceID,
+					Resource_id:             resourceID,
+					Resource_type:           db.OperationResourceType_SyncOperation,
+					State:                   db.OperationState_Waiting,
+					Operation_owner_user_id: testClusterUser.Clusteruser_id,
+				}
+
+				err = dbQueries.CreateOperation(ctx, operationDB, operationDB.Operation_owner_user_id)
+				Expect(err).To(BeNil())
+
+				By("creating Operation CR")
+				operationCR := &managedgitopsv1alpha1.Operation{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+					Spec: managedgitopsv1alpha1.OperationSpec{
+						OperationID: operationDB.Operation_id,
+					},
+				}
+
+				err = task.event.client.Create(ctx, operationCR)
+				Expect(err).To(BeNil())
+			}
 
 			BeforeEach(func() {
 				_, managedEnvironment, _, _, _, err := db.CreateSampleData(dbQueries)
@@ -827,6 +856,8 @@ var _ = Describe("Operation Controller", func() {
 				err = dbQueries.CreateGitopsEngineInstance(ctx, gitopsEngineInstance)
 				Expect(err).To(BeNil())
 
+				gitopsEngineInstanceID = gitopsEngineInstance.Gitopsengineinstance_id
+
 				applicationDB = &db.Application{
 					Application_id:          "test-my-application",
 					Name:                    name,
@@ -838,35 +869,6 @@ var _ = Describe("Operation Controller", func() {
 				By("create Application in Database")
 				err = dbQueries.CreateApplication(ctx, applicationDB)
 				Expect(err).To(BeNil())
-
-				createOperationDBAndCR = func(resourceID string) {
-					By("creating new operation row of type SyncOperation in the database")
-					operationDB := &db.Operation{
-						Operation_id:            "test-operation",
-						Instance_id:             gitopsEngineInstance.Gitopsengineinstance_id,
-						Resource_id:             resourceID,
-						Resource_type:           db.OperationResourceType_SyncOperation,
-						State:                   db.OperationState_Waiting,
-						Operation_owner_user_id: testClusterUser.Clusteruser_id,
-					}
-
-					err = dbQueries.CreateOperation(ctx, operationDB, operationDB.Operation_owner_user_id)
-					Expect(err).To(BeNil())
-
-					By("creating Operation CR")
-					operationCR := &managedgitopsv1alpha1.Operation{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      name,
-							Namespace: namespace,
-						},
-						Spec: managedgitopsv1alpha1.OperationSpec{
-							OperationID: operationDB.Operation_id,
-						},
-					}
-
-					err = task.event.client.Create(ctx, operationCR)
-					Expect(err).To(BeNil())
-				}
 			})
 
 			AfterEach(func() {
@@ -888,10 +890,10 @@ var _ = Describe("Operation Controller", func() {
 				Expect(err).To(BeNil())
 
 				By("create Operation DB row and CR for the SyncOperation")
-				createOperationDBAndCR(syncOperation.SyncOperation_id)
+				createOperationDBAndCR(syncOperation.SyncOperation_id, gitopsEngineInstanceID)
 
 				By("verify there is no retry for a successful sync")
-				task.syncService = &syncService{
+				task.syncFuncs = &syncFuncs{
 					appSync: func(ctx context.Context, s1, s2, s3 string, c client.Client, cs *utils.CredentialService, b bool) error {
 						return nil
 					},
@@ -916,11 +918,11 @@ var _ = Describe("Operation Controller", func() {
 				Expect(err).To(BeNil())
 
 				By("create Operation DB row and CR for the SyncOperation")
-				createOperationDBAndCR(syncOperation.SyncOperation_id)
+				createOperationDBAndCR(syncOperation.SyncOperation_id, gitopsEngineInstanceID)
 
 				By("check if the sync failed error is returned with retry")
 				expectedErr := "sync failed due to xyz reason"
-				task.syncService = &syncService{
+				task.syncFuncs = &syncFuncs{
 					appSync: func(ctx context.Context, s1, s2, s3 string, c client.Client, cs *utils.CredentialService, b bool) error {
 						return fmt.Errorf(expectedErr)
 					},
@@ -934,10 +936,10 @@ var _ = Describe("Operation Controller", func() {
 			It("return an error and don't retry if the SyncOperation DB row is not found", func() {
 
 				By("create Operation DB row and CR for the SyncOperation")
-				createOperationDBAndCR("uknown")
+				createOperationDBAndCR("uknown", gitopsEngineInstanceID)
 
 				By("check if SyncOperation not found error is handled")
-				task.syncService = &syncService{
+				task.syncFuncs = &syncFuncs{
 					appSync: func(ctx context.Context, s1, s2, s3 string, c client.Client, cs *utils.CredentialService, b bool) error {
 						return nil
 					},
@@ -963,9 +965,9 @@ var _ = Describe("Operation Controller", func() {
 				Expect(err).To(BeNil())
 
 				By("create Operation DB row and CR for the SyncOperation")
-				createOperationDBAndCR(syncOperation.SyncOperation_id)
+				createOperationDBAndCR(syncOperation.SyncOperation_id, gitopsEngineInstanceID)
 
-				task.syncService = &syncService{
+				task.syncFuncs = &syncFuncs{
 					appSync: func(ctx context.Context, s1, s2, s3 string, c client.Client, cs *utils.CredentialService, b bool) error {
 						return nil
 					},
@@ -990,10 +992,10 @@ var _ = Describe("Operation Controller", func() {
 				Expect(err).To(BeNil())
 
 				By("create Operation DB row and CR for the SyncOperation")
-				createOperationDBAndCR(syncOperation.SyncOperation_id)
+				createOperationDBAndCR(syncOperation.SyncOperation_id, gitopsEngineInstanceID)
 
 				By("verify that there is no retry and error for a successful termination")
-				task.syncService = &syncService{
+				task.syncFuncs = &syncFuncs{
 					terminateOperation: func(ctx context.Context, s string, n v1.Namespace, cs *utils.CredentialService, c client.Client, d time.Duration, l logr.Logger) error {
 						return nil
 					},
@@ -1018,11 +1020,11 @@ var _ = Describe("Operation Controller", func() {
 				Expect(err).To(BeNil())
 
 				By("create Operation DB row and CR for the SyncOperation")
-				createOperationDBAndCR(syncOperation.SyncOperation_id)
+				createOperationDBAndCR(syncOperation.SyncOperation_id, gitopsEngineInstanceID)
 
 				By("check if an error is returned for the failed termination")
 				expectedErr := "unable to terminate sync due to xyz reason"
-				task.syncService = &syncService{
+				task.syncFuncs = &syncFuncs{
 					terminateOperation: func(ctx context.Context, s string, n v1.Namespace, cs *utils.CredentialService, c client.Client, d time.Duration, l logr.Logger) error {
 						return fmt.Errorf(expectedErr)
 					},

--- a/cluster-agent/main.go
+++ b/cluster-agent/main.go
@@ -22,6 +22,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	routev1 "github.com/openshift/api/route/v1"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/config/db"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -50,6 +51,8 @@ func init() {
 
 	utilruntime.Must(managedgitopsv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(appv1.AddToScheme(scheme))
+
+	utilruntime.Must(routev1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/cluster-agent/utils/argocd_sync_command.go
+++ b/cluster-agent/utils/argocd_sync_command.go
@@ -46,8 +46,7 @@ func AppSync(ctx context.Context, appName string, revision string, namespaceName
 		return err
 	}
 
-	// Setting async to true so that we are not blocked until the app is synced
-	err = appSync(ctx, acdClient, appName, false, false, revision, false, "", false, true, 0, 0, 0, 0, 0)
+	err = appSync(ctx, acdClient, appName, false, false, revision, false, "", false, false, 0, 0, 0, 0, 0)
 	if err != nil {
 		return err
 	}

--- a/cluster-agent/utils/argocd_sync_command.go
+++ b/cluster-agent/utils/argocd_sync_command.go
@@ -46,7 +46,8 @@ func AppSync(ctx context.Context, appName string, revision string, namespaceName
 		return err
 	}
 
-	err = appSync(ctx, acdClient, appName, false, false, revision, false, "", false, false, 0, 0, 0, 0, 0)
+	// Setting async to true so that we are not blocked until the app is synced
+	err = appSync(ctx, acdClient, appName, false, false, revision, false, "", false, true, 0, 0, 0, 0, 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Description:
- Refactored `applicationEventRunner_handleSyncRunModifiedInternal()` and created separate methods to handle creation, updation and deletion of SyncRun CRs
- Resolved TODOs for [GITOPSRVCE-166](https://issues.redhat.com//browse/GITOPSRVCE-166)
- Added unit tests in the backend and cluster agent
- Fixed bugs around goroutine shutdown 

#### Link to JIRA Story (if applicable):
https://issues.redhat.com/browse/GITOPSRVCE-166
https://issues.redhat.com/browse/GITOPSRVCE-82
