### PR TITLE
Update request/limits for backend and cluster-agent components, for Stonesoup

### DIFF
--- a/backend/config/manager/manager.yaml
+++ b/backend/config/manager/manager.yaml
@@ -65,9 +65,9 @@ spec:
         resources:
           limits:
             cpu: 1000m
-            memory: 2400Mi
+            memory: 1024Mi
           requests:
             cpu: 300m
-            memory: 1000Mi
+            memory: 512Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/cluster-agent/config/manager/manager.yaml
+++ b/cluster-agent/config/manager/manager.yaml
@@ -50,22 +50,22 @@ spec:
           httpGet:
             path: /healthz
             port: 8083
-          initialDelaySeconds: 15
+          initialDelaySeconds: 25
           periodSeconds: 20
         name: manager
         readinessProbe:
           httpGet:
             path: /readyz
             port: 8083
-          initialDelaySeconds: 5
+          initialDelaySeconds: 25
           periodSeconds: 10
         resources:
           limits:
             cpu: 300m
-            memory: 200Mi
+            memory: 1000Mi
           requests:
             cpu: 200m
-            memory: 50Mi
+            memory: 200Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/manifests/overlays/appstudio-staging-cluster/backend-deployment-patch.yaml
+++ b/manifests/overlays/appstudio-staging-cluster/backend-deployment-patch.yaml
@@ -43,11 +43,11 @@ spec:
           periodSeconds: 30
         resources:
           limits:
+            cpu: 2000m
+            memory: 4800Mi
+          requests:
             cpu: 1000m
             memory: 2400Mi
-          requests:
-            cpu: 300m
-            memory: 1000Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/manifests/overlays/appstudio-staging-cluster/cluster-agent-deployment-patch.yaml
+++ b/manifests/overlays/appstudio-staging-cluster/cluster-agent-deployment-patch.yaml
@@ -31,7 +31,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8083
-          initialDelaySeconds: 15
+          initialDelaySeconds: 45
           periodSeconds: 20
         name: manager
         ports:
@@ -41,15 +41,15 @@ spec:
           httpGet:
             path: /readyz
             port: 8083
-          initialDelaySeconds: 5
+          initialDelaySeconds: 45
           periodSeconds: 10
         resources:
           limits:
             cpu: 300m
-            memory: 200Mi
+            memory: 1000Mi
           requests:
             cpu: 200m
-            memory: 50Mi
+            memory: 300Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true


### PR DESCRIPTION
#### Description:
- Update request/limits for backend/cluster-agent components when running on Stonesoup
- Reduce requests/limits when not running on Stonesoup (e.g. on dev's machines)

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
