### PR TITLE
Remove Type field from Unit tests and e2e tests

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
@@ -76,7 +76,6 @@ var _ = Describe("Environment controller tests", func() {
 					Namespace: apiNamespace.Name,
 				},
 				Spec: appstudioshared.EnvironmentSpec{
-					Type:               appstudioshared.EnvironmentType_POC,
 					DisplayName:        "my-environment",
 					DeploymentStrategy: appstudioshared.DeploymentStrategy_Manual,
 					ParentEnvironment:  "",
@@ -167,7 +166,6 @@ var _ = Describe("Environment controller tests", func() {
 					Namespace: apiNamespace.Name,
 				},
 				Spec: appstudioshared.EnvironmentSpec{
-					Type:               appstudioshared.EnvironmentType_POC,
 					DisplayName:        "my-environment",
 					DeploymentStrategy: appstudioshared.DeploymentStrategy_Manual,
 					ParentEnvironment:  "",
@@ -260,7 +258,6 @@ var _ = Describe("Environment controller tests", func() {
 					Namespace: apiNamespace.Name,
 				},
 				Spec: appstudioshared.EnvironmentSpec{
-					Type:               appstudioshared.EnvironmentType_POC,
 					DisplayName:        "my-environment",
 					DeploymentStrategy: appstudioshared.DeploymentStrategy_Manual,
 					ParentEnvironment:  "",
@@ -298,7 +295,6 @@ var _ = Describe("Environment controller tests", func() {
 					Namespace: apiNamespace.Name,
 				},
 				Spec: appstudioshared.EnvironmentSpec{
-					Type:               appstudioshared.EnvironmentType_POC,
 					DisplayName:        "my-environment",
 					DeploymentStrategy: appstudioshared.DeploymentStrategy_Manual,
 					ParentEnvironment:  "",
@@ -345,7 +341,6 @@ var _ = Describe("Environment controller tests", func() {
 					Namespace: apiNamespace.Name,
 				},
 				Spec: appstudioshared.EnvironmentSpec{
-					Type:               appstudioshared.EnvironmentType_POC,
 					DisplayName:        "my-environment",
 					DeploymentStrategy: appstudioshared.DeploymentStrategy_Manual,
 					ParentEnvironment:  "",

--- a/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller_test.go
@@ -58,7 +58,6 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 				},
 				Spec: appstudiosharedv1.EnvironmentSpec{
 					DisplayName:        "my-environment",
-					Type:               appstudiosharedv1.EnvironmentType_POC,
 					DeploymentStrategy: appstudiosharedv1.DeploymentStrategy_AppStudioAutomated,
 					ParentEnvironment:  "",
 					Tags:               []string{},

--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller_test.go
@@ -57,7 +57,6 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 				},
 				Spec: appstudiosharedv1.EnvironmentSpec{
 					DisplayName:        "my-environment",
-					Type:               appstudiosharedv1.EnvironmentType_POC,
 					DeploymentStrategy: appstudiosharedv1.DeploymentStrategy_AppStudioAutomated,
 					ParentEnvironment:  "",
 					Tags:               []string{},
@@ -625,7 +624,6 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 				},
 				Spec: appstudiosharedv1.EnvironmentSpec{
 					DisplayName:        "my-environment",
-					Type:               appstudiosharedv1.EnvironmentType_POC,
 					DeploymentStrategy: appstudiosharedv1.DeploymentStrategy_AppStudioAutomated,
 					ParentEnvironment:  "",
 					Tags:               []string{},

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -203,7 +203,6 @@ var _ = Describe("Environment E2E tests", func() {
 					Namespace: fixture.GitOpsServiceE2ENamespace,
 				},
 				Spec: appstudioshared.EnvironmentSpec{
-					Type:               appstudioshared.EnvironmentType_POC,
 					DisplayName:        "my-environment",
 					DeploymentStrategy: appstudioshared.DeploymentStrategy_AppStudioAutomated,
 					ParentEnvironment:  "",

--- a/tests-e2e/core/promotionrun_controller_test.go
+++ b/tests-e2e/core/promotionrun_controller_test.go
@@ -267,7 +267,6 @@ func buildEnvironmentResource(name, displayName, parentEnvironment string, envTy
 		},
 		Spec: appstudiosharedv1.EnvironmentSpec{
 			DisplayName:        displayName,
-			Type:               envType,
 			DeploymentStrategy: appstudiosharedv1.DeploymentStrategy_AppStudioAutomated,
 			ParentEnvironment:  parentEnvironment,
 			Tags:               []string{name},

--- a/tests-e2e/core/snapshotenvironmentbinding_test.go
+++ b/tests-e2e/core/snapshotenvironmentbinding_test.go
@@ -38,7 +38,6 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 					Namespace: fixture.GitOpsServiceE2ENamespace,
 				},
 				Spec: appstudiosharedv1.EnvironmentSpec{
-					Type:               appstudiosharedv1.EnvironmentType_POC,
 					DisplayName:        "my-environment",
 					DeploymentStrategy: appstudiosharedv1.DeploymentStrategy_AppStudioAutomated,
 					ParentEnvironment:  "",


### PR DESCRIPTION
#### Description:
Remove Type field from Unit tests and e2e tests as it is not required
Here is the PR in Application API where I have added omitempty for Type field in Environment Spec
https://github.com/redhat-appstudio/application-api/pull/28 

#### Link to JIRA Story (if applicable):
https://issues.redhat.com/browse/GITOPSRVCE-356
