### PR TITLE
Disable Stonesoup-specific ServiceMonitors, move them to infra-deployments

### DIFF
--- a/manifests/overlays/appstudio-staging-cluster/prometheus/appstudio-controller/kustomization.yaml
+++ b/manifests/overlays/appstudio-staging-cluster/prometheus/appstudio-controller/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- service-monitor.yaml
+#- service-monitor.yaml
 - service.yaml

--- a/manifests/overlays/appstudio-staging-cluster/prometheus/backend/kustomization.yaml
+++ b/manifests/overlays/appstudio-staging-cluster/prometheus/backend/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- service-monitor.yaml
+#- service-monitor.yaml
 - service.yaml

--- a/manifests/overlays/appstudio-staging-cluster/prometheus/cluster-agent/kustomization.yaml
+++ b/manifests/overlays/appstudio-staging-cluster/prometheus/cluster-agent/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- service-monitor.yaml
+#- service-monitor.yaml
 - service.yaml


### PR DESCRIPTION
#### Description:
- Disable the Stonesoup-cluster-specific ServiceMonitors, and instead move them to infra-deployments, as requested.

#### Link to JIRA Story (if applicable): [GITOPSRVCE-341](https://issues.redhat.com/browse/GITOPSRVCE-341)