### PR TITLE
Remove all uses of metadata.Namespace field of Namespace resources

### DIFF
--- a/backend-shared/util/tests/types_test_util.go
+++ b/backend-shared/util/tests/types_test_util.go
@@ -42,27 +42,24 @@ func GenericTestSetup() (*runtime.Scheme, *corev1.Namespace, *corev1.Namespace, 
 
 	argocdNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dbutil.GetGitOpsEngineSingleInstanceNamespace(),
-			UID:       uuid.NewUUID(),
-			Namespace: dbutil.GetGitOpsEngineSingleInstanceNamespace(),
+			Name: dbutil.GetGitOpsEngineSingleInstanceNamespace(),
+			UID:  uuid.NewUUID(),
 		},
 		Spec: corev1.NamespaceSpec{},
 	}
 
 	kubesystemNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-system",
-			UID:       uuid.NewUUID(),
-			Namespace: "kube-system",
+			Name: "kube-system",
+			UID:  uuid.NewUUID(),
 		},
 		Spec: corev1.NamespaceSpec{},
 	}
 
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-user",
-			UID:       uuid.NewUUID(),
-			Namespace: "my-user",
+			Name: "my-user",
+			UID:  uuid.NewUUID(),
 		},
 		Spec: corev1.NamespaceSpec{},
 	}

--- a/backend/eventloop/application_event_loop/application_event_runner.go
+++ b/backend/eventloop/application_event_loop/application_event_runner.go
@@ -230,8 +230,7 @@ func handleManagedEnvironmentModified_shouldInformGitOpsDeployment(ctx context.C
 		// 2a) Retrieve the Namespace containing the ManagedEnvironment CR
 		gitopsDeplNamespace := corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      managedEnvEvent.Request.Namespace,
-				Namespace: managedEnvEvent.Request.Namespace,
+				Name: managedEnvEvent.Request.Namespace,
 			},
 		}
 		if err := managedEnvEvent.Client.Get(ctx, client.ObjectKeyFromObject(&gitopsDeplNamespace), &gitopsDeplNamespace); err != nil {

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -73,7 +73,7 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleDeploym
 
 	gitopsDeplNamespace := corev1.Namespace{}
 
-	if err := a.workspaceClient.Get(ctx, types.NamespacedName{Namespace: deplNamespace, Name: deplNamespace}, &gitopsDeplNamespace); err != nil {
+	if err := a.workspaceClient.Get(ctx, types.NamespacedName{Name: deplNamespace}, &gitopsDeplNamespace); err != nil {
 		userError := fmt.Sprintf("unable to retrieve the contents of the namespace '%s' containing the API resource '%s'. Does it exist?",
 			deplNamespace, deplName)
 		devError := fmt.Errorf("unable to retrieve namespace '%s': %v", deplNamespace, err)
@@ -211,7 +211,7 @@ func (a applicationEventLoopRunner_Action) handleNewGitOpsDeplEvent(ctx context.
 	a.log.Info("Received GitOpsDeployment event for a new GitOpsDeployment resource")
 
 	gitopsDeplNamespace := corev1.Namespace{}
-	if err := a.workspaceClient.Get(ctx, types.NamespacedName{Namespace: gitopsDeployment.ObjectMeta.Namespace,
+	if err := a.workspaceClient.Get(ctx, types.NamespacedName{
 		Name: gitopsDeployment.ObjectMeta.Namespace}, &gitopsDeplNamespace); err != nil {
 
 		userError := "unable to access the Namespace containing the GitOpsDeployment resource"
@@ -352,7 +352,7 @@ func (a applicationEventLoopRunner_Action) handleDeleteGitOpsDeplEvent(ctx conte
 	a.log.Info("Received GitOpsDeployment event for a GitOpsDeployment resource that no longer exists (or does not exist)")
 
 	apiNamespace := corev1.Namespace{}
-	if err := a.workspaceClient.Get(ctx, types.NamespacedName{Namespace: a.eventResourceNamespace, Name: a.eventResourceNamespace}, &apiNamespace); err != nil {
+	if err := a.workspaceClient.Get(ctx, types.NamespacedName{Name: a.eventResourceNamespace}, &apiNamespace); err != nil {
 		userError := "unable to retrieve the namespace containing the GitOpsDeployment"
 		devError := fmt.Errorf("unable to retrieve workspace namespace")
 
@@ -470,7 +470,7 @@ func (a applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplEvent(ctx cont
 	}
 
 	apiNamespace := corev1.Namespace{}
-	if err := a.workspaceClient.Get(ctx, types.NamespacedName{Namespace: a.eventResourceNamespace, Name: a.eventResourceNamespace}, &apiNamespace); err != nil {
+	if err := a.workspaceClient.Get(ctx, types.NamespacedName{Name: a.eventResourceNamespace}, &apiNamespace); err != nil {
 		userError := "unable to retrieve namespace containing the GitOpsDeployment"
 		devError := fmt.Errorf("unable to retrieve workspace namespace")
 		return nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewUserDevError(userError, devError)

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
@@ -53,7 +53,7 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleSyncRun
 	log := a.log
 
 	namespace := corev1.Namespace{}
-	if err := a.workspaceClient.Get(ctx, types.NamespacedName{Namespace: a.eventResourceNamespace, Name: a.eventResourceNamespace}, &namespace); err != nil {
+	if err := a.workspaceClient.Get(ctx, types.NamespacedName{Name: a.eventResourceNamespace}, &namespace); err != nil {
 		userError := fmt.Sprintf("unable to retrieve the contents of the namespace '%s' containing the API resource '%s'. Does it exist?",
 			a.eventResourceNamespace, a.eventResourceName)
 		devError := fmt.Errorf("unable to retrieve namespace '%s': %v", a.eventResourceNamespace, err)

--- a/backend/eventloop/eventlooptypes/types_test.go
+++ b/backend/eventloop/eventlooptypes/types_test.go
@@ -31,8 +31,7 @@ var _ = Describe("GitOpsEngine Client Test", Ordered, func() {
 
 			gitopsNamespace := corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "gitops",
-					Namespace: "gitops",
+					Name: "gitops",
 				},
 			}
 

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -1000,12 +1000,12 @@ func internalProcessMessage_GetOrCreateSharedResources(ctx context.Context, gito
 func internalDetermineGitOpsEngineInstanceForNewApplication(ctx context.Context, user db.ClusterUser, managedEnv db.ManagedEnvironment,
 	k8sClient client.Client, dbq db.DatabaseQueries, l logr.Logger) (*db.GitopsEngineInstance, bool, *db.GitopsEngineCluster, error) {
 
-	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: dbutil.GetGitOpsEngineSingleInstanceNamespace(), Namespace: dbutil.GetGitOpsEngineSingleInstanceNamespace()}}
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: dbutil.GetGitOpsEngineSingleInstanceNamespace()}}
 	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
 		return nil, false, nil, fmt.Errorf("unable to retrieve gitopsengine namespace in determineGitOpsEngineInstanceForNewApplication: %v", err)
 	}
 
-	kubeSystemNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Namespace: "kube-system"}}
+	kubeSystemNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}}
 	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(kubeSystemNamespace), kubeSystemNamespace); err != nil {
 		return nil, false, nil, fmt.Errorf("unable to retrieve kube-system namespace in determineGitOpsEngineInstanceForNewApplication: %v", err)
 	}

--- a/backend/eventloop/workspace_event_loop_test.go
+++ b/backend/eventloop/workspace_event_loop_test.go
@@ -303,7 +303,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 					EventType: eventlooptypes.DeploymentModified,
 					Request: reconcile.Request{
 						NamespacedName: types.NamespacedName{
-							Namespace: apiNamespace.Namespace,
+							Namespace: apiNamespace.Name,
 							Name:      gitopsDepl.Name,
 						},
 					},

--- a/backend/eventloop/workspace_resource_event_loop.go
+++ b/backend/eventloop/workspace_resource_event_loop.go
@@ -182,8 +182,7 @@ func internalProcessWorkspaceResourceMessage(ctx context.Context, msg workspaceR
 		// Retrieve the namespace that the repository credential is contained within
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      req.Namespace,
-				Namespace: req.Namespace,
+				Name: req.Namespace,
 			},
 		}
 		if err := msg.apiNamespaceClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
@@ -226,8 +225,7 @@ func internalProcessWorkspaceResourceMessage(ctx context.Context, msg workspaceR
 		// Retrieve the namespace that the managed environment is contained within
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      req.Namespace,
-				Namespace: req.Namespace,
+				Name: req.Namespace,
 			},
 		}
 		if err := msg.apiNamespaceClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop.go
@@ -364,7 +364,7 @@ func (task *processOperationEventTask) internalPerformTask(taskContext context.C
 
 	// Sanity test: find the gitops engine cluster, by kube-system, and ensure that the
 	// gitopsengineinstance matches the gitops engine cluster we are running on.
-	kubeSystemNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Namespace: "kube-system"}}
+	kubeSystemNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}}
 	if err := eventClient.Get(taskContext, client.ObjectKeyFromObject(kubeSystemNamespace), kubeSystemNamespace); err != nil {
 		log.Error(err, "Unable to retrieve kube-system namespace")
 		return &dbOperation, shouldRetryTrue, fmt.Errorf("unable to retrieve kube-system namespace in internalPerformTask")
@@ -383,8 +383,7 @@ func (task *processOperationEventTask) internalPerformTask(taskContext context.C
 	// 4) Find the namespace for the targeted Argo CD instance
 	argoCDNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dbGitopsEngineInstance.Namespace_name,
-			Namespace: dbGitopsEngineInstance.Namespace_name,
+			Name: dbGitopsEngineInstance.Namespace_name,
 		},
 	}
 	if err := eventClient.Get(taskContext, client.ObjectKeyFromObject(argoCDNamespace), argoCDNamespace); err != nil {

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop_test.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop_test.go
@@ -331,7 +331,7 @@ var _ = Describe("Operation Controller", func() {
 				By("creating a gitops engine instance with a namespace name/uid that don't exist in fakeclient")
 				gitopsEngineInstance := &db.GitopsEngineInstance{
 					Gitopsengineinstance_id: "test-fake-engine-instance",
-					Namespace_name:          workspace.Namespace,
+					Namespace_name:          workspace.Name,
 					Namespace_uid:           string(workspace.UID),
 					EngineCluster_id:        gitopsEngineCluster.Gitopsenginecluster_id,
 				}
@@ -419,7 +419,7 @@ var _ = Describe("Operation Controller", func() {
 				By("creating a gitops engine instance with a namespace name/uid that don't exist in fakeclient")
 				gitopsEngineInstance := &db.GitopsEngineInstance{
 					Gitopsengineinstance_id: "test-fake-engine-instance",
-					Namespace_name:          workspace.Namespace,
+					Namespace_name:          workspace.Name,
 					Namespace_uid:           string(workspace.UID),
 					EngineCluster_id:        gitopsEngineCluster.Gitopsenginecluster_id,
 				}
@@ -525,7 +525,7 @@ var _ = Describe("Operation Controller", func() {
 				By("creating a gitops engine instance with a namespace name/uid that don't exist in fakeclient")
 				gitopsEngineInstance := &db.GitopsEngineInstance{
 					Gitopsengineinstance_id: "test-fake-engine-instance",
-					Namespace_name:          workspace.Namespace,
+					Namespace_name:          workspace.Name,
 					Namespace_uid:           string(workspace.UID),
 					EngineCluster_id:        gitopsEngineCluster.Gitopsenginecluster_id,
 				}
@@ -700,7 +700,7 @@ var _ = Describe("Operation Controller", func() {
 					}
 					gitopsEngineInstance := &db.GitopsEngineInstance{
 						Gitopsengineinstance_id: "test-fake-engine-instance",
-						Namespace_name:          workspace.Namespace,
+						Namespace_name:          workspace.Name,
 						Namespace_uid:           string(workspace.UID),
 						EngineCluster_id:        gitopsEngineCluster.Gitopsenginecluster_id,
 					}
@@ -867,7 +867,7 @@ var _ = Describe("Operation Controller", func() {
 				By("creating a gitops engine instance with a namespace name/uid that don't exist in fakeclient")
 				gitopsEngineInstance := &db.GitopsEngineInstance{
 					Gitopsengineinstance_id: "test-fake-engine-instance",
-					Namespace_name:          workspace.Namespace,
+					Namespace_name:          workspace.Name,
 					Namespace_uid:           string(workspace.UID),
 					EngineCluster_id:        gitopsEngineCluster.Gitopsenginecluster_id,
 				}

--- a/cluster-agent/utils/argocd_login_credentials_test.go
+++ b/cluster-agent/utils/argocd_login_credentials_test.go
@@ -27,8 +27,7 @@ var _ = Describe("ArgoCD Login Credentials", func() {
 
 				namespace := &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "openshift-gitops",
-						Namespace: "openshift-gitops",
+						Name: "openshift-gitops",
 					},
 				}
 

--- a/cluster-agent/utils/argocd_sync_command.go
+++ b/cluster-agent/utils/argocd_sync_command.go
@@ -31,8 +31,7 @@ func AppSync(ctx context.Context, appName string, revision string, namespaceName
 
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespaceName,
-			Name:      namespaceName,
+			Name: namespaceName,
 		},
 	}
 

--- a/cluster-agent/utils/argocd_sync_command_test.go
+++ b/cluster-agent/utils/argocd_sync_command_test.go
@@ -50,8 +50,7 @@ var _ = Describe("ArgoCD AppSync Command", func() {
 
 				namespace := &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "openshift-gitops",
-						Namespace: "openshift-gitops",
+						Name: "openshift-gitops",
 					},
 				}
 

--- a/cluster-agent/utils/argocd_terminate_app_command_test.go
+++ b/cluster-agent/utils/argocd_terminate_app_command_test.go
@@ -29,9 +29,8 @@ var _ = Describe("Terminate Operation on Argo CD Application", func() {
 		It("If the operation never terminates, after we ask it to terminate, then an error should be returned.", func() {
 			argoCDNamespace := corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "argocd",
-					Namespace: "argocd",
-					UID:       uuid.NewUUID(),
+					Name: "argocd",
+					UID:  uuid.NewUUID(),
 				},
 			}
 
@@ -76,9 +75,8 @@ var _ = Describe("Terminate Operation on Argo CD Application", func() {
 		Context("Terminate Operation Goes To Done Test", func() {
 			argoCDNamespace := corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "argocd",
-					Namespace: "argocd",
-					UID:       uuid.NewUUID(),
+					Name: "argocd",
+					UID:  uuid.NewUUID(),
 				},
 			}
 			testCases := []struct {
@@ -154,9 +152,8 @@ var _ = Describe("Terminate Operation on Argo CD Application", func() {
 		It("Verify that the terminate operation exits immediately, if the application is deleted (no longer exists)", func() {
 			argoCDNamespace := corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "argocd",
-					Namespace: "argocd",
-					UID:       uuid.NewUUID(),
+					Name: "argocd",
+					UID:  uuid.NewUUID(),
 				},
 			}
 


### PR DESCRIPTION
#### Description:
- When creating a Namespace, you should not specify the .metadata.Namespace field, e.g.

```yaml
kind: Namespace
metadata:
  name: my-namespce
  namespace: my-namespace  # this field is not require,d or correct, for Namespaces.
```
- Namespaces are not namespace-scoped, and thus should not have a `namespace:` field.
- That one shouldn't do this is pretty obvious, but there were a number of places in the code (primarily in unit tests), where we WERE doing this, and relying on this field
- This PR removes references to the field, and updates tests as needed.

#### Link to JIRA Story (if applicable): N/A