### PR TITLE
Add RBAC to allow controllers to create TokenReviews, add missing appstudio-controller deployment patch

### DIFF
--- a/appstudio-controller/config/rbac/kustomization.yaml
+++ b/appstudio-controller/config/rbac/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-# - auth_proxy_service.yaml
-# - auth_proxy_role.yaml
-# - auth_proxy_role_binding.yaml
-# - auth_proxy_client_clusterrole.yaml
+#- auth_proxy_service.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml
+- auth_proxy_client_clusterrole.yaml

--- a/backend/config/rbac/kustomization.yaml
+++ b/backend/config/rbac/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-# - auth_proxy_service.yaml
-# - auth_proxy_role.yaml
-# - auth_proxy_role_binding.yaml
-# - auth_proxy_client_clusterrole.yaml
+#- auth_proxy_service.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml
+- auth_proxy_client_clusterrole.yaml

--- a/cluster-agent/config/rbac/kustomization.yaml
+++ b/cluster-agent/config/rbac/kustomization.yaml
@@ -13,6 +13,6 @@ resources:
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
 # - auth_proxy_service.yaml
-# - auth_proxy_role.yaml
-# - auth_proxy_role_binding.yaml
-# - auth_proxy_client_clusterrole.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml
+- auth_proxy_client_clusterrole.yaml

--- a/manifests/overlays/appstudio-staging-cluster/kustomization.yaml
+++ b/manifests/overlays/appstudio-staging-cluster/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 resources:
 - ../../base/crd
 - ../../base/gitops-namespace
-
 # TODO: GITOPSRVCE-211: Switch this back from 'default-no-webhook' -> 'default'
 - ../../../appstudio-controller/config/default-no-webhook-no-prometheus
 - ../../../backend/config/default-no-prometheus
@@ -12,12 +11,13 @@ resources:
 - ../../base/postgresql-staging
 - ../../base/gitops-service-argocd/base
 - prometheus/
-# Uncomment to use a custom image:
 
 patchesStrategicMerge:
 - backend-deployment-patch.yaml
 - cluster-agent-deployment-patch.yaml
+- appstudio-controller-deployment-patch.yaml
 
+# Uncomment to use a custom image:
 # images:
 #   - name: \${COMMON_IMAGE}
 #     newName: quay.io/(your user name)/gitops-service


### PR DESCRIPTION

#### Description:
- Add RBAC to allow controllers to create TokenReviews (this was failing on Stonesoup cluster to missing roles/rolebindings)
- Add missing appstudio-controller deployment patch (this was inadvertently excluded).

#### Link to JIRA Story (if applicable): [GITOPSRVCE-341](https://issues.redhat.com/browse/GITOPSRVCE-341)

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
