### PR TITLE
Patch backend component on stonesoup cluster: restore controller limits to original values

### DIFF
--- a/backend/config/default/manager_auth_proxy_patch.yaml
+++ b/backend/config/default/manager_auth_proxy_patch.yaml
@@ -25,3 +25,4 @@ spec:
         - "--health-probe-bind-address=:18081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
+        - --zap-time-encoding=rfc3339nano

--- a/backend/config/manager/manager.yaml
+++ b/backend/config/manager/manager.yaml
@@ -31,7 +31,7 @@ spec:
         - --health-probe-bind-address=:18081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        - --zap-time-encoding=rfc3339nano
+        - --zap-time-encoding=rfc3339nano        
         env:
         - name: ARGO_CD_NAMESPACE
           value: gitops-service-argocd
@@ -57,14 +57,14 @@ spec:
           httpGet:
             path: /readyz
             port: 18081
-          initialDelaySeconds: 120
+          initialDelaySeconds: 180
           periodSeconds: 30
         resources:
           limits:
-            cpu: 300m
-            memory: 1200Mi
+            cpu: 1000m
+            memory: 2400Mi
           requests:
-            cpu: 200m
-            memory: 600Mi
+            cpu: 300m
+            memory: 1000Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
#### Description:
- Restore the controller limits to their original values: they were unintentionally reduced by the latest manifest update.

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
