### PR TITLE
Sync main and service-first branch using Github Action

### DIFF
--- a/.github/workflows/sync-branch.yml
+++ b/.github/workflows/sync-branch.yml
@@ -1,0 +1,24 @@
+name: Sync
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: Syncing branches
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Opening pull request
+        id: pull
+        uses: tretuna/sync-branches@1.4.0
+        with:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          FROM_BRANCH: "main"
+          TO_BRANCH: "service-first"


### PR DESCRIPTION
#### Description:

For the nightly build of the service, we are using the service-first branch to solve the issue with local dependency.
This github action will sync the 'main' and 'service-first' branch by creating auto PRs whenever a new push is made to the main branch

#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-274
