### PR TITLE
Add allowInsecureSkipTLSVerify field in Environment API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TAG ?= latest
 BASE_IMAGE ?= gitops-service
 USERNAME ?= redhat-appstudio
 IMG ?= quay.io/${USERNAME}/${BASE_IMAGE}:${TAG}
-APPLICATION_API_COMMIT ?= 3144e2878df03c3a7eb1fef4bdda3459b59e81a7
+APPLICATION_API_COMMIT ?= 3ef8e0cd2c9ee21c8ce29cdfd5e7069f866ff5db
 
 # Default values match the their respective deployments in staging/production environment for GitOps Service, otherwise the E2E will fail.
 ARGO_CD_NAMESPACE ?= gitops-service-argocd

--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
@@ -212,8 +212,9 @@ func generateDesiredResource(ctx context.Context, env appstudioshared.Environmen
 		},
 	}
 	managedEnv.Spec = managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironmentSpec{
-		APIURL:                   env.Spec.UnstableConfigurationFields.KubernetesClusterCredentials.APIURL,
-		ClusterCredentialsSecret: secret.Name,
+		APIURL:                     env.Spec.UnstableConfigurationFields.KubernetesClusterCredentials.APIURL,
+		ClusterCredentialsSecret:   secret.Name,
+		AllowInsecureSkipTLSVerify: env.Spec.UnstableConfigurationFields.KubernetesClusterCredentials.AllowInsecureSkipTLSVerify,
 	}
 
 	return &managedEnv, nil

--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
@@ -121,6 +121,73 @@ var _ = Describe("Environment controller tests", func() {
 				"ManagedEnvironment should match the Environment")
 		})
 
+		It("should create a GitOpsDeploymentManagedEnvironment, if the Environment is created where AllowInsecureSkipTLSVerify field is false", func() {
+			var err error
+
+			secret := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-my-managed-env-secret",
+					Namespace: apiNamespace.Name,
+				},
+				Type: sharedutil.ManagedEnvironmentSecretType,
+				Data: map[string][]byte{
+					"kubeconfig": ([]byte)("{}"),
+				},
+			}
+			err = k8sClient.Create(ctx, &secret)
+			Expect(err).To(BeNil())
+
+			env := appstudioshared.Environment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-env",
+					Namespace: apiNamespace.Name,
+				},
+				Spec: appstudioshared.EnvironmentSpec{
+					Type:               appstudioshared.EnvironmentType_POC,
+					DisplayName:        "my-environment",
+					DeploymentStrategy: appstudioshared.DeploymentStrategy_Manual,
+					ParentEnvironment:  "",
+					Tags:               []string{},
+					Configuration:      appstudioshared.EnvironmentConfiguration{},
+					UnstableConfigurationFields: &appstudioshared.UnstableEnvironmentConfiguration{
+						KubernetesClusterCredentials: appstudioshared.KubernetesClusterCredentials{
+							TargetNamespace:            "my-target-namespace",
+							APIURL:                     "https://my-api-url",
+							ClusterCredentialsSecret:   secret.Name,
+							AllowInsecureSkipTLSVerify: false,
+						},
+					},
+				},
+			}
+			err = k8sClient.Create(ctx, &env)
+			Expect(err).To(BeNil())
+
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      env.Name,
+					Namespace: env.Namespace,
+				},
+			}
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).To(BeNil())
+
+			managedEnvCR := managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "managed-environment-" + env.Name,
+					Namespace: req.Namespace,
+				},
+			}
+			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&managedEnvCR), &managedEnvCR)
+			Expect(err).To(BeNil(), "the ManagedEnvironment object should have been created by the reconciler")
+
+			Expect(managedEnvCR.Spec.APIURL).To(Equal(env.Spec.UnstableConfigurationFields.APIURL),
+				"ManagedEnvironment should match the Environment")
+			Expect(managedEnvCR.Spec.ClusterCredentialsSecret).To(Equal(env.Spec.UnstableConfigurationFields.ClusterCredentialsSecret),
+				"ManagedEnvironment should match the Environment")
+			Expect(managedEnvCR.Spec.AllowInsecureSkipTLSVerify).To(Equal(env.Spec.UnstableConfigurationFields.AllowInsecureSkipTLSVerify),
+				"ManagedEnvironment should match the Environment")
+		})
+
 		It("should update a GitOpsDeploymentManagedEnvironment, if the Environment is updated", func() {
 
 			var err error
@@ -172,6 +239,108 @@ var _ = Describe("Environment controller tests", func() {
 							APIURL:                     "https://my-api-url",
 							ClusterCredentialsSecret:   secret2.Name,
 							AllowInsecureSkipTLSVerify: true,
+						},
+					},
+				},
+			}
+			err = k8sClient.Create(ctx, &env)
+			Expect(err).To(BeNil())
+
+			By("creating a managed environment containing outdated values, versus what's in the environment")
+
+			previouslyReconciledManagedEnv := generateEmptyManagedEnvironment(env.Name, env.Namespace)
+			previouslyReconciledManagedEnv.Spec = managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironmentSpec{
+				APIURL:                   "https://old-api-url",
+				ClusterCredentialsSecret: secret.Name,
+			}
+			err = k8sClient.Create(ctx, &previouslyReconciledManagedEnv)
+			Expect(err).To(BeNil())
+
+			By("reconciling the ManagedEnvironment")
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      env.Name,
+					Namespace: env.Namespace,
+				},
+			}
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).To(BeNil())
+
+			By("retrieving the update ManagedEnvironment")
+			newManagedEnv := generateEmptyManagedEnvironment(env.Name, env.Namespace)
+			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&newManagedEnv), &newManagedEnv)
+			Expect(err).To(BeNil())
+
+			Expect(newManagedEnv.Spec.APIURL).To(Equal(env.Spec.UnstableConfigurationFields.APIURL),
+				"ManagedEnvironment should match the new Environment spec, not the old value of the managed env")
+			Expect(newManagedEnv.Spec.ClusterCredentialsSecret).To(Equal(env.Spec.UnstableConfigurationFields.ClusterCredentialsSecret),
+				"ManagedEnvironment should match the Environment, not the old value")
+			Expect(newManagedEnv.Spec.AllowInsecureSkipTLSVerify).To(Equal(env.Spec.UnstableConfigurationFields.AllowInsecureSkipTLSVerify),
+				"ManagedEnvironment should match the Environment, not the old value")
+
+			By("reconciling again, and confirming that nothing changed")
+			_, err = reconciler.Reconcile(ctx, req)
+			Expect(err).To(BeNil())
+			Expect(newManagedEnv.Spec.APIURL).To(Equal(env.Spec.UnstableConfigurationFields.APIURL),
+				"ManagedEnvironment should continue to match the new Environment spec")
+			Expect(newManagedEnv.Spec.ClusterCredentialsSecret).To(Equal(env.Spec.UnstableConfigurationFields.ClusterCredentialsSecret),
+				"ManagedEnvironment should continue to match the Environment spec")
+			Expect(newManagedEnv.Spec.AllowInsecureSkipTLSVerify).To(Equal(env.Spec.UnstableConfigurationFields.AllowInsecureSkipTLSVerify),
+				"ManagedEnvironment should continue to match the new Environment spec")
+
+		})
+
+		It("should update a GitOpsDeploymentManagedEnvironment, if the Environment is updated where AllowInsecureSkipTLSVerify field is false", func() {
+
+			var err error
+
+			By("creating first managed environment Secret")
+			secret := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-my-managed-env-secret",
+					Namespace: apiNamespace.Name,
+				},
+				Type: sharedutil.ManagedEnvironmentSecretType,
+				Data: map[string][]byte{
+					"kubeconfig": ([]byte)("{}"),
+				},
+			}
+			err = k8sClient.Create(ctx, &secret)
+			Expect(err).To(BeNil())
+
+			By("creating second managed environment Secret")
+			secret2 := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-my-managed-env-secret-2",
+					Namespace: apiNamespace.Name,
+				},
+				Type: sharedutil.ManagedEnvironmentSecretType,
+				Data: map[string][]byte{
+					"kubeconfig": ([]byte)("{}"),
+				},
+			}
+			err = k8sClient.Create(ctx, &secret2)
+			Expect(err).To(BeNil())
+
+			By("creating an Environment pointing to the first secret")
+			env := appstudioshared.Environment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-env",
+					Namespace: apiNamespace.Name,
+				},
+				Spec: appstudioshared.EnvironmentSpec{
+					Type:               appstudioshared.EnvironmentType_POC,
+					DisplayName:        "my-environment",
+					DeploymentStrategy: appstudioshared.DeploymentStrategy_Manual,
+					ParentEnvironment:  "",
+					Tags:               []string{},
+					Configuration:      appstudioshared.EnvironmentConfiguration{},
+					UnstableConfigurationFields: &appstudioshared.UnstableEnvironmentConfiguration{
+						KubernetesClusterCredentials: appstudioshared.KubernetesClusterCredentials{
+							TargetNamespace:            "my-target-namespace",
+							APIURL:                     "https://my-api-url",
+							ClusterCredentialsSecret:   secret2.Name,
+							AllowInsecureSkipTLSVerify: false,
 						},
 					},
 				},

--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
@@ -84,9 +84,10 @@ var _ = Describe("Environment controller tests", func() {
 					Configuration:      appstudioshared.EnvironmentConfiguration{},
 					UnstableConfigurationFields: &appstudioshared.UnstableEnvironmentConfiguration{
 						KubernetesClusterCredentials: appstudioshared.KubernetesClusterCredentials{
-							TargetNamespace:          "my-target-namespace",
-							APIURL:                   "https://my-api-url",
-							ClusterCredentialsSecret: secret.Name,
+							TargetNamespace:            "my-target-namespace",
+							APIURL:                     "https://my-api-url",
+							ClusterCredentialsSecret:   secret.Name,
+							AllowInsecureSkipTLSVerify: true,
 						},
 					},
 				},
@@ -115,6 +116,8 @@ var _ = Describe("Environment controller tests", func() {
 			Expect(managedEnvCR.Spec.APIURL).To(Equal(env.Spec.UnstableConfigurationFields.APIURL),
 				"ManagedEnvironment should match the Environment")
 			Expect(managedEnvCR.Spec.ClusterCredentialsSecret).To(Equal(env.Spec.UnstableConfigurationFields.ClusterCredentialsSecret),
+				"ManagedEnvironment should match the Environment")
+			Expect(managedEnvCR.Spec.AllowInsecureSkipTLSVerify).To(Equal(env.Spec.UnstableConfigurationFields.AllowInsecureSkipTLSVerify),
 				"ManagedEnvironment should match the Environment")
 		})
 
@@ -165,9 +168,10 @@ var _ = Describe("Environment controller tests", func() {
 					Configuration:      appstudioshared.EnvironmentConfiguration{},
 					UnstableConfigurationFields: &appstudioshared.UnstableEnvironmentConfiguration{
 						KubernetesClusterCredentials: appstudioshared.KubernetesClusterCredentials{
-							TargetNamespace:          "my-target-namespace",
-							APIURL:                   "https://my-api-url",
-							ClusterCredentialsSecret: secret2.Name,
+							TargetNamespace:            "my-target-namespace",
+							APIURL:                     "https://my-api-url",
+							ClusterCredentialsSecret:   secret2.Name,
+							AllowInsecureSkipTLSVerify: true,
 						},
 					},
 				},
@@ -204,6 +208,8 @@ var _ = Describe("Environment controller tests", func() {
 				"ManagedEnvironment should match the new Environment spec, not the old value of the managed env")
 			Expect(newManagedEnv.Spec.ClusterCredentialsSecret).To(Equal(env.Spec.UnstableConfigurationFields.ClusterCredentialsSecret),
 				"ManagedEnvironment should match the Environment, not the old value")
+			Expect(newManagedEnv.Spec.AllowInsecureSkipTLSVerify).To(Equal(env.Spec.UnstableConfigurationFields.AllowInsecureSkipTLSVerify),
+				"ManagedEnvironment should match the Environment, not the old value")
 
 			By("reconciling again, and confirming that nothing changed")
 			_, err = reconciler.Reconcile(ctx, req)
@@ -212,6 +218,8 @@ var _ = Describe("Environment controller tests", func() {
 				"ManagedEnvironment should continue to match the new Environment spec")
 			Expect(newManagedEnv.Spec.ClusterCredentialsSecret).To(Equal(env.Spec.UnstableConfigurationFields.ClusterCredentialsSecret),
 				"ManagedEnvironment should continue to match the Environment spec")
+			Expect(newManagedEnv.Spec.AllowInsecureSkipTLSVerify).To(Equal(env.Spec.UnstableConfigurationFields.AllowInsecureSkipTLSVerify),
+				"ManagedEnvironment should continue to match the new Environment spec")
 
 		})
 

--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Environment controller tests", func() {
 
 		})
 
-		It("should create a GitOpsDeploymentManagedEnvironment, if the Environment is created", func() {
+		createEnvironmentTest := func(allowInsecureSkipTLSVerifyParam bool) {
 			var err error
 
 			secret := corev1.Secret{
@@ -87,7 +87,7 @@ var _ = Describe("Environment controller tests", func() {
 							TargetNamespace:            "my-target-namespace",
 							APIURL:                     "https://my-api-url",
 							ClusterCredentialsSecret:   secret.Name,
-							AllowInsecureSkipTLSVerify: true,
+							AllowInsecureSkipTLSVerify: allowInsecureSkipTLSVerifyParam,
 						},
 					},
 				},
@@ -119,77 +119,17 @@ var _ = Describe("Environment controller tests", func() {
 				"ManagedEnvironment should match the Environment")
 			Expect(managedEnvCR.Spec.AllowInsecureSkipTLSVerify).To(Equal(env.Spec.UnstableConfigurationFields.AllowInsecureSkipTLSVerify),
 				"ManagedEnvironment should match the Environment")
+		}
+
+		It("should create a GitOpsDeploymentManagedEnvironment, if the Environment is created where AllowInsecureSkipTLSVerify field is true", func() {
+			createEnvironmentTest(true)
 		})
 
 		It("should create a GitOpsDeploymentManagedEnvironment, if the Environment is created where AllowInsecureSkipTLSVerify field is false", func() {
-			var err error
-
-			secret := corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-my-managed-env-secret",
-					Namespace: apiNamespace.Name,
-				},
-				Type: sharedutil.ManagedEnvironmentSecretType,
-				Data: map[string][]byte{
-					"kubeconfig": ([]byte)("{}"),
-				},
-			}
-			err = k8sClient.Create(ctx, &secret)
-			Expect(err).To(BeNil())
-
-			env := appstudioshared.Environment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "my-env",
-					Namespace: apiNamespace.Name,
-				},
-				Spec: appstudioshared.EnvironmentSpec{
-					Type:               appstudioshared.EnvironmentType_POC,
-					DisplayName:        "my-environment",
-					DeploymentStrategy: appstudioshared.DeploymentStrategy_Manual,
-					ParentEnvironment:  "",
-					Tags:               []string{},
-					Configuration:      appstudioshared.EnvironmentConfiguration{},
-					UnstableConfigurationFields: &appstudioshared.UnstableEnvironmentConfiguration{
-						KubernetesClusterCredentials: appstudioshared.KubernetesClusterCredentials{
-							TargetNamespace:            "my-target-namespace",
-							APIURL:                     "https://my-api-url",
-							ClusterCredentialsSecret:   secret.Name,
-							AllowInsecureSkipTLSVerify: false,
-						},
-					},
-				},
-			}
-			err = k8sClient.Create(ctx, &env)
-			Expect(err).To(BeNil())
-
-			req := ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      env.Name,
-					Namespace: env.Namespace,
-				},
-			}
-			_, err = reconciler.Reconcile(ctx, req)
-			Expect(err).To(BeNil())
-
-			managedEnvCR := managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "managed-environment-" + env.Name,
-					Namespace: req.Namespace,
-				},
-			}
-			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&managedEnvCR), &managedEnvCR)
-			Expect(err).To(BeNil(), "the ManagedEnvironment object should have been created by the reconciler")
-
-			Expect(managedEnvCR.Spec.APIURL).To(Equal(env.Spec.UnstableConfigurationFields.APIURL),
-				"ManagedEnvironment should match the Environment")
-			Expect(managedEnvCR.Spec.ClusterCredentialsSecret).To(Equal(env.Spec.UnstableConfigurationFields.ClusterCredentialsSecret),
-				"ManagedEnvironment should match the Environment")
-			Expect(managedEnvCR.Spec.AllowInsecureSkipTLSVerify).To(Equal(env.Spec.UnstableConfigurationFields.AllowInsecureSkipTLSVerify),
-				"ManagedEnvironment should match the Environment")
+			createEnvironmentTest(false)
 		})
 
-		It("should update a GitOpsDeploymentManagedEnvironment, if the Environment is updated", func() {
-
+		updateEnvTest := func(allowInsecureSkipTLSVerifyParam bool) {
 			var err error
 
 			By("creating first managed environment Secret")
@@ -238,7 +178,7 @@ var _ = Describe("Environment controller tests", func() {
 							TargetNamespace:            "my-target-namespace",
 							APIURL:                     "https://my-api-url",
 							ClusterCredentialsSecret:   secret2.Name,
-							AllowInsecureSkipTLSVerify: true,
+							AllowInsecureSkipTLSVerify: allowInsecureSkipTLSVerifyParam,
 						},
 					},
 				},
@@ -250,8 +190,9 @@ var _ = Describe("Environment controller tests", func() {
 
 			previouslyReconciledManagedEnv := generateEmptyManagedEnvironment(env.Name, env.Namespace)
 			previouslyReconciledManagedEnv.Spec = managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironmentSpec{
-				APIURL:                   "https://old-api-url",
-				ClusterCredentialsSecret: secret.Name,
+				APIURL:                     "https://old-api-url",
+				ClusterCredentialsSecret:   secret.Name,
+				AllowInsecureSkipTLSVerify: !allowInsecureSkipTLSVerifyParam,
 			}
 			err = k8sClient.Create(ctx, &previouslyReconciledManagedEnv)
 			Expect(err).To(BeNil())
@@ -287,109 +228,14 @@ var _ = Describe("Environment controller tests", func() {
 				"ManagedEnvironment should continue to match the Environment spec")
 			Expect(newManagedEnv.Spec.AllowInsecureSkipTLSVerify).To(Equal(env.Spec.UnstableConfigurationFields.AllowInsecureSkipTLSVerify),
 				"ManagedEnvironment should continue to match the new Environment spec")
+		}
 
+		It("should update a GitOpsDeploymentManagedEnvironment,  if the Environment is updated where AllowInsecureSkipTLSVerify field is true", func() {
+			updateEnvTest(true)
 		})
 
 		It("should update a GitOpsDeploymentManagedEnvironment, if the Environment is updated where AllowInsecureSkipTLSVerify field is false", func() {
-
-			var err error
-
-			By("creating first managed environment Secret")
-			secret := corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-my-managed-env-secret",
-					Namespace: apiNamespace.Name,
-				},
-				Type: sharedutil.ManagedEnvironmentSecretType,
-				Data: map[string][]byte{
-					"kubeconfig": ([]byte)("{}"),
-				},
-			}
-			err = k8sClient.Create(ctx, &secret)
-			Expect(err).To(BeNil())
-
-			By("creating second managed environment Secret")
-			secret2 := corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-my-managed-env-secret-2",
-					Namespace: apiNamespace.Name,
-				},
-				Type: sharedutil.ManagedEnvironmentSecretType,
-				Data: map[string][]byte{
-					"kubeconfig": ([]byte)("{}"),
-				},
-			}
-			err = k8sClient.Create(ctx, &secret2)
-			Expect(err).To(BeNil())
-
-			By("creating an Environment pointing to the first secret")
-			env := appstudioshared.Environment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "my-env",
-					Namespace: apiNamespace.Name,
-				},
-				Spec: appstudioshared.EnvironmentSpec{
-					Type:               appstudioshared.EnvironmentType_POC,
-					DisplayName:        "my-environment",
-					DeploymentStrategy: appstudioshared.DeploymentStrategy_Manual,
-					ParentEnvironment:  "",
-					Tags:               []string{},
-					Configuration:      appstudioshared.EnvironmentConfiguration{},
-					UnstableConfigurationFields: &appstudioshared.UnstableEnvironmentConfiguration{
-						KubernetesClusterCredentials: appstudioshared.KubernetesClusterCredentials{
-							TargetNamespace:            "my-target-namespace",
-							APIURL:                     "https://my-api-url",
-							ClusterCredentialsSecret:   secret2.Name,
-							AllowInsecureSkipTLSVerify: false,
-						},
-					},
-				},
-			}
-			err = k8sClient.Create(ctx, &env)
-			Expect(err).To(BeNil())
-
-			By("creating a managed environment containing outdated values, versus what's in the environment")
-
-			previouslyReconciledManagedEnv := generateEmptyManagedEnvironment(env.Name, env.Namespace)
-			previouslyReconciledManagedEnv.Spec = managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironmentSpec{
-				APIURL:                   "https://old-api-url",
-				ClusterCredentialsSecret: secret.Name,
-			}
-			err = k8sClient.Create(ctx, &previouslyReconciledManagedEnv)
-			Expect(err).To(BeNil())
-
-			By("reconciling the ManagedEnvironment")
-			req := ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      env.Name,
-					Namespace: env.Namespace,
-				},
-			}
-			_, err = reconciler.Reconcile(ctx, req)
-			Expect(err).To(BeNil())
-
-			By("retrieving the update ManagedEnvironment")
-			newManagedEnv := generateEmptyManagedEnvironment(env.Name, env.Namespace)
-			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&newManagedEnv), &newManagedEnv)
-			Expect(err).To(BeNil())
-
-			Expect(newManagedEnv.Spec.APIURL).To(Equal(env.Spec.UnstableConfigurationFields.APIURL),
-				"ManagedEnvironment should match the new Environment spec, not the old value of the managed env")
-			Expect(newManagedEnv.Spec.ClusterCredentialsSecret).To(Equal(env.Spec.UnstableConfigurationFields.ClusterCredentialsSecret),
-				"ManagedEnvironment should match the Environment, not the old value")
-			Expect(newManagedEnv.Spec.AllowInsecureSkipTLSVerify).To(Equal(env.Spec.UnstableConfigurationFields.AllowInsecureSkipTLSVerify),
-				"ManagedEnvironment should match the Environment, not the old value")
-
-			By("reconciling again, and confirming that nothing changed")
-			_, err = reconciler.Reconcile(ctx, req)
-			Expect(err).To(BeNil())
-			Expect(newManagedEnv.Spec.APIURL).To(Equal(env.Spec.UnstableConfigurationFields.APIURL),
-				"ManagedEnvironment should continue to match the new Environment spec")
-			Expect(newManagedEnv.Spec.ClusterCredentialsSecret).To(Equal(env.Spec.UnstableConfigurationFields.ClusterCredentialsSecret),
-				"ManagedEnvironment should continue to match the Environment spec")
-			Expect(newManagedEnv.Spec.AllowInsecureSkipTLSVerify).To(Equal(env.Spec.UnstableConfigurationFields.AllowInsecureSkipTLSVerify),
-				"ManagedEnvironment should continue to match the new Environment spec")
-
+			updateEnvTest(false)
 		})
 
 		It("should not return an error, if the Environment is deleted", func() {

--- a/appstudio-controller/go.mod
+++ b/appstudio-controller/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/devfile/api/v2 v2.0.0-20211021164004-dabee4e633ed
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.20.1
-	github.com/redhat-appstudio/application-api v0.0.0-20230111181119-3144e2878df0
+	github.com/redhat-appstudio/application-api v0.0.0-20230116140450-3ef8e0cd2c9e
 	github.com/redhat-appstudio/application-service v0.0.0-20220609190313-7a1a14b575dc
 	github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0
 	k8s.io/apimachinery v0.24.3

--- a/appstudio-controller/go.sum
+++ b/appstudio-controller/go.sum
@@ -1808,8 +1808,8 @@ github.com/rboyer/safeio v0.2.1/go.mod h1:Cq/cEPK+YXFn622lsQ0K4KsPZSPtaptHHEldsy
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20190706150252-9beb055b7962/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/redhat-appstudio/application-api v0.0.0-20230111181119-3144e2878df0 h1:hOg8NOdkofcy2sMC4RJy7erKNk8q4szdDU9ds6TWLoQ=
-github.com/redhat-appstudio/application-api v0.0.0-20230111181119-3144e2878df0/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
+github.com/redhat-appstudio/application-api v0.0.0-20230116140450-3ef8e0cd2c9e h1:2IFJPbDFEpD0pnyGIbCN0ijzhcsODYLkbuh+DExORzw=
+github.com/redhat-appstudio/application-api v0.0.0-20230116140450-3ef8e0cd2c9e/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
 github.com/redhat-appstudio/application-service v0.0.0-20220609190313-7a1a14b575dc h1:f0fQXsJZR5Du/PQS2SMBinju0b9PAHLEKPbOwg/ERAI=
 github.com/redhat-appstudio/application-service v0.0.0-20220609190313-7a1a14b575dc/go.mod h1:QME/qCjHbFRj7f9Jh5EN0mwXQTR1YVM4jImRXr3KKbk=
 github.com/redhat-appstudio/service-provider-integration-operator v0.4.3/go.mod h1:S7NKaaZ0rhCrmHGqae9i21ROY23LurTtII3eMKqxjBQ=

--- a/manifests/base/crd/kustomization.yaml
+++ b/manifests/base/crd/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/redhat-appstudio/application-api/config/crd?ref=8119473cf51efc5c4307a4df43564b6c2fd160ee
+- https://github.com/redhat-appstudio/application-api/config/crd?ref=3ef8e0cd2c9ee21c8ce29cdfd5e7069f866ff5db
 - ../../../backend-shared/config/crd

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -169,9 +169,9 @@ var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 	})
 })
 
-var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
+var _ = Describe("Environment E2E tests", func() {
 
-	Context("Create a new Environment and checks whether managedEnvironment has been created", func() {
+	Context("Create a new Environment and checks whether ManagedEnvironment has been created", func() {
 
 		It("should ensure that AllowInsecureSkipTLSVerify field of Environment API is equal to AllowInsecureSkipTLSVerify field of GitOpsDeploymentManagedEnvironment", func() {
 
@@ -257,7 +257,7 @@ var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 
 			Eventually(managedEnvCR, "2m", "1s").Should(
 				SatisfyAll(
-					managedenvironment.HaveAllowInsecureSkipTLSVerify(managedEnvCR.Spec.AllowInsecureSkipTLSVerify),
+					managedenvironment.HaveAllowInsecureSkipTLSVerify(environment.Spec.UnstableConfigurationFields.AllowInsecureSkipTLSVerify),
 				),
 			)
 

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -183,7 +183,7 @@ var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 			kubeConfigContents, apiServerURL, err := extractKubeConfigValues()
 			Expect(err).To(BeNil())
 
-			By("creating second managed environment Secret")
+			By("creating managed environment Secret")
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-managed-env-secret",
@@ -196,7 +196,7 @@ var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 			err = k8s.Create(secret, k8sClient)
 			Expect(err).To(BeNil())
 
-			By("creating the 'staging' Environment")
+			By("creating the new 'staging' Environment")
 			environment := appstudioshared.Environment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "staging",
@@ -242,7 +242,7 @@ var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 			err = k8s.Get(&environment, k8sClient)
 			Expect(err).To(BeNil())
 
-			By("update AllowInsecureSkipTLSVerify field to false")
+			By("update AllowInsecureSkipTLSVerify field of Environment to false and verify whether it updates the AllowInsecureSkipTLSVerify field of GitOpsDeploymentManagedEnvironment")
 			environment.Spec.UnstableConfigurationFields = &appstudioshared.UnstableEnvironmentConfiguration{
 				KubernetesClusterCredentials: appstudioshared.KubernetesClusterCredentials{
 					TargetNamespace:            fixture.GitOpsServiceE2ENamespace,

--- a/tests-e2e/fixture/managedenvironment/fixture.go
+++ b/tests-e2e/fixture/managedenvironment/fixture.go
@@ -37,3 +37,30 @@ func HaveStatusCondition(conditionType string) matcher.GomegaMatcher {
 		return false
 	}, BeTrue())
 }
+
+// HaveAllowInsecureSkipTLSVerify checks if AllowInsecureSkipTLSVerify field of Environment is equal to ManagedEnvironment.
+func HaveAllowInsecureSkipTLSVerify(allowInsecureSkipTLSVerify bool) matcher.GomegaMatcher {
+	return WithTransform(func(menv managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment) bool {
+		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+		Expect(err).To(BeNil())
+
+		k8sClient, err := fixture.GetKubeClient(config)
+		if err != nil {
+			fmt.Println(k8s.K8sClientError, err)
+			return false
+		}
+
+		err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&menv), &menv)
+		if err != nil {
+			fmt.Println(k8s.K8sClientError, err)
+			return false
+		}
+
+		res := allowInsecureSkipTLSVerify == menv.Spec.AllowInsecureSkipTLSVerify
+
+		fmt.Println("HaveAllowInsecureSkipTLSVerify:", res, "/ Expected:", allowInsecureSkipTLSVerify, "/ Actual:", menv.Spec.AllowInsecureSkipTLSVerify)
+
+		return res
+
+	}, BeTrue())
+}

--- a/tests-e2e/go.mod
+++ b/tests-e2e/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/argoproj/argo-cd/v2 v2.5.1
 	github.com/argoproj/gitops-engine v0.7.1-0.20221004132320-98ccd3d43fd9
 	github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible
-	github.com/redhat-appstudio/application-api v0.0.0-20230111181119-3144e2878df0
+	github.com/redhat-appstudio/application-api v0.0.0-20230116140450-3ef8e0cd2c9e
 	github.com/redhat-appstudio/managed-gitops/appstudio-controller v0.0.0
 	github.com/redhat-appstudio/managed-gitops/backend v0.0.0
 	github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0

--- a/tests-e2e/go.sum
+++ b/tests-e2e/go.sum
@@ -2206,8 +2206,8 @@ github.com/rboyer/safeio v0.2.1/go.mod h1:Cq/cEPK+YXFn622lsQ0K4KsPZSPtaptHHEldsy
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20190706150252-9beb055b7962/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/redhat-appstudio/application-api v0.0.0-20230111181119-3144e2878df0 h1:hOg8NOdkofcy2sMC4RJy7erKNk8q4szdDU9ds6TWLoQ=
-github.com/redhat-appstudio/application-api v0.0.0-20230111181119-3144e2878df0/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
+github.com/redhat-appstudio/application-api v0.0.0-20230116140450-3ef8e0cd2c9e h1:2IFJPbDFEpD0pnyGIbCN0ijzhcsODYLkbuh+DExORzw=
+github.com/redhat-appstudio/application-api v0.0.0-20230116140450-3ef8e0cd2c9e/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
 github.com/redhat-appstudio/application-service v0.0.0-20220609190313-7a1a14b575dc h1:f0fQXsJZR5Du/PQS2SMBinju0b9PAHLEKPbOwg/ERAI=
 github.com/redhat-appstudio/application-service v0.0.0-20220609190313-7a1a14b575dc/go.mod h1:QME/qCjHbFRj7f9Jh5EN0mwXQTR1YVM4jImRXr3KKbk=
 github.com/redhat-appstudio/service-provider-integration-operator v0.4.3/go.mod h1:S7NKaaZ0rhCrmHGqae9i21ROY23LurTtII3eMKqxjBQ=


### PR DESCRIPTION
#### Description:
- Updated allowInsecureSkipTLSVerify field of GitOpsDeploymentManagedEnvironment with allowInsecureSkipTLSVerify field of App-studio Environment API
- Updated Unit tests
- Added E2E test

#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-334