### PR TITLE
Add support for resource cleanup finalizer for GitOpsDeployment 

### DIFF
--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_types.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_types.go
@@ -62,6 +62,12 @@ type ApplicationDestination struct {
 	Namespace string `json:"namespace,omitempty"`
 }
 
+const (
+	// DeletionFinalizer will indicate the GitOpsDeployment to wait until all its dependencies are removed.
+	// In the absence of this finalizer, GitOpsDeployment will be deleted first and its dependencies will be removed in the background.
+	DeletionFinalizer string = "resources-finalizer.managed-gitops.redhat.com"
+)
+
 type SyncOption string
 
 // Supported values for SyncOptions

--- a/backend-shared/db/utils.go
+++ b/backend-shared/db/utils.go
@@ -460,8 +460,10 @@ func SetupForTestingDBGinkgo() error {
 	for _, managedEnvironment := range managedEnvironments {
 		if strings.HasPrefix(managedEnvironment.Managedenvironment_id, "test-") {
 			rowsAffected, err := dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
-			Expect(rowsAffected).Should(Equal(1))
 			Expect(err).To(BeNil())
+			if err == nil {
+				Expect(rowsAffected).Should(Equal(1))
+			}
 		}
 	}
 

--- a/backend-shared/db/utils.go
+++ b/backend-shared/db/utils.go
@@ -461,9 +461,7 @@ func SetupForTestingDBGinkgo() error {
 		if strings.HasPrefix(managedEnvironment.Managedenvironment_id, "test-") {
 			rowsAffected, err := dbq.DeleteManagedEnvironmentById(ctx, managedEnvironment.Managedenvironment_id)
 			Expect(err).To(BeNil())
-			if err == nil {
-				Expect(rowsAffected).Should(Equal(1))
-			}
+			Expect(rowsAffected).Should(Equal(1))
 		}
 	}
 

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -42,10 +42,6 @@ const (
 	deploymentModifiedResult_NoChange deploymentModifiedResult = "noChangeInApp"
 
 	prunePropagationPolicy = "PrunePropagationPolicy=background"
-
-	// deletionFinalizer will indicate the GitOpsDeployment to wait until all its dependencies are removed.
-	// In the absence of this finalizer, GitOpsDeployment will be deleted first and its dependencies will be removed in the background.
-	deletionFinalizer = "resources-finalizer.managed-gitops.redhat.com"
 )
 
 // This file is responsible for processing events related to GitOpsDeployment CR.
@@ -419,7 +415,7 @@ func (a applicationEventLoopRunner_Action) handleDeleteGitOpsDeplEvent(ctx conte
 	if allErrors == nil {
 		if gitopsDepl != nil && isGitOpsDeploymentDeleted(gitopsDepl) {
 			// remove the finalizer if all the dependencies are cleaned up
-			if err := removeFinalizerIfExist(ctx, a.workspaceClient, gitopsDepl, deletionFinalizer); err != nil {
+			if err := removeFinalizerIfExist(ctx, a.workspaceClient, gitopsDepl, managedgitopsv1alpha1.DeletionFinalizer); err != nil {
 				a.log.Error(err, "failed to remove the deletion finalizer from GitOpsDeployment", "name", gitopsDepl.Name, "namespace", gitopsDepl.Namespace)
 				return false, gitopserrors.NewDevOnlyError(err)
 			}

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -413,7 +413,7 @@ func (a applicationEventLoopRunner_Action) handleDeleteGitOpsDeplEvent(ctx conte
 	}
 
 	if allErrors == nil {
-		if gitopsDepl != nil && isGitOpsDeploymentDeleted(gitopsDepl) {
+		if isGitOpsDeploymentDeleted(gitopsDepl) {
 			// remove the finalizer if all the dependencies are cleaned up
 			if err := removeFinalizerIfExist(ctx, a.workspaceClient, gitopsDepl, managedgitopsv1alpha1.DeletionFinalizer); err != nil {
 				a.log.Error(err, "failed to remove the deletion finalizer from GitOpsDeployment", "name", gitopsDepl.Name, "namespace", gitopsDepl.Namespace)

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -25,7 +25,6 @@ import (
 	"github.com/redhat-appstudio/managed-gitops/backend/metrics"
 	goyaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -440,7 +439,7 @@ func removeFinalizerIfExist(ctx context.Context, k8sClient client.Client, gitops
 
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(gitopsDepl), gitopsDepl)
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !apierr.IsNotFound(err) {
 			return err
 		}
 

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -464,20 +464,14 @@ func isGitOpsDeploymentDeleted(gitopsDepl *managedgitopsv1alpha1.GitOpsDeploymen
 }
 
 func removeItemFromSlice(item string, items []string) []string {
-	itemIndex := -1
-	for n, i := range items {
-		if i == item {
-			itemIndex = n
-			break
+	result := []string{}
+	for _, i := range items {
+		if i != item {
+			result = append(result, i)
 		}
 	}
 
-	if itemIndex > -1 {
-		items[itemIndex] = items[len(items)-1]
-		items = items[:len(items)-1]
-	}
-
-	return items
+	return result
 }
 
 // Note: this function will return a nil ManagedEnvironment and/or GitOpsEngineInstance if the ManagedEnvironment

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -40,7 +40,7 @@ const (
 	deploymentModifiedResult_Updated  deploymentModifiedResult = "updatedApp"
 	deploymentModifiedResult_NoChange deploymentModifiedResult = "noChangeInApp"
 
-	prunePropagationPolicy = "PrunePropagationPolicy=background"
+	prunePropagationPolicy = "PrunePropagationPolicy=foreground"
 )
 
 // This file is responsible for processing events related to GitOpsDeployment CR.

--- a/backend/eventloop/application_event_loop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_test.go
@@ -234,7 +234,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			By("Delete the GitOpsDepl and verify that the corresponding DB entries are removed.")
 			// ----------------------------------------------------------------------------
 
-			gitopsDepl.Finalizers = append(gitopsDepl.Finalizers, deletionFinalizer)
+			gitopsDepl.Finalizers = append(gitopsDepl.Finalizers, managedgitopsv1alpha1.DeletionFinalizer)
 			err = k8sClient.Update(ctx, gitopsDepl)
 			Expect(err).To(BeNil())
 
@@ -1777,7 +1777,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 		})
 
 		It("should not update if the finalizer is not found", func() {
-			err := removeFinalizerIfExist(ctx, k8sClient, gitopsDepl, deletionFinalizer)
+			err := removeFinalizerIfExist(ctx, k8sClient, gitopsDepl, managedgitopsv1alpha1.DeletionFinalizer)
 			Expect(err).To(BeNil())
 
 			gitopsDeplUpdated := false
@@ -1793,8 +1793,8 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			err := k8sClient.Delete(ctx, gitopsDepl)
 			Expect(err).To(BeNil())
 
-			gitopsDepl.Finalizers = append(gitopsDepl.Finalizers, deletionFinalizer)
-			err = removeFinalizerIfExist(ctx, k8sClient, gitopsDepl, deletionFinalizer)
+			gitopsDepl.Finalizers = append(gitopsDepl.Finalizers, managedgitopsv1alpha1.DeletionFinalizer)
+			err = removeFinalizerIfExist(ctx, k8sClient, gitopsDepl, managedgitopsv1alpha1.DeletionFinalizer)
 			Expect(err).To(BeNil())
 
 			gitopsDeplUpdated := false
@@ -1809,7 +1809,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 		It("should retry when there is a conflict", func() {
 			By("introduce a conflict by updating the object")
 			gitopsDeplClone := gitopsDepl.DeepCopy()
-			gitopsDeplClone.Finalizers = append(gitopsDeplClone.Finalizers, deletionFinalizer)
+			gitopsDeplClone.Finalizers = append(gitopsDeplClone.Finalizers, managedgitopsv1alpha1.DeletionFinalizer)
 			err := k8sClient.Update(ctx, gitopsDeplClone)
 			Expect(err).To(BeNil())
 
@@ -1820,7 +1820,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			Expect(errors.IsConflict(err)).To(BeTrue())
 
 			By("verify if the conflict will be handled by retrying")
-			err = removeFinalizerIfExist(ctx, k8sClient, gitopsDepl, deletionFinalizer)
+			err = removeFinalizerIfExist(ctx, k8sClient, gitopsDepl, managedgitopsv1alpha1.DeletionFinalizer)
 			Expect(err).To(BeNil())
 
 			gitopsDeplUpdated := false

--- a/backend/eventloop/application_event_loop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_test.go
@@ -1793,6 +1793,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			err := k8sClient.Delete(ctx, gitopsDepl)
 			Expect(err).To(BeNil())
 
+			gitopsDepl.Finalizers = append(gitopsDepl.Finalizers, deletionFinalizer)
 			err = removeFinalizerIfExist(ctx, k8sClient, gitopsDepl, deletionFinalizer)
 			Expect(err).To(BeNil())
 

--- a/tests-e2e/core/gitopsdeployment_test.go
+++ b/tests-e2e/core/gitopsdeployment_test.go
@@ -657,7 +657,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 			)
 			By("delete the GitOpsDeployment resource")
 
-			err = k8s.Delete(&gitOpsDeploymentResource, k8sClient)
+			err = k8sClient.Delete(ctx,&gitOpsDeploymentResource)
 			Expect(err).To(Succeed())
 
 			By("verify if the finalizer has prevented the GitOpsDeployment from deletion")

--- a/tests-e2e/core/gitopsdeployment_test.go
+++ b/tests-e2e/core/gitopsdeployment_test.go
@@ -626,7 +626,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				"https://github.com/redhat-appstudio/managed-gitops", "resources/test-data/sample-gitops-repository/environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
-			gitOpsDeploymentResource.Finalizers = append(gitOpsDeploymentResource.Finalizers, "resources-finalizer.managed-gitops.redhat.com")
+			gitOpsDeploymentResource.Finalizers = append(gitOpsDeploymentResource.Finalizers, managedgitopsv1alpha1.DeletionFinalizer)
 
 			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
 			Expect(err).To(Succeed())

--- a/tests-e2e/core/gitopsdeployment_test.go
+++ b/tests-e2e/core/gitopsdeployment_test.go
@@ -682,10 +682,10 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 			err = k8s.Get(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(BeNil())
 
-			Eventually(gitOpsDeploymentResource, "60s", "1s").Should(Satisfy(gitopsDeplFixture.HasNonNilDeletionTimestamp()))
+			Eventually(gitOpsDeploymentResource, "60s", "1s").Should(gitopsDeplFixture.HasNonNilDeletionTimestamp())
 
 			// check if the GitOps Service has not removed the finalizer before the dependent resources are deleted.
-			Consistently(gitOpsDeploymentResource, "30s", "1s").Should(k8s.ExistByName(k8sClient))
+			Consistently(&gitOpsDeploymentResource, "30s", "1s").Should(k8s.ExistByName(k8sClient))
 
 			// Remove the test finalizer and verify if all the dependent resources are deleted
 			err = k8s.UpdateWithoutConflict(cm, k8sClient, func(o client.Object) {
@@ -696,7 +696,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 			expectAllResourcesToBeDeleted(expectedResourceStatusList)
 
 			By("verify if the GitOpsDeployment is deleted after all the dependencies are removed")
-			Eventually(gitOpsDeploymentResource, "30s", "1s").Should(k8s.NotExist(k8sClient))
+			Eventually(&gitOpsDeploymentResource, "30s", "1s").Should(k8s.NotExist(k8sClient))
 		})
 
 		It("Checks for failure of deployment when an invalid input is provided", func() {

--- a/tests-e2e/fixture/gitopsdeployment/fixture.go
+++ b/tests-e2e/fixture/gitopsdeployment/fixture.go
@@ -295,6 +295,28 @@ func HaveReconciledState(reconciledState managedgitopsv1alpha1.ReconciledState) 
 	}, BeTrue())
 }
 
+// HasNonNilDeletionTimestamp checks whether the GitOpsDeployment has a non-nil deletion timestamp.
+func HasNonNilDeletionTimestamp() matcher.GomegaMatcher {
+	return WithTransform(func(gitopsDepl managedgitopsv1alpha1.GitOpsDeployment) bool {
+		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+		Expect(err).To(BeNil())
+
+		k8sClient, err := fixture.GetKubeClient(config)
+		if err != nil {
+			fmt.Println(k8sFixture.K8sClientError, err)
+			return false
+		}
+
+		err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&gitopsDepl), &gitopsDepl)
+		if err != nil {
+			fmt.Println(k8sFixture.K8sClientError, err)
+			return false
+		}
+
+		return gitopsDepl.DeletionTimestamp != nil
+	}, BeTrue())
+}
+
 func UpdateDeploymentWithFunction(gitopsDeployment *managedgitopsv1alpha1.GitOpsDeployment,
 	mutationFn func(*managedgitopsv1alpha1.GitOpsDeployment)) error {
 


### PR DESCRIPTION
#### Description:
- Adds support for the deletion finalizer `resources-finalizer.managed-gitops.redhat.com`. 
- In the presence of the finalizer, GitOpsDeployment will wait for the deletion of all the child resources. Once all the dependencies are removed, the backend will remove the deletion finalizer and the GitOpsDeployment CR will be deleted.
- Unit tests and e2e tests 
#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-360
