### PR TITLE
Added support for building container images for different platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal:8.5-218
 ################################################################################################
 FROM golang:1.18 as builder
 
+ARG OS=linux
+ARG ARCH=amd64
+
 WORKDIR /workspace
 
 COPY Makefile ./Makefile

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,13 @@ APPLICATION_API_COMMIT ?= 3144e2878df03c3a7eb1fef4bdda3459b59e81a7
 ARGO_CD_NAMESPACE ?= gitops-service-argocd
 ARGO_CD_VERSION ?= v2.5.1
 
+# Tool to build the container image. It can be either docker or podman
+DOCKER ?= docker
+
+# Get the OS and ARCH values to be used for building the binary.
+OS ?= $(shell go env GOOS)
+ARCH ?= $(shell go env GOARCH)
+
 help: ## Display this help menu
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
@@ -138,10 +145,10 @@ clean: ## remove the bin and vendor folders from each component
 build: build-backend build-cluster-agent build-appstudio-controller ## Build all the components - note: you do not need to do this before running start
 
 docker-build: ## Build docker image -- note: you have to change the USERNAME var. Optionally change the BASE_IMAGE or TAG
-	docker build -t ${IMG} $(MAKEFILE_ROOT)
+	$(DOCKER) build --build-arg OS=$(OS) --build-arg ARCH=$(ARCH) -t ${IMG} $(MAKEFILE_ROOT)
 
 docker-push: ## Push docker image - note: you have to change the USERNAME var. Optionally change the BASE_IMAGE or TAG
-	docker push ${IMG}
+	$(DOCKER) push ${IMG}
 
 test: test-backend test-backend-shared test-cluster-agent test-appstudio-controller ## Run tests for all components
 

--- a/appstudio-controller/Makefile
+++ b/appstudio-controller/Makefile
@@ -47,6 +47,10 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Get the OS and ARCH values to be used for building the binary.
+OS ?= $(shell go env GOOS)
+ARCH ?= $(shell go env GOARCH)
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -99,7 +103,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/manager main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -10,6 +10,10 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Get the OS and ARCH values to be used for building the binary.
+OS ?= $(shell go env GOOS)
+ARCH ?= $(shell go env GOARCH)
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -54,7 +58,7 @@ test: fmt vet envtest ## Run tests.
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano

--- a/cluster-agent/Makefile
+++ b/cluster-agent/Makefile
@@ -49,6 +49,10 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Get the OS and ARCH values to be used for building the binary.
+OS ?= $(shell go env GOOS)
+ARCH ?= $(shell go env GOARCH)
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -109,7 +113,7 @@ test: fmt vet envtest ## Run tests.
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	KUBECONFIG=${WORKLOAD_KUBECONFIG} go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano


### PR DESCRIPTION
#### Description:
The change
- helps developers build binaries and container images for different processor architectures and Operating Systems
Eg: 
To build binary for Darwin OS and `arm64` architecture, using podman
`cd backend && DOCKER=podman ARCH=arm64 OS=darwin make build`
To build binary for Darwin OS and `arm64` architecture, using docker
`cd backend && ARCH=arm64 OS=darwin make build`
To build binary for Darwin OS and `amd64` architecture, using docker
`cd backend && OS=darwin make build`

- gives the flexibility to switch between `podman` and `docker` for building container images
Eg: To build a container image for `arm64` architecture, using podman,
`DOCKER=podman ARCH=arm64 make docker-build`
- by default, it builds for Linux OS and `amd64` architecture and uses `docker` for building the container image.
#### Link to JIRA Story (if applicable):

