### PR TITLE
Add initial Grafana dashboard

### DIFF
--- a/manifests/grafana/Gitops-combined.json
+++ b/manifests/grafana/Gitops-combined.json
@@ -1,0 +1,147 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 4,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {
+        "failed": "semi-dark-red",
+        "gitopsDeployments_failures{container=\"manager\", endpoint=\"http-metrics\", gitopsDeployment=\"fail\", instance=\"10.128.2.19:8080\", job=\"gitops-core-service-controller-manager-metrics-service\", namespace=\"gitops\", pod=\"gitops-core-service-controller-manager-9dc9cb9bc-p5p4g\", prometheus=\"openshift-user-workload-monitoring/user-workload\", service=\"gitops-core-service-controller-manager-metrics-service\"}": "semi-dark-red",
+        "total": "semi-dark-green"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Number of active and failed GitopsDeployments",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 17,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.17",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "active_gitopsDeployments",
+          "interval": "",
+          "legendFormat": "total",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "gitopsDeployments_failures",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "failed",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Deployments",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "GitOps",
+  "uid": "BhY6sRo4z",
+  "version": 1
+}

--- a/manifests/grafana/gitops-dashboard.json
+++ b/manifests/grafana/gitops-dashboard.json
@@ -106,6 +106,8 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:280",
+          "decimals": 0,
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -114,6 +116,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:281",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -143,5 +146,5 @@
   "timezone": "",
   "title": "GitOps",
   "uid": "BhY6sRo4z",
-  "version": 1
+  "version": 2
 }

--- a/manifests/grafana/gitops-dashboard.json
+++ b/manifests/grafana/gitops-dashboard.json
@@ -30,6 +30,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "decimals": 0,
       "description": "Number of active and failed GitopsDeployments",
       "fieldConfig": {
         "defaults": {
@@ -148,5 +149,5 @@
   "timezone": "",
   "title": "GitOps",
   "uid": "BhY6sRo4z",
-  "version": 3
+  "version": 2
 }

--- a/manifests/grafana/gitops-dashboard.json
+++ b/manifests/grafana/gitops-dashboard.json
@@ -20,6 +20,8 @@
   "panels": [
     {
       "aliasColors": {
+        "Failed": "semi-dark-red",
+        "Total": "semi-dark-green",
         "failed": "semi-dark-red",
         "gitopsDeployments_failures{container=\"manager\", endpoint=\"http-metrics\", gitopsDeployment=\"fail\", instance=\"10.128.2.19:8080\", job=\"gitops-core-service-controller-manager-metrics-service\", namespace=\"gitops\", pod=\"gitops-core-service-controller-manager-9dc9cb9bc-p5p4g\", prometheus=\"openshift-user-workload-monitoring/user-workload\", service=\"gitops-core-service-controller-manager-metrics-service\"}": "semi-dark-red",
         "total": "semi-dark-green"
@@ -47,12 +49,12 @@
       "id": 2,
       "legend": {
         "avg": false,
-        "current": false,
+        "current": true,
         "max": false,
         "min": false,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -74,7 +76,7 @@
           "exemplar": true,
           "expr": "active_gitopsDeployments",
           "interval": "",
-          "legendFormat": "total",
+          "legendFormat": "Total",
           "refId": "A"
         },
         {
@@ -82,7 +84,7 @@
           "expr": "gitopsDeployments_failures",
           "hide": false,
           "interval": "",
-          "legendFormat": "failed",
+          "legendFormat": "Failed",
           "refId": "B"
         }
       ],
@@ -139,12 +141,12 @@
     "list": []
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "GitOps",
   "uid": "BhY6sRo4z",
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>


#### Description:
- Add initial Grafana dashboard showing the active and failed gitops deployments

<img width="1253" alt="combined" src="https://user-images.githubusercontent.com/29612372/213467344-6b88fb5f-795b-45f0-a9b9-816d6af6ae45.png">

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-340

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
