### PR TITLE
Skip reconciliation of events for resources in Namespaces that are being deleted

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
@@ -59,6 +59,12 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	rClient := sharedutil.IfEnabledSimulateUnreliableClient(r.Client)
 
+	// If the Namespace is in the process of being deleted, don't handle any additional requests.
+	if isNamespaceBeingDeleted, err := isRequestInNamespaceBeingDeleted(ctx, req.Namespace,
+		rClient, log); isNamespaceBeingDeleted || err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// The goal of this function is to ensure that if an Environment exists, and that Environment
 	// has the 'kubernetesCredentials' field defined, that a corresponding
 	// GitOpsDeploymentManagedEnvironment exists (and is up-to-date).

--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
@@ -60,7 +60,7 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	rClient := sharedutil.IfEnabledSimulateUnreliableClient(r.Client)
 
 	// If the Namespace is in the process of being deleted, don't handle any additional requests.
-	if isNamespaceBeingDeleted, err := isRequestInNamespaceBeingDeleted(ctx, req.Namespace,
+	if isNamespaceBeingDeleted, err := isRequestNamespaceBeingDeleted(ctx, req.Namespace,
 		rClient, log); isNamespaceBeingDeleted || err != nil {
 		return ctrl.Result{}, err
 	}

--- a/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
@@ -78,6 +78,12 @@ func (r *PromotionRunReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	rClient := sharedutil.IfEnabledSimulateUnreliableClient(r.Client)
 
+	// If the Namespace is in the process of being deleted, don't handle any additional requests.
+	if isNamespaceBeingDeleted, err := isRequestInNamespaceBeingDeleted(ctx, req.Namespace,
+		rClient, log); isNamespaceBeingDeleted || err != nil {
+		return ctrl.Result{}, err
+	}
+
 	if err := rClient.Get(ctx, req.NamespacedName, promotionRun); err != nil {
 		if apierr.IsNotFound(err) {
 			// Nothing more to do!

--- a/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
@@ -79,7 +79,7 @@ func (r *PromotionRunReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	rClient := sharedutil.IfEnabledSimulateUnreliableClient(r.Client)
 
 	// If the Namespace is in the process of being deleted, don't handle any additional requests.
-	if isNamespaceBeingDeleted, err := isRequestInNamespaceBeingDeleted(ctx, req.Namespace,
+	if isNamespaceBeingDeleted, err := isRequestNamespaceBeingDeleted(ctx, req.Namespace,
 		rClient, log); isNamespaceBeingDeleted || err != nil {
 		return ctrl.Result{}, err
 	}

--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
@@ -77,7 +77,7 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 	rClient := sharedutil.IfEnabledSimulateUnreliableClient(r.Client)
 
 	// If the Namespace is in the process of being deleted, don't handle any additional requests.
-	if isNamespaceBeingDeleted, err := isRequestInNamespaceBeingDeleted(ctx, req.Namespace,
+	if isNamespaceBeingDeleted, err := isRequestNamespaceBeingDeleted(ctx, req.Namespace,
 		rClient, log); isNamespaceBeingDeleted || err != nil {
 		return ctrl.Result{}, err
 	}
@@ -481,8 +481,8 @@ func removeAppStudioLabelsFromMap(m map[string]string) {
 	}
 }
 
-// isRequestInNamespaceBeingDeleted returns true if the Namespace of the resource is being deleted, false otherwise.
-func isRequestInNamespaceBeingDeleted(ctx context.Context, namespaceName string, k8sClient client.Client, log logr.Logger) (bool, error) {
+// isRequestNamespaceBeingDeleted returns true if the Namespace of the resource is being deleted, false otherwise.
+func isRequestNamespaceBeingDeleted(ctx context.Context, namespaceName string, k8sClient client.Client, log logr.Logger) (bool, error) {
 	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}}
 	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
 		if apierr.IsNotFound(err) {

--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
@@ -28,6 +28,7 @@ import (
 	appstudioshared "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	apibackend "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
+	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -74,6 +75,12 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 	binding := &appstudioshared.SnapshotEnvironmentBinding{}
 
 	rClient := sharedutil.IfEnabledSimulateUnreliableClient(r.Client)
+
+	// If the Namespace is in the process of being deleted, don't handle any additional requests.
+	if isNamespaceBeingDeleted, err := isRequestInNamespaceBeingDeleted(ctx, req.Namespace,
+		rClient, log); isNamespaceBeingDeleted || err != nil {
+		return ctrl.Result{}, err
+	}
 
 	if err := rClient.Get(ctx, req.NamespacedName, binding); err != nil {
 		// Binding doesn't exist: it was deleted.
@@ -472,4 +479,23 @@ func removeAppStudioLabelsFromMap(m map[string]string) {
 			delete(m, key)
 		}
 	}
+}
+
+// isRequestInNamespaceBeingDeleted returns true if the Namespace of the resource is being deleted, false otherwise.
+func isRequestInNamespaceBeingDeleted(ctx context.Context, namespaceName string, k8sClient client.Client, log logr.Logger) (bool, error) {
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}}
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
+		if apierr.IsNotFound(err) {
+			return false, nil
+		}
+		log.Error(err, "Unexpected error occurred on retrieving Namespace")
+		return false, err
+
+	} else if namespace.DeletionTimestamp != nil {
+		log.Info("Ignoring request to Namespace that is being deleted (has non-nil deletionTimestamp)")
+		return true, nil
+	}
+
+	return false, nil
+
 }

--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller_test.go
@@ -871,7 +871,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 
 	})
 
-	Context("Test isNamespaceBeingDeleted", func() {
+	Context("Test isRequestNamespaceBeingDeleted", func() {
 
 		var k8sClient client.Client
 		ctx := context.Background()
@@ -904,7 +904,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			err := k8sClient.Create(ctx, namespace)
 			Expect(err).To(BeNil())
 
-			res, err := isRequestInNamespaceBeingDeleted(ctx, namespace.Name, k8sClient, log)
+			res, err := isRequestNamespaceBeingDeleted(ctx, namespace.Name, k8sClient, log)
 			Expect(res).To(BeFalse())
 			Expect(err).To(BeNil())
 
@@ -921,13 +921,13 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			err := k8sClient.Create(ctx, namespace)
 			Expect(err).To(BeNil())
 
-			res, err := isRequestInNamespaceBeingDeleted(ctx, namespace.Name, k8sClient, log)
+			res, err := isRequestNamespaceBeingDeleted(ctx, namespace.Name, k8sClient, log)
 			Expect(res).To(BeTrue())
 			Expect(err).To(BeNil())
 		})
 
 		It("should return false, with no error, if the Namespace doesn't exist", func() {
-			res, err := isRequestInNamespaceBeingDeleted(ctx, "does-not-exist", k8sClient, log)
+			res, err := isRequestNamespaceBeingDeleted(ctx, "does-not-exist", k8sClient, log)
 			Expect(res).To(BeFalse())
 			Expect(err).To(BeNil())
 		})

--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller_test.go
@@ -5,14 +5,17 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
@@ -865,6 +868,69 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			Entry("different appstudio label in both",
 				map[string]string{appstudioLabelKey + "/label1": "value"}, map[string]string{appstudioLabelKey + "/label2": "value"}, false),
 		)
+
+	})
+
+	Context("Test isNamespaceBeingDeleted", func() {
+
+		var k8sClient client.Client
+		ctx := context.Background()
+		log := log.FromContext(ctx)
+
+		BeforeEach(func() {
+			// Create fake client
+			scheme,
+				argocdNamespace,
+				kubesystemNamespace,
+				apiNamespace,
+				err := tests.GenericTestSetup()
+			Expect(err).To(BeNil())
+
+			// Create fake client
+			k8sClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(apiNamespace, argocdNamespace, kubesystemNamespace).
+				Build()
+
+		})
+
+		It("should return false if the Namespace is not being deleted", func() {
+
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ns",
+				},
+			}
+			err := k8sClient.Create(ctx, namespace)
+			Expect(err).To(BeNil())
+
+			res, err := isRequestInNamespaceBeingDeleted(ctx, namespace.Name, k8sClient, log)
+			Expect(res).To(BeFalse())
+			Expect(err).To(BeNil())
+
+		})
+
+		It("should return true if the Namespace has a deletionTimestamp", func() {
+
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "ns",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+			}
+			err := k8sClient.Create(ctx, namespace)
+			Expect(err).To(BeNil())
+
+			res, err := isRequestInNamespaceBeingDeleted(ctx, namespace.Name, k8sClient, log)
+			Expect(res).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("should return false, with no error, if the Namespace doesn't exist", func() {
+			res, err := isRequestInNamespaceBeingDeleted(ctx, "does-not-exist", k8sClient, log)
+			Expect(res).To(BeFalse())
+			Expect(err).To(BeNil())
+		})
 
 	})
 })

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -231,6 +231,12 @@ func (a applicationEventLoopRunner_Action) handleNewGitOpsDeplEvent(ctx context.
 
 	}
 
+	// Don't process a new GitOpsDeployment in a Namespace that is in the process of being deleted.
+	if gitopsDeplNamespace.DeletionTimestamp != nil {
+		a.log.Info("Skipping GitOpsDeployment event in Namespace that is being deleted")
+		return nil, nil, deploymentModifiedResult_NoChange, nil
+	}
+
 	isWorkspaceTarget := gitopsDeployment.Spec.Destination.Environment == ""
 	managedEnv, engineInstance, destinationName, err := a.reconcileManagedEnvironmentOfGitOpsDeployment(ctx, gitopsDeployment,
 		gitopsDeplNamespace, isWorkspaceTarget)


### PR DESCRIPTION
#### Description:
- Skip reconciliation of events for resources in Namespaces that are being deleted
- We want to avoid the case where the GitOps Service/Argo CD are keeping the Namespace from being deleted by creating/recreating resources as they are deleted.

#### Link to JIRA Story (if applicable): [STONE-446](https://issues.redhat.com/browse/STONE-446)

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
