### PR TITLE
Fix test race condition in SnapshotEnvironmentBinding E2E test

### DIFF
--- a/tests-e2e/core/snapshotenvironmentbinding_test.go
+++ b/tests-e2e/core/snapshotenvironmentbinding_test.go
@@ -414,11 +414,11 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			// Check no GitOpsDeployment CR found with default name (longer name).
 			gitOpsDeployment := buildGitOpsDeploymentObjectMeta(gitOpsDeploymentName, binding.Namespace)
-			Consistently(gitOpsDeployment, "30s", "1s").ShouldNot(k8s.ExistByName(k8sClient), "wait 30s for the object not to exist")
+			Consistently(&gitOpsDeployment, "30s", "1s").ShouldNot(k8s.ExistByName(k8sClient), "wait 30s for the object not to exist")
 
 			// Check GitOpsDeployment is created with short name.
 			gitOpsDeployment.Name = binding.Name + "-" + binding.Spec.Components[0].Name
-			Eventually(gitOpsDeployment, "2m", "1s").Should(k8s.ExistByName(k8sClient))
+			Eventually(&gitOpsDeployment, "2m", "1s").Should(k8s.ExistByName(k8sClient))
 
 			// Check GitOpsDeployment is having repository data as given in Binding.
 			Eventually(gitOpsDeployment, "2m", "1s").Should(gitopsDeplFixture.HaveSpecSource(managedgitopsv1alpha1.ApplicationSource{

--- a/tests-e2e/core/snapshotenvironmentbinding_test.go
+++ b/tests-e2e/core/snapshotenvironmentbinding_test.go
@@ -414,13 +414,11 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 			// Check no GitOpsDeployment CR found with default name (longer name).
 			gitOpsDeployment := buildGitOpsDeploymentObjectMeta(gitOpsDeploymentName, binding.Namespace)
-			err = k8s.Get(&gitOpsDeployment, k8sClient)
-			Expect(apierr.IsNotFound(err)).To(BeTrue())
+			Consistently(gitOpsDeployment, "30s", "1s").ShouldNot(k8s.ExistByName(k8sClient), "wait 30s for the object not to exist")
 
-			// Check GitOpsDeployment is created with short name).
+			// Check GitOpsDeployment is created with short name.
 			gitOpsDeployment.Name = binding.Name + "-" + binding.Spec.Components[0].Name
-			err = k8s.Get(&gitOpsDeployment, k8sClient)
-			Expect(err).To(Succeed())
+			Eventually(gitOpsDeployment, "2m", "1s").Should(k8s.ExistByName(k8sClient))
 
 			// Check GitOpsDeployment is having repository data as given in Binding.
 			Eventually(gitOpsDeployment, "2m", "1s").Should(gitopsDeplFixture.HaveSpecSource(managedgitopsv1alpha1.ApplicationSource{


### PR DESCRIPTION
#### Description:
- Fix a race condition I noticed in the SnapshotEnvironmentBinding tests: we should wait for the GitOpsDeployment to exist (and not exist), rather than assuming it that it will be created quickly.

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
