### PR TITLE
Error is set in .status.conditions field when path field is empty

### DIFF
--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_types.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_types.go
@@ -44,7 +44,7 @@ type ApplicationSource struct {
 	// RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
 	RepoURL string `json:"repoURL"`
 	// Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
-	Path string `json:"path,omitempty"`
+	Path string `json:"path"`
 	// TargetRevision defines the revision of the source to sync the application to.
 	// In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD.
 	// In case of Helm, this is a semver tag for the Chart's version.
@@ -178,8 +178,9 @@ type GitOpsDeploymentCondition struct {
 type GitOpsDeploymentConditionType string
 
 const (
-	GitOpsDeploymentConditionSyncError     GitOpsDeploymentConditionType = "SyncError"
-	GitOpsDeploymentConditionErrorOccurred GitOpsDeploymentConditionType = "ErrorOccurred"
+	GitOpsDeploymentConditionSyncError        GitOpsDeploymentConditionType = "SyncError"
+	GitOpsDeploymentConditionErrorOccurred    GitOpsDeploymentConditionType = "ErrorOccurred"
+	GitOpsDeploymentConditionInvalidSpecError GitOpsDeploymentConditionType = "InvalidSpecError"
 )
 
 // GitOpsConditionStatus is a type which represents possible comparison results
@@ -198,8 +199,9 @@ const (
 type GitOpsDeploymentReasonType string
 
 const (
-	GitopsDeploymentReasonSyncError     GitOpsDeploymentReasonType = "SyncError"
-	GitopsDeploymentReasonErrorOccurred GitOpsDeploymentReasonType = "ErrorOccurred"
+	GitopsDeploymentReasonSyncError        GitOpsDeploymentReasonType = "SyncError"
+	GitopsDeploymentReasonErrorOccurred    GitOpsDeploymentReasonType = "ErrorOccurred"
+	GitOpsDeploymentReasonInvalidSpecError GitOpsDeploymentReasonType = "InvalidSpecError"
 )
 
 //+kubebuilder:object:root=true

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_types.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_types.go
@@ -202,6 +202,11 @@ const (
 	GitopsDeploymentReasonErrorOccurred GitOpsDeploymentReasonType = "ErrorOccurred"
 )
 
+const (
+	GitOpsDeploymentUserError_InvalidPathSlash = "spec.source.path cannot be '/'"
+	GitOpsDeploymentUserError_PathIsRequired   = "spec.source.path is a required field and it cannot be empty"
+)
+
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_types.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_types.go
@@ -178,9 +178,8 @@ type GitOpsDeploymentCondition struct {
 type GitOpsDeploymentConditionType string
 
 const (
-	GitOpsDeploymentConditionSyncError        GitOpsDeploymentConditionType = "SyncError"
-	GitOpsDeploymentConditionErrorOccurred    GitOpsDeploymentConditionType = "ErrorOccurred"
-	GitOpsDeploymentConditionInvalidSpecError GitOpsDeploymentConditionType = "InvalidSpecError"
+	GitOpsDeploymentConditionSyncError     GitOpsDeploymentConditionType = "SyncError"
+	GitOpsDeploymentConditionErrorOccurred GitOpsDeploymentConditionType = "ErrorOccurred"
 )
 
 // GitOpsConditionStatus is a type which represents possible comparison results
@@ -199,9 +198,8 @@ const (
 type GitOpsDeploymentReasonType string
 
 const (
-	GitopsDeploymentReasonSyncError        GitOpsDeploymentReasonType = "SyncError"
-	GitopsDeploymentReasonErrorOccurred    GitOpsDeploymentReasonType = "ErrorOccurred"
-	GitOpsDeploymentReasonInvalidSpecError GitOpsDeploymentReasonType = "InvalidSpecError"
+	GitopsDeploymentReasonSyncError     GitOpsDeploymentReasonType = "SyncError"
+	GitopsDeploymentReasonErrorOccurred GitOpsDeploymentReasonType = "ErrorOccurred"
 )
 
 //+kubebuilder:object:root=true

--- a/backend-shared/config/crd/bases/managed-gitops.redhat.com_gitopsdeployments.yaml
+++ b/backend-shared/config/crd/bases/managed-gitops.redhat.com_gitopsdeployments.yaml
@@ -68,6 +68,7 @@ spec:
                       this is a semver tag for the Chart's version.
                     type: string
                 required:
+                - path
                 - repoURL
                 type: object
               type:

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -794,10 +794,28 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleUpdateD
 	if applicationState.SyncError != "" {
 		condition.NewConditionManager().SetCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionSyncError, managedgitopsv1alpha1.GitOpsConditionStatusTrue, managedgitopsv1alpha1.GitopsDeploymentReasonSyncError, applicationState.SyncError)
 	} else {
-		// Update syncError Condition as false if applicationState.SyncError field in database is empty
-		reason := managedgitopsv1alpha1.GitopsDeploymentReasonSyncError + "Resolved"
-		if cond, _ := condition.NewConditionManager().FindCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionSyncError); cond.Reason != reason {
-			condition.NewConditionManager().SetCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionSyncError, managedgitopsv1alpha1.GitOpsConditionStatusFalse, reason, "")
+		// Update syncError Condition as false if applicationState.SyncError field in database is empty by checking if the condition field is empty or not
+		if condition.NewConditionManager().HasCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionSyncError) {
+			reason := managedgitopsv1alpha1.GitopsDeploymentReasonSyncError + "Resolved"
+			if cond, _ := condition.NewConditionManager().FindCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionSyncError); cond.Reason != reason {
+				condition.NewConditionManager().SetCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionSyncError, managedgitopsv1alpha1.GitOpsConditionStatusFalse, reason, "")
+			}
+		}
+	}
+
+	// Set gitopsDeploymentCondition if spec.source.path field is empty or '/'
+	if gitopsDeployment.Spec.Source.Path == "" {
+		condition.NewConditionManager().SetCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError, managedgitopsv1alpha1.GitOpsConditionStatusTrue, managedgitopsv1alpha1.GitOpsDeploymentReasonInvalidSpecError, "spec.source.path is a required field and it cannot be empty")
+	} else if gitopsDeployment.Spec.Source.Path == "/" {
+		condition.NewConditionManager().SetCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError, managedgitopsv1alpha1.GitOpsConditionStatusTrue, managedgitopsv1alpha1.GitOpsDeploymentReasonInvalidSpecError, "spec.source.path cannot be '/'")
+	} else {
+		// Update Condition as Resolved if gitopsDeployment.Spec.Source.Path is updated with correct value
+		if condition.NewConditionManager().HasCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError) {
+			reason := managedgitopsv1alpha1.GitOpsDeploymentReasonInvalidSpecError + "Resolved"
+			if cond, _ := condition.NewConditionManager().FindCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError); cond.Reason != reason {
+				cond.Message = ""
+				condition.NewConditionManager().SetCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError, managedgitopsv1alpha1.GitOpsConditionStatusFalse, reason, "")
+			}
 		}
 	}
 

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -106,6 +106,16 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleDeploym
 		}
 	}
 
+	if gitopsDeployment != nil {
+		if gitopsDeployment.Spec.Source.Path == "" {
+			userError := "spec.source.path is a required field and it cannot be empty"
+			return signalledShutdown_false, nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewUserDevError(userError, err)
+		} else if gitopsDeployment.Spec.Source.Path == "/" {
+			userError := "spec.source.path cannot be '/'"
+			return signalledShutdown_false, nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewUserDevError(userError, err)
+		}
+	}
+
 	// Update the list of GitOpsDeployments that we use to generate metrics
 	if gitopsDeployment != nil {
 		metrics.AddOrUpdateGitOpsDeployment(deplName, deplNamespace, string(gitopsDeplNamespace.UID))
@@ -799,22 +809,6 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleUpdateD
 			reason := managedgitopsv1alpha1.GitopsDeploymentReasonSyncError + "Resolved"
 			if cond, _ := condition.NewConditionManager().FindCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionSyncError); cond.Reason != reason {
 				condition.NewConditionManager().SetCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionSyncError, managedgitopsv1alpha1.GitOpsConditionStatusFalse, reason, "")
-			}
-		}
-	}
-
-	// Set gitopsDeploymentCondition if spec.source.path field is empty or '/'
-	if gitopsDeployment.Spec.Source.Path == "" {
-		condition.NewConditionManager().SetCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError, managedgitopsv1alpha1.GitOpsConditionStatusTrue, managedgitopsv1alpha1.GitOpsDeploymentReasonInvalidSpecError, "spec.source.path is a required field and it cannot be empty")
-	} else if gitopsDeployment.Spec.Source.Path == "/" {
-		condition.NewConditionManager().SetCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError, managedgitopsv1alpha1.GitOpsConditionStatusTrue, managedgitopsv1alpha1.GitOpsDeploymentReasonInvalidSpecError, "spec.source.path cannot be '/'")
-	} else {
-		// Update Condition as Resolved if gitopsDeployment.Spec.Source.Path is updated with correct value
-		if condition.NewConditionManager().HasCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError) {
-			reason := managedgitopsv1alpha1.GitOpsDeploymentReasonInvalidSpecError + "Resolved"
-			if cond, _ := condition.NewConditionManager().FindCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError); cond.Reason != reason {
-				cond.Message = ""
-				condition.NewConditionManager().SetCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError, managedgitopsv1alpha1.GitOpsConditionStatusFalse, reason, "")
 			}
 		}
 	}

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns_test.go
@@ -44,6 +44,9 @@ var _ = Describe("Application Event Runner SyncRuns", func() {
 				},
 				Spec: managedgitopsv1alpha1.GitOpsDeploymentSpec{
 					Type: managedgitopsv1alpha1.GitOpsDeploymentSpecType_Manual,
+					Source: managedgitopsv1alpha1.ApplicationSource{
+						Path: "resources/test-data/sample-gitops-repository/environments/overlays/dev",
+					},
 				},
 			}
 
@@ -139,6 +142,9 @@ var _ = Describe("Application Event Runner SyncRuns", func() {
 				},
 				Spec: managedgitopsv1alpha1.GitOpsDeploymentSpec{
 					Type: managedgitopsv1alpha1.GitOpsDeploymentSpecType_Manual,
+					Source: managedgitopsv1alpha1.ApplicationSource{
+						Path: "resources/test-data/sample-gitops-repository/environments/overlays/dev",
+					},
 				},
 			}
 

--- a/backend/eventloop/application_event_loop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_test.go
@@ -946,6 +946,319 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			Expect(userDevErr).To(BeNil())
 		})
 
+		It("Should update status condition of deployment when path field of gitopsDeployment is empty", func() {
+			By("Create new deployment.")
+
+			gitopsDepl := &managedgitopsv1alpha1.GitOpsDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-gitops-depl",
+					Namespace: workspace.Name,
+					UID:       uuid.NewUUID(),
+				},
+			}
+
+			k8sClient := fake.
+				NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(gitopsDepl, workspace, argocdNamespace, kubesystemNamespace).
+				Build()
+
+			a := applicationEventLoopRunner_Action{
+				// When the code asks for a new k8s client, give it our fake client
+				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
+					return k8sClient, nil
+				},
+				eventResourceName:           gitopsDepl.Name,
+				eventResourceNamespace:      gitopsDepl.Namespace,
+				workspaceClient:             k8sClient,
+				log:                         log.FromContext(context.Background()),
+				sharedResourceEventLoop:     shared_resource_loop.NewSharedResourceLoop(),
+				workspaceID:                 workspaceID,
+				testOnlySkipCreateOperation: true,
+				k8sClientFactory: MockSRLK8sClientFactory{
+					fakeClient: k8sClient,
+				},
+			}
+
+			_, _, _, _, userDevErr := a.applicationEventRunner_handleDeploymentModified(ctx, dbQueries)
+			Expect(userDevErr).To(BeNil())
+
+			By("Get DeploymentToApplicationMapping and Application objects, to be used later.")
+			var deplToAppMapping db.DeploymentToApplicationMapping
+			{
+				var appMappings []db.DeploymentToApplicationMapping
+
+				err = dbQueries.ListDeploymentToApplicationMappingByNamespaceAndName(context.Background(), gitopsDepl.Name, gitopsDepl.Namespace, workspaceID, &appMappings)
+				Expect(err).To(BeNil())
+
+				Expect(len(appMappings)).To(Equal(1))
+
+				deplToAppMapping = appMappings[0]
+			}
+
+			By("Inserting dummy data into ApplicationState table, because we are not calling the Reconciler for this, which updates the status of application into db.")
+			var resourceStatus managedgitopsv1alpha1.ResourceStatus
+			var resources []managedgitopsv1alpha1.ResourceStatus
+			resources = append(resources, resourceStatus)
+
+			var buffer bytes.Buffer
+
+			By("Convert ResourceStatus object into String")
+			resourceStr, err := yaml.Marshal(&resources)
+			Expect(err).To(BeNil())
+
+			By("Compress the data")
+			gzipWriter, err := gzip.NewWriterLevel(&buffer, gzip.BestSpeed)
+			Expect(err).To(BeNil())
+
+			_, err = gzipWriter.Write([]byte(string(resourceStr)))
+			Expect(err).To(BeNil())
+
+			err = gzipWriter.Close()
+			Expect(err).To(BeNil())
+
+			reconciledStateString, reconciledobj, err := dummyApplicationComparedToField()
+			Expect(err).To(BeNil())
+
+			applicationState := &db.ApplicationState{
+				Applicationstate_application_id: deplToAppMapping.Application_id,
+				Health:                          string(managedgitopsv1alpha1.HeathStatusCodeHealthy),
+				Sync_Status:                     string(managedgitopsv1alpha1.SyncStatusCodeSynced),
+				Revision:                        "abcdefg",
+				Message:                         "Success",
+				Resources:                       buffer.Bytes(),
+				ReconciledState:                 reconciledStateString,
+			}
+
+			err = dbQueries.CreateApplicationState(ctx, applicationState)
+			Expect(err).To(BeNil())
+
+			By("Retrieve latest version of GitOpsDeployment and check Health/Sync before calling applicationEventRunner_handleUpdateDeploymentStatusTick function.")
+			gitopsDeployment := &managedgitopsv1alpha1.GitOpsDeployment{}
+			gitopsDeploymentKey := client.ObjectKey{Namespace: gitopsDepl.Namespace, Name: gitopsDepl.Name}
+
+			clientErr := a.workspaceClient.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
+			Expect(clientErr).To(BeNil())
+
+			By("Verify gitopsDeployment.Spec.Source.Path is empty")
+			Expect(gitopsDeployment.Spec.Source.Path).To(BeEmpty())
+
+			Expect(gitopsDeployment.Status.Health.Status).To(BeEmpty())
+			Expect(gitopsDeployment.Status.Sync.Status).To(BeEmpty())
+			Expect(gitopsDeployment.Status.Sync.Revision).To(BeEmpty())
+			Expect(gitopsDeployment.Status.Health.Message).To(BeEmpty())
+			Expect(gitopsDeployment.Status.ReconciledState.Destination.Namespace).To(BeEmpty())
+			Expect(gitopsDeployment.Status.ReconciledState.Destination.Name).To(BeEmpty())
+			Expect(gitopsDeployment.Status.Conditions).To(BeNil())
+
+			By("Call applicationEventRunner_handleUpdateDeploymentStatusTick function to update Health/Sync status.")
+			err = a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDepl.Name, gitopsDepl.Namespace, dbQueries)
+			Expect(err).To(BeNil())
+
+			By("Retrieve latest version of GitOpsDeployment and check Health/Sync after calling applicationEventRunner_handleUpdateDeploymentStatusTick function.")
+			clientErr = a.workspaceClient.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
+			Expect(clientErr).To(BeNil())
+
+			Expect(gitopsDeployment.Status.Health.Status).To(Equal(managedgitopsv1alpha1.HeathStatusCodeHealthy))
+			Expect(gitopsDeployment.Status.Sync.Status).To(Equal(managedgitopsv1alpha1.SyncStatusCodeSynced))
+			Expect(gitopsDeployment.Status.Sync.Revision).To(Equal("abcdefg"))
+			Expect(gitopsDeployment.Status.Health.Message).To(Equal("Success"))
+			Expect(gitopsDeployment.Status.ReconciledState.Source.Path).To(Equal(reconciledobj.Source.Path))
+			Expect(gitopsDeployment.Status.ReconciledState.Source.RepoURL).To(Equal(reconciledobj.Source.RepoURL))
+			Expect(gitopsDeployment.Status.ReconciledState.Source.Branch).To(Equal(reconciledobj.Source.TargetRevision))
+			Expect(gitopsDeployment.Status.ReconciledState.Destination.Namespace).To(Equal(reconciledobj.Destination.Namespace))
+
+			matchingCondition, _ := conditions.NewConditionManager().FindCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError)
+			Expect(matchingCondition).ToNot(BeNil())
+			Expect(matchingCondition.Message).To(Equal("spec.source.path is a required field and it cannot be empty"))
+			Expect(matchingCondition.Status).To(Equal(managedgitopsv1alpha1.GitOpsConditionStatusTrue))
+			Expect(matchingCondition.Type).To(Equal(managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError))
+
+			clientErr = a.workspaceClient.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
+			Expect(clientErr).To(BeNil())
+
+			By("Update the path to verify whether gitopsDeployment condition status is false")
+			gitopsDeployment.Spec.Source.Path = "resources/test-data/sample-gitops-repository/environments/overlays/dev"
+			err = k8sClient.Update(ctx, gitopsDeployment)
+			Expect(err).To(BeNil())
+
+			err = a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDepl.Name, gitopsDepl.Namespace, dbQueries)
+			Expect(err).To(BeNil())
+
+			clientErr = a.workspaceClient.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
+			Expect(clientErr).To(BeNil())
+
+			By("Verify whether gitOpsCondition status is false")
+			matchingCondition, _ = conditions.NewConditionManager().FindCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError)
+			Expect(matchingCondition).ToNot(BeNil())
+			Expect(matchingCondition.Status).To(Equal(managedgitopsv1alpha1.GitOpsConditionStatusFalse))
+			Expect(matchingCondition.Message).To(Equal(""))
+
+			By("Delete GitOpsDepl to clean resources.")
+			err = k8sClient.Delete(ctx, gitopsDepl)
+			Expect(err).To(BeNil())
+
+		})
+
+		It("Should update status condition of deployment when path field of gitopsDeployment is '/' ", func() {
+			By("Create new deployment.")
+
+			gitopsDepl := &managedgitopsv1alpha1.GitOpsDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-gitops-depl",
+					Namespace: workspace.Name,
+					UID:       uuid.NewUUID(),
+				},
+				Spec: managedgitopsv1alpha1.GitOpsDeploymentSpec{
+					Source: managedgitopsv1alpha1.ApplicationSource{
+						Path: "/",
+					},
+				},
+			}
+
+			k8sClient := fake.
+				NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(gitopsDepl, workspace, argocdNamespace, kubesystemNamespace).
+				Build()
+
+			a := applicationEventLoopRunner_Action{
+				// When the code asks for a new k8s client, give it our fake client
+				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
+					return k8sClient, nil
+				},
+				eventResourceName:           gitopsDepl.Name,
+				eventResourceNamespace:      gitopsDepl.Namespace,
+				workspaceClient:             k8sClient,
+				log:                         log.FromContext(context.Background()),
+				sharedResourceEventLoop:     shared_resource_loop.NewSharedResourceLoop(),
+				workspaceID:                 workspaceID,
+				testOnlySkipCreateOperation: true,
+				k8sClientFactory: MockSRLK8sClientFactory{
+					fakeClient: k8sClient,
+				},
+			}
+
+			_, _, _, _, userDevErr := a.applicationEventRunner_handleDeploymentModified(ctx, dbQueries)
+			Expect(userDevErr).To(BeNil())
+
+			By("Get DeploymentToApplicationMapping and Application objects, to be used later.")
+			var deplToAppMapping db.DeploymentToApplicationMapping
+			{
+				var appMappings []db.DeploymentToApplicationMapping
+
+				err = dbQueries.ListDeploymentToApplicationMappingByNamespaceAndName(context.Background(), gitopsDepl.Name, gitopsDepl.Namespace, workspaceID, &appMappings)
+				Expect(err).To(BeNil())
+
+				Expect(len(appMappings)).To(Equal(1))
+
+				deplToAppMapping = appMappings[0]
+			}
+
+			By("Inserting dummy data into ApplicationState table, because we are not calling the Reconciler for this, which updates the status of application into db.")
+			var resourceStatus managedgitopsv1alpha1.ResourceStatus
+			var resources []managedgitopsv1alpha1.ResourceStatus
+			resources = append(resources, resourceStatus)
+
+			var buffer bytes.Buffer
+
+			By("Convert ResourceStatus object into String")
+			resourceStr, err := yaml.Marshal(&resources)
+			Expect(err).To(BeNil())
+
+			By("Compress the data")
+			gzipWriter, err := gzip.NewWriterLevel(&buffer, gzip.BestSpeed)
+			Expect(err).To(BeNil())
+
+			_, err = gzipWriter.Write([]byte(string(resourceStr)))
+			Expect(err).To(BeNil())
+
+			err = gzipWriter.Close()
+			Expect(err).To(BeNil())
+
+			reconciledStateString, reconciledobj, err := dummyApplicationComparedToField()
+			Expect(err).To(BeNil())
+
+			applicationState := &db.ApplicationState{
+				Applicationstate_application_id: deplToAppMapping.Application_id,
+				Health:                          string(managedgitopsv1alpha1.HeathStatusCodeHealthy),
+				Sync_Status:                     string(managedgitopsv1alpha1.SyncStatusCodeSynced),
+				Revision:                        "abcdefg",
+				Message:                         "Success",
+				Resources:                       buffer.Bytes(),
+				ReconciledState:                 reconciledStateString,
+			}
+
+			err = dbQueries.CreateApplicationState(ctx, applicationState)
+			Expect(err).To(BeNil())
+
+			By("Retrieve latest version of GitOpsDeployment and check Health/Sync before calling applicationEventRunner_handleUpdateDeploymentStatusTick function.")
+			gitopsDeployment := &managedgitopsv1alpha1.GitOpsDeployment{}
+			gitopsDeploymentKey := client.ObjectKey{Namespace: gitopsDepl.Namespace, Name: gitopsDepl.Name}
+
+			clientErr := a.workspaceClient.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
+			Expect(clientErr).To(BeNil())
+
+			By("Verify gitopsDeployment.Spec.Source.Path is '/' ")
+			Expect(gitopsDeployment.Spec.Source.Path).To(Equal("/"))
+
+			Expect(gitopsDeployment.Status.Health.Status).To(BeEmpty())
+			Expect(gitopsDeployment.Status.Sync.Status).To(BeEmpty())
+			Expect(gitopsDeployment.Status.Sync.Revision).To(BeEmpty())
+			Expect(gitopsDeployment.Status.Health.Message).To(BeEmpty())
+			Expect(gitopsDeployment.Status.ReconciledState.Destination.Namespace).To(BeEmpty())
+			Expect(gitopsDeployment.Status.ReconciledState.Destination.Name).To(BeEmpty())
+			Expect(gitopsDeployment.Status.Conditions).To(BeNil())
+
+			By("Call applicationEventRunner_handleUpdateDeploymentStatusTick function to update Health/Sync status.")
+			err = a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDepl.Name, gitopsDepl.Namespace, dbQueries)
+			Expect(err).To(BeNil())
+
+			By("Retrieve latest version of GitOpsDeployment and check Health/Sync after calling applicationEventRunner_handleUpdateDeploymentStatusTick function.")
+			clientErr = a.workspaceClient.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
+			Expect(clientErr).To(BeNil())
+
+			Expect(gitopsDeployment.Status.Health.Status).To(Equal(managedgitopsv1alpha1.HeathStatusCodeHealthy))
+			Expect(gitopsDeployment.Status.Sync.Status).To(Equal(managedgitopsv1alpha1.SyncStatusCodeSynced))
+			Expect(gitopsDeployment.Status.Sync.Revision).To(Equal("abcdefg"))
+			Expect(gitopsDeployment.Status.Health.Message).To(Equal("Success"))
+			Expect(gitopsDeployment.Status.ReconciledState.Source.Path).To(Equal(reconciledobj.Source.Path))
+			Expect(gitopsDeployment.Status.ReconciledState.Source.RepoURL).To(Equal(reconciledobj.Source.RepoURL))
+			Expect(gitopsDeployment.Status.ReconciledState.Source.Branch).To(Equal(reconciledobj.Source.TargetRevision))
+			Expect(gitopsDeployment.Status.ReconciledState.Destination.Namespace).To(Equal(reconciledobj.Destination.Namespace))
+
+			matchingCondition, _ := conditions.NewConditionManager().FindCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError)
+			Expect(matchingCondition).ToNot(BeNil())
+			Expect(matchingCondition.Message).To(Equal("spec.source.path cannot be '/'"))
+			Expect(matchingCondition.Status).To(Equal(managedgitopsv1alpha1.GitOpsConditionStatusTrue))
+			Expect(matchingCondition.Type).To(Equal(managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError))
+
+			clientErr = a.workspaceClient.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
+			Expect(clientErr).To(BeNil())
+
+			By("Update the path to verify whether gitopsDeployment condition status is false")
+			gitopsDeployment.Spec.Source.Path = "resources/test-data/sample-gitops-repository/environments/overlays/dev"
+			err = k8sClient.Update(ctx, gitopsDeployment)
+			Expect(err).To(BeNil())
+
+			err = a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDepl.Name, gitopsDepl.Namespace, dbQueries)
+			Expect(err).To(BeNil())
+
+			clientErr = a.workspaceClient.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
+			Expect(clientErr).To(BeNil())
+
+			By("Verify whether gitOpsCondition status is false")
+			matchingCondition, _ = conditions.NewConditionManager().FindCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError)
+			Expect(matchingCondition).ToNot(BeNil())
+			Expect(matchingCondition.Status).To(Equal(managedgitopsv1alpha1.GitOpsConditionStatusFalse))
+			Expect(matchingCondition.Message).To(Equal(""))
+
+			By("Delete GitOpsDepl to clean resources.")
+			err = k8sClient.Delete(ctx, gitopsDepl)
+			Expect(err).To(BeNil())
+
+		})
+
 		It("Verify that the .status.reconciledState value of the GitOpsDeployment resource correctly references the name of the GitOpsDeploymentManagedEnvironment resource", func() {
 			defer dbQueries.CloseDatabase()
 			defer testTeardown()

--- a/tests-e2e/core/gitopsdeployment_status_test.go
+++ b/tests-e2e/core/gitopsdeployment_status_test.go
@@ -263,7 +263,7 @@ var _ = Describe("GitOpsDeployment Status.Conditions tests", func() {
 			expectedConditions := []managedgitopsv1alpha1.GitOpsDeploymentCondition{
 				{
 					Type:    managedgitopsv1alpha1.GitOpsDeploymentConditionErrorOccurred,
-					Message: "spec.source.path is a required field and it cannot be empty",
+					Message: managedgitopsv1alpha1.GitOpsDeploymentUserError_PathIsRequired,
 					Status:  managedgitopsv1alpha1.GitOpsConditionStatusTrue,
 					Reason:  managedgitopsv1alpha1.GitopsDeploymentReasonErrorOccurred,
 				},
@@ -304,7 +304,7 @@ var _ = Describe("GitOpsDeployment Status.Conditions tests", func() {
 			expectedConditions := []managedgitopsv1alpha1.GitOpsDeploymentCondition{
 				{
 					Type:    managedgitopsv1alpha1.GitOpsDeploymentConditionErrorOccurred,
-					Message: "spec.source.path cannot be '/'",
+					Message: managedgitopsv1alpha1.GitOpsDeploymentUserError_InvalidPathSlash,
 					Status:  managedgitopsv1alpha1.GitOpsConditionStatusTrue,
 					Reason:  managedgitopsv1alpha1.GitopsDeploymentReasonErrorOccurred,
 				},

--- a/tests-e2e/core/gitopsdeployment_status_test.go
+++ b/tests-e2e/core/gitopsdeployment_status_test.go
@@ -235,7 +235,7 @@ var _ = Describe("GitOpsDeployment Status.Conditions tests", func() {
 			Expect(err).To(Succeed())
 		})
 
-		It("ensures that GitOpsDeployment .Status.Conditions field contains the InvalidSpecError if spec.source.path field is empty in GitOpsDeployment CR", func() {
+		It("ensures that errors are set properly in GitOpsDeployment .Status.Conditions field when spec.source.path field is empty", func() {
 
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
@@ -262,10 +262,10 @@ var _ = Describe("GitOpsDeployment Status.Conditions tests", func() {
 
 			expectedConditions := []managedgitopsv1alpha1.GitOpsDeploymentCondition{
 				{
-					Type:    managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError,
+					Type:    managedgitopsv1alpha1.GitOpsDeploymentConditionErrorOccurred,
 					Message: "spec.source.path is a required field and it cannot be empty",
 					Status:  managedgitopsv1alpha1.GitOpsConditionStatusTrue,
-					Reason:  managedgitopsv1alpha1.GitOpsDeploymentReasonInvalidSpecError,
+					Reason:  managedgitopsv1alpha1.GitopsDeploymentReasonErrorOccurred,
 				},
 			}
 
@@ -276,7 +276,7 @@ var _ = Describe("GitOpsDeployment Status.Conditions tests", func() {
 			)
 		})
 
-		It("ensures that GitOpsDeployment .Status.Conditions field contains the InvalidSpecError if spec.source.path field is '/' in GitOpsDeployment CR", func() {
+		It("ensures that errors are set properly in GitOpsDeployment .Status.Conditions field when spec.source.path field is '/'", func() {
 
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
@@ -303,10 +303,10 @@ var _ = Describe("GitOpsDeployment Status.Conditions tests", func() {
 
 			expectedConditions := []managedgitopsv1alpha1.GitOpsDeploymentCondition{
 				{
-					Type:    managedgitopsv1alpha1.GitOpsDeploymentConditionInvalidSpecError,
+					Type:    managedgitopsv1alpha1.GitOpsDeploymentConditionErrorOccurred,
 					Message: "spec.source.path cannot be '/'",
 					Status:  managedgitopsv1alpha1.GitOpsConditionStatusTrue,
-					Reason:  managedgitopsv1alpha1.GitOpsDeploymentReasonInvalidSpecError,
+					Reason:  managedgitopsv1alpha1.GitopsDeploymentReasonErrorOccurred,
 				},
 			}
 


### PR DESCRIPTION
#### Description:
- Removed omitempty from path field
- Setting error in .status.conditions field of GitopsDeployment CR when spec.source.path field is empty  or '/'
- Some minor tweaks in syncError condition(not related to this PR)
- Unit tests and e2e tests

#### Link to JIRA Story (if applicable):
https://issues.redhat.com/browse/GITOPSRVCE-307
