### PR TITLE
Fix continual increment of deployment failures metric

### DIFF
--- a/backend/metrics/metrics.go
+++ b/backend/metrics/metrics.go
@@ -63,7 +63,9 @@ func AddOrUpdateGitOpsDeployment(resourceName string, resourceNamespace string, 
 
 	// Add the key to the list of tracked GitOpsDeployments, but only if there are less than 'maxTrackedDeployments'
 	if len(activeGitOpsDeployments.gitOpsDeployments) <= maxTrackedDeployments {
-		activeGitOpsDeployments.gitOpsDeployments[mapKey] = false
+		if _, exists := activeGitOpsDeployments.gitOpsDeployments[mapKey]; !exists {
+			activeGitOpsDeployments.gitOpsDeployments[mapKey] = false
+		}
 	}
 
 	Gitopsdepl.Set((float64)(len(activeGitOpsDeployments.gitOpsDeployments)))

--- a/backend/metrics/metrics_test.go
+++ b/backend/metrics/metrics_test.go
@@ -56,4 +56,33 @@ var _ = Describe("Test for Gitopsdeployment metrics counter", func() {
 
 		})
 	})
+
+	Context("Prometheus metrics keep an accurate count of failed deployments", func() {
+		It("tests AddOrUpdateGitOpsDeployment doesn't overwite error indicator for a failed deployment", func() {
+
+			ClearMetrics()
+
+			gitopsDepl := &managedgitopsv1alpha1.GitOpsDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-gitops-depl",
+					Namespace: "gitops-depl-namespace",
+					UID:       uuid.NewUUID(),
+				},
+			}
+
+			key := generateMapKey(gitopsDepl.Name, gitopsDepl.Namespace, string(gitopsDepl.UID))
+
+			By("simulating a new valid GitOpsDeployment being processed")
+			AddOrUpdateGitOpsDeployment(gitopsDepl.Name, gitopsDepl.Namespace, string(gitopsDepl.UID))
+			Expect(activeGitOpsDeployments.gitOpsDeployments[key]).To(BeFalse())
+
+			By("setting the GitOpsDeployment to an error state")
+			SetErrorState(gitopsDepl.Name, gitopsDepl.Namespace, string(gitopsDepl.UID), true)
+			Expect(activeGitOpsDeployments.gitOpsDeployments[key]).To(BeTrue())
+
+			By("simulating the GitOpsDeployment being reprocessed")
+			AddOrUpdateGitOpsDeployment(gitopsDepl.Name, gitopsDepl.Namespace, string(gitopsDepl.UID))
+			Expect(activeGitOpsDeployments.gitOpsDeployments[key]).To(BeTrue())
+		})
+	})
 })


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>


#### Description:
- Change `AddOrUpdateGitOpsDeployment()` to check if an entry for the deployment already exists before setting its error condition to `false`. 

#### Link to JIRA Bug (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-352

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
