### PR TITLE
Re-removing the gitOpsDeployment creation logic for Applications

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/application_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/application_controller.go
@@ -71,6 +71,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	rClient := sharedutil.IfEnabledSimulateUnreliableClient(r.Client)
 
+	// TODO: GITOPSRVCE-373: remove this call to processDeleteGitOpsDeployment
 	if err := rClient.Get(ctx, req.NamespacedName, &asApplication); err != nil {
 
 		if apierrors.IsNotFound(err) {
@@ -84,17 +85,19 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
-	/*
-	   Will remove this commented out code after some days once this behaviour is not required anymore
-	   // gitOpsDeploymentCreation consists of code that creates a GitOpsDeployment for each AppStudio Application resource.
-	   // We plan to deprecate/remove this function once the Environment API logic is fully in place.
-
-	   // 'skipGitOpsDeploymentCreation' is a temporary annotation which can be added to Applications to trigger the new behaviour.
-	   // - If this annotation is not specified, OR the old annotation has any other value, the deprecated behaviour will be used.
-	   // if asApplication.ObjectMeta.Annotations != nil && asApplication.ObjectMeta.Annotations["skipGitOpsDeploymentCreation"] == "true" {
-	   //  return ctrl.Result{}, nil
-	   // }
-	*/
+	// TODO: GITOPSRVCE-373: remove this commented out code after some days once this behaviour is not required anymore
+	//
+	// gitOpsDeploymentCreation consists of code that creates a GitOpsDeployment for each AppStudio Application resource.
+	// We plan to deprecate/remove this function once the Environment API logic is fully in place.
+	//
+	// 'skipGitOpsDeploymentCreation' is a temporary annotation which can be added to Applications to trigger the new behaviour.
+	// - If this annotation is not specified, OR the old annotation has any other value, the deprecated behaviour will be used.
+	//
+	// if asApplication.ObjectMeta.Annotations != nil && asApplication.ObjectMeta.Annotations["skipGitOpsDeploymentCreation"] == "true" {
+	//  return ctrl.Result{}, nil
+	// }
+	// return gitOpsDeploymentCreation(asApplication, ctx, req, r.Client, log)
+	//
 
 	return ctrl.Result{}, nil
 }

--- a/appstudio-controller/controllers/appstudio.redhat.com/application_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/application_controller.go
@@ -84,16 +84,19 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
-	// gitOpsDeploymentCreation consists of code that creates a GitOpsDeployment for each AppStudio Application resource.
-	// We plan to deprecate/remove this function once the Environment API logic is fully in place.
+	/*
+	   Will remove this commented out code after some days once this behaviour is not required anymore
+	   // gitOpsDeploymentCreation consists of code that creates a GitOpsDeployment for each AppStudio Application resource.
+	   // We plan to deprecate/remove this function once the Environment API logic is fully in place.
 
-	// 'skipGitOpsDeploymentCreation' is a temporary annotation which can be added to Applications to trigger the new behaviour.
-	// - If this annotation is not specified, OR the old annotation has any other value, the deprecated behaviour will be used.
-	if asApplication.ObjectMeta.Annotations != nil && asApplication.ObjectMeta.Annotations["skipGitOpsDeploymentCreation"] == "true" {
-		return ctrl.Result{}, nil
-	}
+	   // 'skipGitOpsDeploymentCreation' is a temporary annotation which can be added to Applications to trigger the new behaviour.
+	   // - If this annotation is not specified, OR the old annotation has any other value, the deprecated behaviour will be used.
+	   // if asApplication.ObjectMeta.Annotations != nil && asApplication.ObjectMeta.Annotations["skipGitOpsDeploymentCreation"] == "true" {
+	   //  return ctrl.Result{}, nil
+	   // }
+	*/
 
-	return gitOpsDeploymentCreation(asApplication, ctx, req, r.Client, log)
+	return ctrl.Result{}, nil
 }
 
 // processDeleteGitOpsDeployment deletes the GitOpsDeployment that corresponds to req

--- a/tests-e2e/core/appstudio_application_test.go
+++ b/tests-e2e/core/appstudio_application_test.go
@@ -104,6 +104,8 @@ schemaVersion: 2.1.0`,
 	Context("Test the appstudio-controller Application controller", func() {
 
 		DescribeTable("Verify skip annotation on Application works as expected", func(annotationValue bool) {
+
+			// TODO: GITOPSRVCE-373: remove this test once this behaviour is not required anymore
 			Skip("Skipping this tests as this functionality is removed and will remove this test completely once the functionality is completely removed from the ApplicationReconciler")
 
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())

--- a/tests-e2e/core/appstudio_application_test.go
+++ b/tests-e2e/core/appstudio_application_test.go
@@ -104,6 +104,7 @@ schemaVersion: 2.1.0`,
 	Context("Test the appstudio-controller Application controller", func() {
 
 		DescribeTable("Verify skip annotation on Application works as expected", func(annotationValue bool) {
+			Skip("Skipping this tests as this functionality is removed and will remove this test completely once the functionality is completely removed from the ApplicationReconciler")
 
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 


### PR DESCRIPTION
#### Description:
- Removed GitOpsDeployment creation logic for Applications in ApplicationReconciler
- Skipped e2e test related to this

#### Link to JIRA Story (if applicable):
https://issues.redhat.com/browse/GITOPSRVCE-357
