### PR TITLE
Add printcolumn tags for sync and health status

### DIFF
--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_types.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_types.go
@@ -207,8 +207,10 @@ const (
 	GitOpsDeploymentUserError_PathIsRequired   = "spec.source.path is a required field and it cannot be empty"
 )
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Sync Status",type=string,JSONPath=`.status.sync.status`
+// +kubebuilder:printcolumn:name="Health Status",type=string,JSONPath=`.status.health.status`
 
 // GitOpsDeployment is the Schema for the gitopsdeployments API
 type GitOpsDeployment struct {

--- a/backend-shared/config/crd/bases/managed-gitops.redhat.com_gitopsdeployments.yaml
+++ b/backend-shared/config/crd/bases/managed-gitops.redhat.com_gitopsdeployments.yaml
@@ -16,7 +16,14 @@ spec:
     singular: gitopsdeployment
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.sync.status
+      name: Sync Status
+      type: string
+    - jsonPath: .status.health.status
+      name: Health Status
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: GitOpsDeployment is the Schema for the gitopsdeployments API


### PR DESCRIPTION
#### Description:
- Add kubebuilder print column tags to show sync and health status columns
```shell
$ kubectl get gitopsdeployments.managed-gitops.redhat.com -A
NAMESPACE   NAME          SYNC STATUS   HEALTH STATUS
jane        gitops-depl   Synced        Healthy
jgw         gitops-depl   Synced        Degraded
```