### PR TITLE
Fix application event loop closing too quickly after a GitOpsDeployment is deleted, and workspace event loop not starting a new one

### DIFF
--- a/backend/eventloop/application_event_loop/application_event_loop.go
+++ b/backend/eventloop/application_event_loop/application_event_loop.go
@@ -53,7 +53,7 @@ type RequestMessage struct {
 	ResponseChan chan ResponseMessage
 }
 
-// RequestMessage is a message sent back on the ResponseChan of the RequestMessage
+// ResponseMesage is a message sent back on the ResponseChan of the RequestMessage
 type ResponseMessage struct {
 
 	// RequestAccepted is true if the Application Event Loop is actively accepting message, and false

--- a/backend/eventloop/application_event_loop/application_event_loop_test.go
+++ b/backend/eventloop/application_event_loop/application_event_loop_test.go
@@ -27,12 +27,12 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 				WorkspaceID:               "",
 				SharedResourceEventLoop:   nil,
 				VwsAPIExportName:          "gitops-api",
-				InputChan:                 make(chan ApplicationEventLoopRequestMessage),
+				InputChan:                 make(chan RequestMessage),
 			}
 
 			startApplicationEventQueueLoopWithFactory(context.Background(), aeqlParam, &mockApplicationEventLoopRunnerFactory)
 
-			aeqlParam.InputChan <- ApplicationEventLoopRequestMessage{
+			aeqlParam.InputChan <- RequestMessage{
 				Message: eventlooptypes.EventLoopMessage{
 					MessageType: eventlooptypes.ApplicationEventLoopMessageType_Event,
 					Event: &eventlooptypes.EventLoopEvent{
@@ -65,7 +65,7 @@ type mockApplicationEventLoopRunnerFactory struct {
 
 var _ applicationEventRunnerFactory = &mockApplicationEventLoopRunnerFactory{}
 
-func (fact *mockApplicationEventLoopRunnerFactory) createNewApplicationEventLoopRunner(informWorkCompleteChan chan ApplicationEventLoopRequestMessage,
+func (fact *mockApplicationEventLoopRunnerFactory) createNewApplicationEventLoopRunner(informWorkCompleteChan chan RequestMessage,
 	sharedResourceEventLoop *shared_resource_loop.SharedResourceEventLoop, gitopsDeplName string, gitopsDeplNamespace string,
 	workspaceID string, debugContext string) chan *eventlooptypes.EventLoopEvent {
 

--- a/backend/eventloop/application_event_loop/application_event_loop_test.go
+++ b/backend/eventloop/application_event_loop/application_event_loop_test.go
@@ -34,16 +34,18 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 
 			startApplicationEventQueueLoopWithFactory(context.Background(), aeqlParam, &mockApplicationEventLoopRunnerFactory)
 
+			inputEvent := &eventlooptypes.EventLoopEvent{
+				EventType:   eventlooptypes.DeploymentModified,
+				Request:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "", Name: ""}},
+				Client:      nil,
+				ReqResource: eventlooptypes.GitOpsDeploymentTypeName,
+				WorkspaceID: "",
+			}
+
 			aeqlParam.InputChan <- RequestMessage{
 				Message: eventlooptypes.EventLoopMessage{
-					MessageType: eventlooptypes.ApplicationEventLoopMessageType_Event,
-					Event: &eventlooptypes.EventLoopEvent{
-						EventType:   eventlooptypes.DeploymentModified,
-						Request:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "", Name: ""}},
-						Client:      nil,
-						ReqResource: eventlooptypes.GitOpsDeploymentTypeName,
-						WorkspaceID: "",
-					},
+					MessageType:       eventlooptypes.ApplicationEventLoopMessageType_Event,
+					Event:             inputEvent,
 					ShutdownSignalled: false,
 				},
 				ResponseChan: nil, // no response channel needed
@@ -51,10 +53,10 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 
 			outputEvent := <-mockApplicationEventLoopRunnerFactory.mockChannel
 			Expect(outputEvent).NotTo(BeNil())
-			Expect(outputEvent.EventType).To(Equal(outputEvent.EventType))
-			Expect(outputEvent.Request).To(Equal(outputEvent.Request))
-			Expect(outputEvent.ReqResource).To(Equal(outputEvent.ReqResource))
-			Expect(outputEvent.WorkspaceID).To(Equal(outputEvent.WorkspaceID))
+			Expect(outputEvent.EventType).To(Equal(inputEvent.EventType))
+			Expect(outputEvent.Request).To(Equal(inputEvent.Request))
+			Expect(outputEvent.ReqResource).To(Equal(inputEvent.ReqResource))
+			Expect(outputEvent.WorkspaceID).To(Equal(inputEvent.WorkspaceID))
 
 		})
 	})
@@ -108,10 +110,10 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 
 			outputEvent := <-mockApplicationEventLoopRunnerFactory.mockChannel
 			Expect(outputEvent).NotTo(BeNil(), "we should have received the event on a runner")
-			Expect(outputEvent.EventType).To(Equal(outputEvent.EventType))
-			Expect(outputEvent.Request).To(Equal(outputEvent.Request))
-			Expect(outputEvent.ReqResource).To(Equal(outputEvent.ReqResource))
-			Expect(outputEvent.WorkspaceID).To(Equal(outputEvent.WorkspaceID))
+			Expect(outputEvent.EventType).To(Equal(event.EventType))
+			Expect(outputEvent.Request).To(Equal(event.Request))
+			Expect(outputEvent.ReqResource).To(Equal(event.ReqResource))
+			Expect(outputEvent.WorkspaceID).To(Equal(event.WorkspaceID))
 
 		})
 

--- a/backend/eventloop/application_event_loop/application_event_loop_test.go
+++ b/backend/eventloop/application_event_loop/application_event_loop_test.go
@@ -2,6 +2,8 @@ package application_event_loop
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -15,7 +17,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 
 	Context("Application Event Loop test", func() {
 
-		It("should forward messages received on the input channel, to the runner", func() {
+		It("should forward messages received on the input channel, to the runner, without a response channel", func() {
 
 			mockApplicationEventLoopRunnerFactory := mockApplicationEventLoopRunnerFactory{
 				mockChannel: make(chan *eventlooptypes.EventLoopEvent),
@@ -44,6 +46,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 					},
 					ShutdownSignalled: false,
 				},
+				ResponseChan: nil, // no response channel needed
 			}
 
 			outputEvent := <-mockApplicationEventLoopRunnerFactory.mockChannel
@@ -53,6 +56,117 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			Expect(outputEvent.ReqResource).To(Equal(outputEvent.ReqResource))
 			Expect(outputEvent.WorkspaceID).To(Equal(outputEvent.WorkspaceID))
 
+		})
+	})
+
+	Context("Simulate a deleted GitOpsDeployment", Ordered, func() {
+
+		const (
+			gitopsDeplName      = "my-gitops-depl"
+			gitopsDeplNamespace = "my-namespace"
+			namespaceUID        = "my-namespace-uid"
+		)
+
+		aeqlParam := ApplicationEventQueueLoop{
+			GitopsDeploymentName:      gitopsDeplName,
+			GitopsDeploymentNamespace: gitopsDeplNamespace,
+			WorkspaceID:               namespaceUID,
+			SharedResourceEventLoop:   nil,
+			VwsAPIExportName:          "gitops-api",
+			InputChan:                 make(chan RequestMessage),
+		}
+
+		event := &eventlooptypes.EventLoopEvent{
+			EventType:   eventlooptypes.DeploymentModified,
+			Request:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: gitopsDeplNamespace, Name: gitopsDeplName}},
+			Client:      nil,
+			ReqResource: eventlooptypes.GitOpsDeploymentTypeName,
+			WorkspaceID: namespaceUID,
+		}
+
+		It("should start a runner based on incoming GitOpsDeployment request ", func() {
+			mockApplicationEventLoopRunnerFactory := mockApplicationEventLoopRunnerFactory{
+				mockChannel: make(chan *eventlooptypes.EventLoopEvent),
+			}
+
+			startApplicationEventQueueLoopWithFactory(context.Background(), aeqlParam, &mockApplicationEventLoopRunnerFactory)
+
+			By("sending message to the application event loop, informing it of a new GitOpsDeployment")
+			responseChan := make(chan ResponseMessage)
+			aeqlParam.InputChan <- RequestMessage{
+				Message: eventlooptypes.EventLoopMessage{
+					MessageType:       eventlooptypes.ApplicationEventLoopMessageType_Event,
+					Event:             event,
+					ShutdownSignalled: false,
+				},
+				ResponseChan: responseChan,
+			}
+
+			By("By reading the response message from the application event loop")
+			response := <-responseChan
+			Expect(response.RequestAccepted).To(BeTrue())
+
+			outputEvent := <-mockApplicationEventLoopRunnerFactory.mockChannel
+			Expect(outputEvent).NotTo(BeNil(), "we should have received the event on a runner")
+			Expect(outputEvent.EventType).To(Equal(outputEvent.EventType))
+			Expect(outputEvent.Request).To(Equal(outputEvent.Request))
+			Expect(outputEvent.ReqResource).To(Equal(outputEvent.ReqResource))
+			Expect(outputEvent.WorkspaceID).To(Equal(outputEvent.WorkspaceID))
+
+		})
+
+		It("should shutdown the runner based on work complete, and then verify the event loop rejects additional work", func() {
+
+			By("sending message to application event loop that the runner is complete")
+			aeqlParam.InputChan <- RequestMessage{
+				Message: eventlooptypes.EventLoopMessage{
+					MessageType:       eventlooptypes.ApplicationEventLoopMessageType_WorkComplete,
+					Event:             event,
+					ShutdownSignalled: true,
+				},
+				ResponseChan: nil,
+			}
+
+			By("by attempting to send another request to the application event loop")
+			responseChan := make(chan ResponseMessage)
+			aeqlParam.InputChan <- RequestMessage{
+				Message: eventlooptypes.EventLoopMessage{
+					MessageType:       eventlooptypes.ApplicationEventLoopMessageType_Event,
+					Event:             event,
+					ShutdownSignalled: false,
+				},
+				ResponseChan: responseChan,
+			}
+
+			response := <-responseChan
+			Expect(response.RequestAccepted).To(BeFalse(), "the second request to the event loop should be rejected, as "+
+				"the application event loop has terminate.")
+
+			By("attempting to send another request to the application event loop")
+			mutex := sync.Mutex{}
+			responseReceived := false
+			go func() {
+				responseChan = make(chan ResponseMessage)
+				aeqlParam.InputChan <- RequestMessage{
+					Message: eventlooptypes.EventLoopMessage{
+						MessageType:       eventlooptypes.ApplicationEventLoopMessageType_Event,
+						Event:             event,
+						ShutdownSignalled: false,
+					},
+					ResponseChan: nil,
+				}
+				mutex.Lock()
+				defer mutex.Unlock()
+				responseReceived = true
+
+			}()
+
+			Consistently(func() bool {
+				mutex.Lock()
+				defer mutex.Unlock()
+				return responseReceived
+			}).WithTimeout(time.Second).WithPolling(time.Millisecond*10).Should(BeFalse(),
+				"we should not receive a response, because the event loop goroutine has terminated.")
 		})
 	})
 

--- a/backend/eventloop/application_event_loop/application_event_runner.go
+++ b/backend/eventloop/application_event_loop/application_event_runner.go
@@ -101,7 +101,9 @@ func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent
 
 		// Process the event
 
-		log.V(sharedutil.LogLevel_Debug).Info("applicationEventLoopRunner - event received", "event", eventlooptypes.StringEventLoopEvent(newEvent))
+		if !(newEvent.EventType == eventlooptypes.UpdateDeploymentStatusTick && disableDeploymentStatusTickLogging == true) {
+			log.V(sharedutil.LogLevel_Debug).Info("applicationEventLoopRunner - event received", "event", eventlooptypes.StringEventLoopEvent(newEvent))
+		}
 
 		// Keep attempting the process the event until no error is returned, or the request is cancelled.
 		attempts := 1
@@ -109,7 +111,9 @@ func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent
 	inner_for:
 		for {
 
-			log.V(sharedutil.LogLevel_Debug).Info("applicationEventLoopRunner - processing event", "event", eventlooptypes.StringEventLoopEvent(newEvent), "attempt", attempts)
+			if !(newEvent.EventType == eventlooptypes.UpdateDeploymentStatusTick && disableDeploymentStatusTickLogging == true) {
+				log.V(sharedutil.LogLevel_Debug).Info("applicationEventLoopRunner - processing event", "event", eventlooptypes.StringEventLoopEvent(newEvent), "attempt", attempts)
+			}
 
 			// Break if the context is cancelled
 			select {

--- a/backend/eventloop/application_event_loop/application_event_runner.go
+++ b/backend/eventloop/application_event_loop/application_event_runner.go
@@ -60,7 +60,7 @@ import (
 // For more information on how events are distributed between goroutines by event loop, see:
 // https://miro.com/app/board/o9J_lgiqJAs=/?moveToWidget=3458764514216218600&cot=14
 
-func startNewApplicationEventLoopRunner(informWorkCompleteChan chan eventlooptypes.EventLoopMessage,
+func startNewApplicationEventLoopRunner(informWorkCompleteChan chan ApplicationEventLoopRequestMessage,
 	sharedResourceEventLoop *shared_resource_loop.SharedResourceEventLoop,
 	gitopsDeplName string, gitopsDeplNamespace, workspaceID string, debugContext string) chan *eventlooptypes.EventLoopEvent {
 
@@ -76,7 +76,7 @@ func startNewApplicationEventLoopRunner(informWorkCompleteChan chan eventlooptyp
 }
 
 func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent,
-	informWorkCompleteChan chan eventlooptypes.EventLoopMessage,
+	informWorkCompleteChan chan ApplicationEventLoopRequestMessage,
 	sharedResourceEventLoop *shared_resource_loop.SharedResourceEventLoop, gitopsDeploymentName string,
 	gitopsDeploymentNamespace string, namespaceID string, debugContext string) {
 
@@ -188,7 +188,13 @@ func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent
 		}
 
 		// Inform the caller that we have completed a single unit of work
-		informWorkCompleteChan <- eventlooptypes.EventLoopMessage{MessageType: eventlooptypes.ApplicationEventLoopMessageType_WorkComplete, Event: newEvent, ShutdownSignalled: signalledShutdown}
+		informWorkCompleteChan <- ApplicationEventLoopRequestMessage{
+			Message: eventlooptypes.EventLoopMessage{
+				MessageType:       eventlooptypes.ApplicationEventLoopMessageType_WorkComplete,
+				Event:             newEvent,
+				ShutdownSignalled: signalledShutdown},
+			ResponseChan: nil,
+		}
 
 		// If the event processing logic concluded that the goroutine should shutdown, then break out of the outer for loop.
 		// This is usually because the API CR no longer exists.

--- a/backend/eventloop/application_event_loop/application_event_runner.go
+++ b/backend/eventloop/application_event_loop/application_event_runner.go
@@ -60,7 +60,7 @@ import (
 // For more information on how events are distributed between goroutines by event loop, see:
 // https://miro.com/app/board/o9J_lgiqJAs=/?moveToWidget=3458764514216218600&cot=14
 
-func startNewApplicationEventLoopRunner(informWorkCompleteChan chan ApplicationEventLoopRequestMessage,
+func startNewApplicationEventLoopRunner(informWorkCompleteChan chan RequestMessage,
 	sharedResourceEventLoop *shared_resource_loop.SharedResourceEventLoop,
 	gitopsDeplName string, gitopsDeplNamespace, workspaceID string, debugContext string) chan *eventlooptypes.EventLoopEvent {
 
@@ -76,7 +76,7 @@ func startNewApplicationEventLoopRunner(informWorkCompleteChan chan ApplicationE
 }
 
 func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent,
-	informWorkCompleteChan chan ApplicationEventLoopRequestMessage,
+	informWorkCompleteChan chan RequestMessage,
 	sharedResourceEventLoop *shared_resource_loop.SharedResourceEventLoop, gitopsDeploymentName string,
 	gitopsDeploymentNamespace string, namespaceID string, debugContext string) {
 
@@ -188,7 +188,7 @@ func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent
 		}
 
 		// Inform the caller that we have completed a single unit of work
-		informWorkCompleteChan <- ApplicationEventLoopRequestMessage{
+		informWorkCompleteChan <- RequestMessage{
 			Message: eventlooptypes.EventLoopMessage{
 				MessageType:       eventlooptypes.ApplicationEventLoopMessageType_WorkComplete,
 				Event:             newEvent,

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -234,7 +234,7 @@ func (a applicationEventLoopRunner_Action) handleNewGitOpsDeplEvent(ctx context.
 	}
 
 	if engineInstance == nil {
-		return nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewDevOnlyError(fmt.Errorf("unable to locate managed environment for new application"))
+		return nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewDevOnlyError(fmt.Errorf("engine instance is nil when reconciling new GitOpsDeployment"))
 	}
 
 	appName := argosharedutil.GenerateArgoCDApplicationName(string(gitopsDeployment.UID))

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
@@ -62,7 +62,7 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleSyncRun
 
 	clusterUser, _, err := a.sharedResourceEventLoop.GetOrCreateClusterUserByNamespaceUID(ctx, a.workspaceClient, namespace, log)
 	if err != nil {
-		userError := "unable to locate managed environment for new application"
+		userError := "unable to locate managed environment for new application in syncrun modified"
 		devError := fmt.Errorf("unable to retrieve cluster user in applicationEventRunner_handleSyncRunModifiedInternal, '%s': %v",
 			string(namespace.UID), err)
 		return gitopserrors.NewUserDevError(userError, devError)

--- a/backend/eventloop/event_loop_suite_test.go
+++ b/backend/eventloop/event_loop_suite_test.go
@@ -6,7 +6,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(zapcore.DebugLevel)))
+})
 
 func TestEventLoop(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/backend/eventloop/eventlooptypes/types.go
+++ b/backend/eventloop/eventlooptypes/types.go
@@ -95,12 +95,18 @@ type EventLoopMessage struct {
 type EventLoopMessageType int
 
 const (
+
 	// ApplicationEventLoopMessageType_WorkComplete indicates the message indicates that a particular task has completed.
 	// For example:
 	ApplicationEventLoopMessageType_WorkComplete EventLoopMessageType = iota
 
 	// ApplicationEventLoopMessageType_Event indicates that the message contains an event
 	ApplicationEventLoopMessageType_Event
+
+	// ApplicationEventLoopMessageType_ShutdownTicker is a periodic ticker that tells the application event loop to
+	// check if it should terminate its goroutine
+	// - the goroutine should be terminated X minutes after the application event loop runners shutdown.
+	ApplicationEventLoopMessageType_ShutdownTicker
 )
 
 // eventlooptypes.StringEventLoopEvent is a utility function for debug purposes.

--- a/backend/eventloop/eventlooptypes/types.go
+++ b/backend/eventloop/eventlooptypes/types.go
@@ -103,10 +103,9 @@ const (
 	// ApplicationEventLoopMessageType_Event indicates that the message contains an event
 	ApplicationEventLoopMessageType_Event
 
-	// ApplicationEventLoopMessageType_ShutdownTicker is a periodic ticker that tells the application event loop to
+	// ApplicationEventLoopMessageType_StatusCheck is a periodic ticker that tells the application event loop to
 	// check if it should terminate its goroutine
-	// - the goroutine should be terminated X minutes after the application event loop runners shutdown.
-	ApplicationEventLoopMessageType_ShutdownTicker
+	ApplicationEventLoopMessageType_StatusCheck
 )
 
 // eventlooptypes.StringEventLoopEvent is a utility function for debug purposes.

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -25,8 +25,8 @@ import (
 // This ensures that:
 //   - When multiple 'application event loop' goroutines are attempting to create workspace-scoped resources,
 //     that no duplicates are created (eg it shouldn't be possible to create multiple ClusterUsers for a single user, or multiple
-//     ManagedEnvironments for a single workspace)
-//   - There are no race conditions on creation of workspace-scoped resources.
+//     ManagedEnvironments for a single namespce)
+//   - There are no race conditions on creation of namespace-scoped resources.
 //
 // API-namespace-scoped resources are:
 // - managedenv

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -25,7 +25,7 @@ import (
 // This ensures that:
 //   - When multiple 'application event loop' goroutines are attempting to create workspace-scoped resources,
 //     that no duplicates are created (eg it shouldn't be possible to create multiple ClusterUsers for a single user, or multiple
-//     ManagedEnvironments for a single namespce)
+//     ManagedEnvironments for a single namespace)
 //   - There are no race conditions on creation of namespace-scoped resources.
 //
 // API-namespace-scoped resources are:

--- a/backend/eventloop/workspace_event_loop.go
+++ b/backend/eventloop/workspace_event_loop.go
@@ -233,8 +233,8 @@ func workspaceEventLoopRouter(input chan workspaceEventLoopMessage, namespaceID 
 
 			// Send the event to the channel/go routine that handles all events for this application/gitopsdepl
 			// we wait for a response from the channel (on ResponseChan) before continuing.
-			syncResponseChan := make(chan application_event_loop.ApplicationEventLoopResponseMessage)
-			applicationEntryVal.input <- application_event_loop.ApplicationEventLoopRequestMessage{
+			syncResponseChan := make(chan application_event_loop.ResponseMessage)
+			applicationEntryVal.input <- application_event_loop.RequestMessage{
 				Message: eventlooptypes.EventLoopMessage{
 					MessageType: eventlooptypes.ApplicationEventLoopMessageType_Event,
 					Event:       event.Event,
@@ -271,7 +271,7 @@ func workspaceEventLoopRouter(input chan workspaceEventLoopMessage, namespaceID 
 
 				go func() {
 
-					applicationEntryVal.input <- application_event_loop.ApplicationEventLoopRequestMessage{
+					applicationEntryVal.input <- application_event_loop.RequestMessage{
 						Message: eventlooptypes.EventLoopMessage{
 							MessageType: eventlooptypes.ApplicationEventLoopMessageType_Event,
 							Event:       event.Event,
@@ -299,7 +299,7 @@ func startApplicationEventQueueLoop(ctx context.Context, associatedGitOpsDeploym
 		WorkspaceID:               event.Event.WorkspaceID,
 		SharedResourceEventLoop:   sharedResourceEventLoop,
 		VwsAPIExportName:          "", // this value will be replaced in startApplicationEventQueueLoop, so is blank
-		InputChan:                 make(chan application_event_loop.ApplicationEventLoopRequestMessage),
+		InputChan:                 make(chan application_event_loop.RequestMessage),
 	}
 
 	// Start the application event loop's goroutine
@@ -317,7 +317,7 @@ func startApplicationEventQueueLoop(ctx context.Context, associatedGitOpsDeploym
 
 type workspaceEventLoop_applicationEventLoopEntry struct {
 	// input is the channel used to communicate with an application event loop goroutine.
-	input chan application_event_loop.ApplicationEventLoopRequestMessage
+	input chan application_event_loop.RequestMessage
 }
 
 // applicationEventQueueLoopFactory is used to start the application event queue. It is a lightweight wrapper

--- a/backend/eventloop/workspace_event_loop.go
+++ b/backend/eventloop/workspace_event_loop.go
@@ -255,11 +255,11 @@ func handleWorkspaceEventLoopMessage(ctx context.Context, event eventlooptypes.E
 
 	// First, sanity check the event
 	if event.MessageType == eventlooptypes.ApplicationEventLoopMessageType_WorkComplete {
-		log.Error(nil, "SEVERE: invalid message type received in applicationEventLooRouter")
+		log.Error(nil, "SEVERE: invalid message type received in workspaceEventLoopRouter")
 		return
 	}
 	if event.Event == nil {
-		log.Error(nil, "SEVERE: event was nil in workspaceEventLooRouter")
+		log.Error(nil, "SEVERE: event was nil in workspaceEventLoopRouter")
 		return
 	}
 

--- a/backend/eventloop/workspace_event_loop.go
+++ b/backend/eventloop/workspace_event_loop.go
@@ -145,13 +145,47 @@ func startStatusCheckTicker(interval time.Duration, input chan workspaceEventLoo
 
 			input <- workspaceEventLoopMessage{
 				messageType: workspaceEventLoopMessageType_statusTicker,
-				payload:     nil,
+				payload:     eventlooptypes.EventLoopMessage{},
 			}
 		}
 
 	}()
 
 	return ticker
+}
+
+// workspaceEventLoopInternalState is the internal state of the workspace event loop.
+// - represents the internal state of the workspace event loop
+// - thus variables inside this struct should only be called from within the workspace event loop.
+type workspaceEventLoopInternalState struct {
+
+	// input is the channel that the workspace event loop will read messages from
+	input chan workspaceEventLoopMessage
+
+	// orphanedResources:
+	// - key: gitops depl name
+	// - value: map: name field of orphaned syncrun CR -> last event that referenced it
+	orphanedResources map[string]map[string]eventlooptypes.EventLoopEvent
+
+	// applicationMap: maintains a list of which which GitOpsDeployment resources (1-1 relationship) are handled by which Go Routines
+	// - key: string, of format "(namespace UID)-(namespace name)-(GitOpsDeployment name)"
+	// - value:  channel for the go routine responsible for handling events for this GitOpsDeployment
+	applicationMap map[string]workspaceEventLoop_applicationEventLoopEntry
+
+	// workspaceResourceLoop is a reference to the workspace resource loop
+	workspaceResourceLoop *workspaceResourceEventLoop
+
+	// sharedResourceEventLoop is a reference to the shared resource loop
+	sharedResourceEventLoop *shared_resource_loop.SharedResourceEventLoop
+
+	// namespaceID is the UID of the namespace that the workspace event loop is handling
+	namespaceID string
+
+	// log is the logger to use when logging inside the workspace event loop
+	log logr.Logger
+
+	// applEventLoopFactory is the factory function to use, to create the application event loop
+	applEventLoopFactory applicationEventQueueLoopFactory
 }
 
 // workspaceEventLoopRouter receives all events for the namespace, and passes them to specific goroutine responsible
@@ -168,17 +202,17 @@ func workspaceEventLoopRouter(input chan workspaceEventLoopMessage, namespaceID 
 
 	sharedResourceEventLoop := shared_resource_loop.NewSharedResourceLoop()
 
-	workspaceResourceLoop := newWorkspaceResourceLoop(sharedResourceEventLoop, input)
+	state := workspaceEventLoopInternalState{
+		sharedResourceEventLoop: sharedResourceEventLoop,
+		orphanedResources:       map[string]map[string]eventlooptypes.EventLoopEvent{},
+		applicationMap:          map[string]workspaceEventLoop_applicationEventLoopEntry{},
+		applEventLoopFactory:    applEventLoopFactory,
+		workspaceResourceLoop:   newWorkspaceResourceLoop(sharedResourceEventLoop, input),
 
-	// orphanedResources:
-	// - key: gitops depl name
-	// - value: map: name field of orphaned syncrun CR -> last event that referenced it
-	orphanedResources := map[string]map[string]eventlooptypes.EventLoopEvent{}
-
-	// applicationMap: maintains a list of which which GitOpsDeployment resources (1-1 relationship) are handled by which Go Routines
-	// - key: string, of format "(namespace UID)-(namespace name)-(GitOpsDeployment name)"
-	// - value:  channel for the go routine responsible for handling events for this GitOpsDeployment
-	applicationMap := map[string]workspaceEventLoop_applicationEventLoopEntry{}
+		log:         log,
+		input:       input,
+		namespaceID: namespaceID,
+	}
 
 	statusTicker := startStatusCheckTicker(statusCheckInterval, input)
 	defer statusTicker.Stop()
@@ -187,163 +221,198 @@ func workspaceEventLoopRouter(input chan workspaceEventLoopMessage, namespaceID 
 		wrapperEvent := <-input
 
 		event := (wrapperEvent.payload).(eventlooptypes.EventLoopMessage)
-		ctx = sharedutil.AddKCPClusterToContext(ctx, event.Event.Request.ClusterName)
+
+		if event.Event != nil {
+			ctx = sharedutil.AddKCPClusterToContext(ctx, event.Event.Request.ClusterName)
+		}
 
 		if wrapperEvent.messageType == workspaceEventLoopMessageType_Event {
-			// First, sanity check the event
-			if event.MessageType == eventlooptypes.ApplicationEventLoopMessageType_WorkComplete {
-				log.Error(nil, "SEVERE: invalid message type received in applicationEventLooRouter")
-				continue
-			}
-			if event.Event == nil {
-				log.Error(nil, "SEVERE: event was nil in workspaceEventLooRouter")
-				continue
-			}
+			// When the workspace event loop receive an event message, process it
 
-			log.V(sharedutil.LogLevel_Debug).Info("workspaceEventLoop received event",
-				"event", eventlooptypes.StringEventLoopEvent(event.Event))
+			handleWorkspaceEventLoopMessage(ctx, event, wrapperEvent, state)
 
-			// Check GitOpsDeployment resource events that come in: if we get an event for GitOpsDeployment that has an
-			// orphaned child resource depending on it, then unorphan the child resource.
-			if event.Event.ReqResource == eventlooptypes.GitOpsDeploymentTypeName {
-				unorphanResourcesIfPossible(ctx, event, orphanedResources, input, log)
-			}
-
-			// Handle Repository Credentials
-			if event.Event.ReqResource == eventlooptypes.GitOpsDeploymentRepositoryCredentialTypeName {
-				workspaceResourceLoop.processRepositoryCredential(ctx, event.Event.Request, event.Event.Client)
-				continue
-			}
-
-			// Handle Managed Environment
-			if event.Event.ReqResource == eventlooptypes.GitOpsDeploymentManagedEnvironmentTypeName {
-
-				// Reconcile to managed environment in the workspace resource loop, to ensure it is up-to-date (exists, or is deleted)
-				workspaceResourceLoop.processManagedEnvironment(ctx, event, event.Event.Client)
-
-				continue
-			}
-
-			var associatedGitOpsDeploymentName string // name of the GitOpsDeployment (in this namespace) that this resource is associated with
-
-			if event.Event.ReqResource == eventlooptypes.GitOpsDeploymentTypeName {
-				associatedGitOpsDeploymentName = event.Event.Request.Name
-
-			} else if event.Event.ReqResource == eventlooptypes.GitOpsDeploymentSyncRunTypeName {
-
-				associatedGitOpsDeploymentName = checkIfOrphanedGitOpsDeploymentSyncRun(ctx, event, orphanedResources, log)
-
-				if associatedGitOpsDeploymentName == "" {
-					// The SyncRun no longer exists, or an unrecoverable error occurred, so just continue
-					continue
-				}
-			}
-
-			if associatedGitOpsDeploymentName == "" {
-				// Sanity check the name field is non-empty
-				log.Error(nil, "SEVERE: received a resource event that we could not determine a GitOpsDeployment name for", "event", eventlooptypes.StringEventLoopEvent(event.Event))
-				continue
-			}
-
-			mapKey := namespaceID + "-" + event.Event.Request.Namespace + "-" + associatedGitOpsDeploymentName
-
-			applicationEntryVal, exists := applicationMap[mapKey]
-			if !exists {
-
-				var err error
-				applicationEntryVal, err = startApplicationEventQueueLoop(ctx, associatedGitOpsDeploymentName, event, sharedResourceEventLoop, applEventLoopFactory, log)
-				if err != nil {
-					// We already logged the error in startApplicationEventLoop, no need to log here
-					continue
-				}
-
-				// Add the loop to our map
-				applicationMap[mapKey] = applicationEntryVal
-			}
-
-			// Send the event to the channel/go routine that handles all events for this application/gitopsdepl
-			// we wait for a response from the channel (on ResponseChan) before continuing.
-			syncResponseChan := make(chan application_event_loop.ResponseMessage)
-			applicationEntryVal.input <- application_event_loop.RequestMessage{
-				Message: eventlooptypes.EventLoopMessage{
-					MessageType: eventlooptypes.ApplicationEventLoopMessageType_Event,
-					Event:       event.Event,
-				},
-				ResponseChan: syncResponseChan,
-			}
-
-			responseMessage := <-syncResponseChan
-
-			if !responseMessage.RequestAccepted {
-				// Request was rejected: this means the application event loop has terminated.
-
-				// Remove the terminated application event loop from the map
-				delete(applicationMap, mapKey)
-
-				// Requeue the message on a separate goroutine, so it will be processed again.
-				go func() {
-					input <- wrapperEvent
-				}()
-
-				continue
-			}
-
-			// When the workspace event loop receives this message, it informs all of the applictions event loops about the event
 		} else if wrapperEvent.messageType == workspaceEventLoopMessageType_managedEnvProcessed_Event {
+			// When the workspace event loop receives this message, it informs all of the applictions event loops about the event
 
-			log.V(sharedutil.LogLevel_Debug).Info(fmt.Sprintf("received ManagedEnvironment event, passed event to %d applications",
-				len(applicationMap)))
+			handleManagedEnvProcessedMessage(event, state)
 
-			// Send a message about this ManagedEnvironment to all of the goroutines currently processing GitOpsDeployment/SyncRuns
-			for key := range applicationMap {
-				applicationEntryVal := applicationMap[key]
-
-				go func() {
-
-					applicationEntryVal.input <- application_event_loop.RequestMessage{
-						Message: eventlooptypes.EventLoopMessage{
-							MessageType: eventlooptypes.ApplicationEventLoopMessageType_Event,
-							Event:       event.Event,
-						},
-						ResponseChan: nil,
-					}
-				}()
-			}
-
+		} else if wrapperEvent.messageType == workspaceEventLoopMessageType_statusTicker {
 			// Every X minutes, the workspace event loop will send itself a message, causing it to check the
 			// status of the application event loops it is tracking, and clean them up if needed.
-		} else if wrapperEvent.messageType == workspaceEventLoopMessageType_statusTicker {
 
-			// For each of the Application Event Loops (GitOpsDeployments in the namespace) that we are tracking...
-			for key := range applicationMap {
-				applicationEntryVal := applicationMap[key]
-
-				// Send a synchronous message to each Application Event Loop, asking if it is still active
-				syncResponseChan := make(chan application_event_loop.ResponseMessage)
-
-				applicationEntryVal.input <- application_event_loop.RequestMessage{
-					Message: eventlooptypes.EventLoopMessage{
-						MessageType: eventlooptypes.ApplicationEventLoopMessageType_StatusCheck,
-						Event:       event.Event,
-					},
-					ResponseChan: syncResponseChan,
-				}
-				responseMessage := <-syncResponseChan
-
-				// If the Application Event Loop is not active (it is terminating), then the remove it from
-				// the list of active applications.
-				// - This allows us to clean up old appliction event loops.
-				if !responseMessage.RequestAccepted {
-					// Request was rejected: this means the application event loop has terminated.
-					// Remove the terminated application event loop from the map
-					delete(applicationMap, key)
-				}
-			}
+			handleStatusTickerMessage(event, state)
 
 		} else {
 			log.Error(nil, "SEVERE: unrecognized workspace event loop message type")
 		}
 	}
+}
+
+func handleWorkspaceEventLoopMessage(ctx context.Context, event eventlooptypes.EventLoopMessage, wrapperEvent workspaceEventLoopMessage,
+	state workspaceEventLoopInternalState) {
+
+	log := state.log
+
+	// First, sanity check the event
+	if event.MessageType == eventlooptypes.ApplicationEventLoopMessageType_WorkComplete {
+		log.Error(nil, "SEVERE: invalid message type received in applicationEventLooRouter")
+		return
+	}
+	if event.Event == nil {
+		log.Error(nil, "SEVERE: event was nil in workspaceEventLooRouter")
+		return
+	}
+
+	log.V(sharedutil.LogLevel_Debug).Info("workspaceEventLoop received event", "event", eventlooptypes.StringEventLoopEvent(event.Event))
+
+	// If it's a GitOpsDeploymentSyncRun:
+	//   - If the SyncRun exists, use the name that was specified
+	//   - If the Syncrun doesn't exist, retrieve from the database
+	//     - If it's not found in the database, it's orphaned.
+
+	// Check GitOpsDeployment resource events that come in: if we get an event for GitOpsDeployment that has an
+	// orphaned child resource depending on it, then unorphan the child resource.
+	if event.Event.ReqResource == eventlooptypes.GitOpsDeploymentTypeName {
+		unorphanResourcesIfPossible(ctx, event, state.orphanedResources, state.input, log)
+	}
+
+	// Repository Credentials: Handle, then reutrn
+	if event.Event.ReqResource == eventlooptypes.GitOpsDeploymentRepositoryCredentialTypeName {
+		state.workspaceResourceLoop.processRepositoryCredential(ctx, event.Event.Request, event.Event.Client)
+		return
+	}
+
+	// Managed Environment: Handle, then return
+	if event.Event.ReqResource == eventlooptypes.GitOpsDeploymentManagedEnvironmentTypeName {
+
+		// Reconcile to managed environment in the workspace resource loop, to ensure it is up-to-date (exists, or is deleted)
+		state.workspaceResourceLoop.processManagedEnvironment(ctx, event, event.Event.Client)
+
+		return
+	}
+
+	var associatedGitOpsDeploymentName string // name of the GitOpsDeployment (in this namespace) that this resource is associated with
+
+	if event.Event.ReqResource == eventlooptypes.GitOpsDeploymentTypeName {
+		associatedGitOpsDeploymentName = event.Event.Request.Name
+
+	} else if event.Event.ReqResource == eventlooptypes.GitOpsDeploymentSyncRunTypeName {
+
+		associatedGitOpsDeploymentName = checkIfOrphanedGitOpsDeploymentSyncRun(ctx, event, state.orphanedResources, log)
+
+		if associatedGitOpsDeploymentName == "" {
+			// The SyncRun no longer exists, or an unrecoverable error occurred, so just continue
+			return
+		}
+	}
+
+	if associatedGitOpsDeploymentName == "" {
+		// Sanity check the name field is non-empty
+		log.Error(nil, "SEVERE: received a resource event that we could not determine a GitOpsDeployment name for", "event", eventlooptypes.StringEventLoopEvent(event.Event))
+		return
+	}
+
+	mapKey := state.namespaceID + "-" + event.Event.Request.Namespace + "-" + associatedGitOpsDeploymentName
+
+	applicationEntryVal, exists := state.applicationMap[mapKey]
+	if !exists {
+
+		var err error
+		applicationEntryVal, err = startApplicationEventQueueLoop(ctx, associatedGitOpsDeploymentName, event,
+			state.sharedResourceEventLoop, state.applEventLoopFactory, log)
+		if err != nil {
+			// We already logged the error in startApplicationEventLoop, no need to log here
+			return
+		}
+
+		// Add the loop to our map
+		state.applicationMap[mapKey] = applicationEntryVal
+	}
+
+	// Send the event to the channel/go routine that handles all events for this application/gitopsdepl
+	// we wait for a response from the channel (on ResponseChan) before continuing.
+	syncResponseChan := make(chan application_event_loop.ResponseMessage)
+	applicationEntryVal.input <- application_event_loop.RequestMessage{
+		Message: eventlooptypes.EventLoopMessage{
+			MessageType: eventlooptypes.ApplicationEventLoopMessageType_Event,
+			Event:       event.Event,
+		},
+		ResponseChan: syncResponseChan,
+	}
+
+	responseMessage := <-syncResponseChan
+
+	if !responseMessage.RequestAccepted {
+		// Request was rejected: this means the application event loop has terminated.
+
+		// Remove the terminated application event loop from the map
+		delete(state.applicationMap, mapKey)
+
+		// Requeue the message on a separate goroutine, so it will be processed again.
+		go func() {
+			state.input <- wrapperEvent
+		}()
+
+		return
+	}
+
+}
+
+// handleManagedEnvProcessedMessage: when the workspace event loop receives this message, it informs all of
+// the applictions event loops about the event.
+func handleManagedEnvProcessedMessage(event eventlooptypes.EventLoopMessage, state workspaceEventLoopInternalState) {
+
+	state.log.V(sharedutil.LogLevel_Debug).Info(fmt.Sprintf("received ManagedEnvironment event, passed event to %d applications",
+		len(state.applicationMap)))
+
+	// Send a message about this ManagedEnvironment to all of the goroutines currently processing GitOpsDeployment/SyncRuns
+	for key := range state.applicationMap {
+		applicationEntryVal := state.applicationMap[key]
+
+		go func() {
+
+			applicationEntryVal.input <- application_event_loop.RequestMessage{
+				Message: eventlooptypes.EventLoopMessage{
+					MessageType: eventlooptypes.ApplicationEventLoopMessageType_Event,
+					Event:       event.Event,
+				},
+				ResponseChan: nil,
+			}
+		}()
+	}
+
+}
+
+// handleStatusTickerMessage: every X minutes, the workspace event loop will send itself a message, causing it to
+// check the status of the application event loops it is tracking, and clean them up if needed.
+func handleStatusTickerMessage(event eventlooptypes.EventLoopMessage, state workspaceEventLoopInternalState) {
+
+	// For each of the Application Event Loops (GitOpsDeployments in the namespace) that we are tracking...
+	for key := range state.applicationMap {
+		applicationEntryVal := state.applicationMap[key]
+
+		// Send a synchronous message to each Application Event Loop, asking if it is still active
+		syncResponseChan := make(chan application_event_loop.ResponseMessage)
+
+		applicationEntryVal.input <- application_event_loop.RequestMessage{
+			Message: eventlooptypes.EventLoopMessage{
+				MessageType: eventlooptypes.ApplicationEventLoopMessageType_StatusCheck,
+				Event:       event.Event,
+			},
+			ResponseChan: syncResponseChan,
+		}
+		responseMessage := <-syncResponseChan
+
+		// If the Application Event Loop is not active (it is terminating), then the remove it from
+		// the list of active applications.
+		// - This allows us to clean up old appliction event loops.
+		if !responseMessage.RequestAccepted {
+			// Request was rejected: this means the application event loop has terminated.
+			// Remove the terminated application event loop from the map
+			delete(state.applicationMap, key)
+		}
+	}
+
 }
 
 func startApplicationEventQueueLoop(ctx context.Context, associatedGitOpsDeploymentName string, event eventlooptypes.EventLoopMessage,

--- a/backend/eventloop/workspace_event_loop_test.go
+++ b/backend/eventloop/workspace_event_loop_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 			Expect(result).NotTo(BeNil())
 
 			Expect(result.ResponseChan).ToNot(BeNil())
-			result.ResponseChan <- application_event_loop.ApplicationEventLoopResponseMessage{
+			result.ResponseChan <- application_event_loop.ResponseMessage{
 				RequestAccepted: true,
 			}
 
@@ -154,7 +154,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 			Expect(result).NotTo(BeNil())
 
 			Expect(result.ResponseChan).ToNot(BeNil())
-			result.ResponseChan <- application_event_loop.ApplicationEventLoopResponseMessage{
+			result.ResponseChan <- application_event_loop.ResponseMessage{
 				RequestAccepted: true,
 			}
 
@@ -211,7 +211,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 			Expect(result).NotTo(BeNil())
 
 			Expect(result.ResponseChan).ToNot(BeNil())
-			result.ResponseChan <- application_event_loop.ApplicationEventLoopResponseMessage{
+			result.ResponseChan <- application_event_loop.ResponseMessage{
 				RequestAccepted: true,
 			}
 			Expect(result.Message).NotTo(BeNil())
@@ -335,7 +335,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 			// Make sure this is the gitopsdeployment event from above
 			Expect(deploymentModifiedMsg).NotTo(BeNil())
 			Expect(deploymentModifiedMsg.ResponseChan).NotTo(BeNil())
-			deploymentModifiedMsg.ResponseChan <- application_event_loop.ApplicationEventLoopResponseMessage{
+			deploymentModifiedMsg.ResponseChan <- application_event_loop.ResponseMessage{
 				RequestAccepted: true,
 			}
 			Expect(deploymentModifiedMsg.Message).NotTo(BeNil())
@@ -347,7 +347,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 			// Make sure this is the gitopsdeploymentsyncrun event from above
 			Expect(syncRunModifiedMsg).NotTo(BeNil())
 			Expect(syncRunModifiedMsg.ResponseChan).NotTo(BeNil())
-			syncRunModifiedMsg.ResponseChan <- application_event_loop.ApplicationEventLoopResponseMessage{
+			syncRunModifiedMsg.ResponseChan <- application_event_loop.ResponseMessage{
 				RequestAccepted: true,
 			}
 			Expect(syncRunModifiedMsg.Message).NotTo(BeNil())
@@ -423,7 +423,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 				result := <-tAELF.outputChannel2Inner[gitopsDepl.Name]
 				Expect(result).NotTo(BeNil())
 				Expect(result.ResponseChan).NotTo(BeNil())
-				result.ResponseChan <- application_event_loop.ApplicationEventLoopResponseMessage{
+				result.ResponseChan <- application_event_loop.ResponseMessage{
 					RequestAccepted: true,
 				}
 
@@ -440,7 +440,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 
 			By("Starting the workspace event loop with our custom test factory, so that we can capture output")
 			tAELF := &managedEnvironmentTestApplicationEventLoopFactory{
-				outputChannel2Inner: map[string]chan application_event_loop.ApplicationEventLoopRequestMessage{},
+				outputChannel2Inner: map[string]chan application_event_loop.RequestMessage{},
 			}
 			workspaceEventLoopRouter := newWorkspaceEventLoopRouterWithFactory(string(apiNamespace.UID), tAELF)
 
@@ -474,7 +474,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 
 			By("Starting the workspace event loop with our custom test factory, so that we can capture output")
 			tAELF := &managedEnvironmentTestApplicationEventLoopFactory{
-				outputChannel2Inner: map[string]chan application_event_loop.ApplicationEventLoopRequestMessage{},
+				outputChannel2Inner: map[string]chan application_event_loop.RequestMessage{},
 			}
 			workspaceEventLoopRouter := newWorkspaceEventLoopRouterWithFactory(string(apiNamespace.UID), tAELF)
 
@@ -506,14 +506,14 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 
 			By("ensuring that each mock GitOpsDeployment runner was forwarded the managed environment event")
 
-			messagesReceived := map[string][]application_event_loop.ApplicationEventLoopRequestMessage{}
+			messagesReceived := map[string][]application_event_loop.RequestMessage{}
 
 			for idx := range gitopsDeployments {
 				var mutex sync.Mutex
 
 				gitopsDeployment := gitopsDeployments[idx]
 
-				eventLoopMsgsReceived := []application_event_loop.ApplicationEventLoopRequestMessage{}
+				eventLoopMsgsReceived := []application_event_loop.RequestMessage{}
 
 				By("starting a goroutine which writes all received events to eventLoopMsgsReceived for " + string(gitopsDeployment.UID))
 				go func() {
@@ -542,7 +542,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 				}, "500ms", "50ms").Should(BeTrue())
 
 				By("adding all received messages to messagesReceived, for final expect checks")
-				messagesReceived[string(gitopsDeployment.UID)] = []application_event_loop.ApplicationEventLoopRequestMessage{}
+				messagesReceived[string(gitopsDeployment.UID)] = []application_event_loop.RequestMessage{}
 				mutex.Lock()
 				defer mutex.Unlock()
 				for idx := range eventLoopMsgsReceived {
@@ -572,7 +572,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 // testApplicationEventLoopFactory is a mock applicationEventQueueLoopFactory, used for unit tests above.
 type testApplicationEventLoopFactory struct {
 	mutex                     sync.Mutex
-	outputChannelInner        chan application_event_loop.ApplicationEventLoopRequestMessage
+	outputChannelInner        chan application_event_loop.RequestMessage
 	numberOfEventLoopsCreated int
 }
 
@@ -608,7 +608,7 @@ func (ta *testApplicationEventLoopFactory) startApplicationEventQueueLoop(ctx co
 
 // testApplicationEventLoopFactory is a mock applicationEventQueueLoopFactory, used for unit tests above.
 type managedEnvironmentTestApplicationEventLoopFactory struct {
-	outputChannel2Inner       map[string]chan application_event_loop.ApplicationEventLoopRequestMessage
+	outputChannel2Inner       map[string]chan application_event_loop.RequestMessage
 	numberOfEventLoopsCreated int
 	mutex                     sync.Mutex
 }

--- a/backend/eventloop/workspace_event_loop_test.go
+++ b/backend/eventloop/workspace_event_loop_test.go
@@ -456,7 +456,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 				Client:    k8sClient,
 			}
 			workspaceEventLoopRouter.channel <- workspaceEventLoopMessage{
-				messageType: managedEnvProcessed_Event,
+				messageType: workspaceEventLoopMessageType_managedEnvProcessed_Event,
 				payload: eventlooptypes.EventLoopMessage{
 					MessageType: eventlooptypes.ApplicationEventLoopMessageType_Event,
 					Event:       internalEvent,
@@ -497,7 +497,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 				Client:    k8sClient,
 			}
 			workspaceEventLoopRouter.channel <- workspaceEventLoopMessage{
-				messageType: managedEnvProcessed_Event,
+				messageType: workspaceEventLoopMessageType_managedEnvProcessed_Event,
 				payload: eventlooptypes.EventLoopMessage{
 					MessageType: eventlooptypes.ApplicationEventLoopMessageType_Event,
 					Event:       internalEvent,

--- a/backend/eventloop/workspace_resource_event_loop.go
+++ b/backend/eventloop/workspace_resource_event_loop.go
@@ -214,6 +214,11 @@ func internalProcessWorkspaceResourceMessage(ctx context.Context, msg workspaceR
 		if !ok {
 			return noRetry, fmt.Errorf("invalid payload in processWorkspaceResourceMessage")
 		}
+
+		if evlMessage.Event == nil { // Sanity test the message
+			log.Error(nil, "SEVERE: process managed env event is nil")
+		}
+
 		req := evlMessage.Event.Request
 
 		ctx = sharedutil.AddKCPClusterToContext(ctx, req.ClusterName)

--- a/backend/eventloop/workspace_resource_event_loop.go
+++ b/backend/eventloop/workspace_resource_event_loop.go
@@ -246,7 +246,7 @@ func internalProcessWorkspaceResourceMessage(ctx context.Context, msg workspaceR
 		// - Send it on another go routine to keep from blocking this one
 		go func() {
 			workspaceEventLoopInputChannel <- workspaceEventLoopMessage{
-				messageType: managedEnvProcessed_Event,
+				messageType: workspaceEventLoopMessageType_managedEnvProcessed_Event,
 				payload:     evlMessage,
 			}
 		}()

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
@@ -264,7 +264,7 @@ func (task *processOperationEventTask) PerformTask(taskContext context.Context) 
 
 		if err != nil {
 			// TODO: GITOPSRVCE-77 - SECURITY - At some point, we will likely want to sanitize the error value for users
-			dbOperation.Human_readable_state = err.Error()
+			dbOperation.Human_readable_state = db.TruncateVarchar(err.Error(), db.OperationHumanReadableStateLength)
 		}
 
 		// Update the Operation row of the database, based on the new state.
@@ -366,7 +366,7 @@ func (task *processOperationEventTask) internalPerformTask(taskContext context.C
 	// gitopsengineinstance matches the gitops engine cluster we are running on.
 	kubeSystemNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Namespace: "kube-system"}}
 	if err := eventClient.Get(taskContext, client.ObjectKeyFromObject(kubeSystemNamespace), kubeSystemNamespace); err != nil {
-		log.Error(err, "SEVERE: Unable to retrieve kube-system namespace")
+		log.Error(err, "Unable to retrieve kube-system namespace")
 		return &dbOperation, shouldRetryTrue, fmt.Errorf("unable to retrieve kube-system namespace in internalPerformTask")
 	}
 	if thisCluster, err := dbutil.GetGitopsEngineClusterByKubeSystemNamespaceUID(taskContext, string(kubeSystemNamespace.UID), dbQueries, log); err != nil {

--- a/tests-e2e/core/gitopsdeployment_test.go
+++ b/tests-e2e/core/gitopsdeployment_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	typed "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -32,13 +33,19 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 	Context("Create, Update and Delete a GitOpsDeployment ", func() {
 
-		// this assumes that service is running on non aware kcp client
-		config, err := fixture.GetSystemKubeConfig()
-		Expect(err).To(BeNil())
-
-		k8sClient, err := fixture.GetKubeClient(config)
-		Expect(err).To(BeNil())
+		var config *rest.Config
+		var k8sClient client.Client
 		ctx := context.Background()
+
+		// this assumes that service is running on non aware kcp client
+		BeforeEach(func() {
+			var err error
+			config, err = fixture.GetSystemKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err = fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+		})
 
 		AfterEach(func() {
 			// At end of a test, output the state of Argo CD Application, for post-mortem debuggign

--- a/tests-e2e/core/gitopsdeployment_test.go
+++ b/tests-e2e/core/gitopsdeployment_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
 	typed "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -733,7 +734,9 @@ func expectAllResourcesToBeDeleted(expectedResourceStatusList []managedgitopsv1a
 				GinkgoWriter.Println("unrecognize kind:", resourceValue.Kind)
 				return false
 			}
-			if err := k8sclient.Get(context.Background(), resourceName, obj); err != nil {
+
+			// The object should not exist: a NotFound error should be returned, otherwise return false.
+			if err := k8sclient.Get(context.Background(), resourceName, obj); err == nil || !apierr.IsNotFound(err) {
 				return false
 			}
 		}

--- a/utilities/db-migration/go.mod
+++ b/utilities/db-migration/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/onsi/ginkgo/v2 v2.1.4 // indirect
 	github.com/onsi/gomega v1.20.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect

--- a/utilities/db-migration/go.sum
+++ b/utilities/db-migration/go.sum
@@ -919,6 +919,7 @@ github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.1.4 h1:GNapqRSid3zijZ9H77KrgVG4/8KqiyRsxcSxe+7ApXY=
+github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=


### PR DESCRIPTION
#### Description:
- This PR fixes a bug where events would stop being handled for `GitOpsDeployment`s, due to the goroutine responsible for handling them closing too early.
    - The Goroutine responsible for handling them, the application event loop, would terminate when the GitOpsDeployment resources was deleted.
    - However, the workspace event loop would not know that the application event loop has closed, and so the workspace event loop would keep trying to send events to the app event loop.
    - This would block the workspace event loop, as it was trying to send a message on a channel with no receiver.
    - This was an unforeseen consequence of a [previous bug fix](https://github.com/redhat-appstudio/managed-gitops/pull/249).

Fixes:
- Application Event Loop will now receive/send `application_event_loop.RequestMessage`/`ResponseMessage` message struct, rather than the `eventlooptypes.EventLoopEvent` struct
- When a message is sent to the Application Event Loop, it will reply back with 'workRejected=true' if the Application Event Loop has shut down. 
- This allows the workspace event loop to know that it should dispose of the application event loop instance.
- This also allows the workspace event loop not to send any more messages to this application event loop instance.

Technical details:
- Some light refactoring to reduce the # of variables we need to pass as parameters to functions
- Update workspace event loop to call Application Event Loop with the new message format
- Update workspace event loop to wait for responses to messages, and delete the application event loop from the map when the application event loop has terminated
- updated unit test cases to use new struct, and to send/receive sync messages

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
