### PR TITLE
Webhook implementation for CRs.

### DIFF
--- a/appstudio-controller/config/default/manager_webhook_patch.yaml
+++ b/appstudio-controller/config/default/manager_webhook_patch.yaml
@@ -9,6 +9,8 @@ spec:
       containers:
       - name: manager
         ports:
+        - containerPort: 8080
+          name: http-metrics
         - containerPort: 9443
           name: webhook-server
           protocol: TCP

--- a/appstudio-controller/config/manager/manager.yaml
+++ b/appstudio-controller/config/manager/manager.yaml
@@ -37,6 +37,9 @@ spec:
         ports:
           - containerPort: 8080
             name: http-metrics
+          - containerPort: 9443
+            name: webhook-server
+            protocol: TCP
         image: ${COMMON_IMAGE}
         name: manager
         securityContext:
@@ -61,17 +64,14 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
-
-        # TODO: GITOPSRVCE-211: remove this, once it is proven not to be needed
-        # volumeMounts:
-        # - mountPath: /tmp/k8s-webhook-server/serving-certs
-        #   name: cert
-        #   readOnly: true
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
       serviceAccountName: gitops-appstudio-service-controller-manager
       terminationGracePeriodSeconds: 10
-      # TODO: GITOPSRVCE-211: remove this, once it is proven not to be needed
-      # volumes:
-      # - name: cert
-      #   secret:
-      #     defaultMode: 420
-      #     secretName: webhook-server-cert
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/appstudio-controller/config/webhook/manifests.yaml
+++ b/appstudio-controller/config/webhook/manifests.yaml
@@ -4,6 +4,8 @@ kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
   name: validating-webhook-configuration
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -24,4 +26,44 @@ webhooks:
     - UPDATE
     resources:
     - snapshots
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-appstudio-redhat-com-v1alpha1-snapshotenvironmentbinding
+  failurePolicy: Fail
+  name: vsnapshotenvironmentbinding.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - snapshotenvironmentbindings
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-appstudio-redhat-com-v1alpha1-promotionrun
+  failurePolicy: Fail
+  name: vpromotionrun.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - promotionruns
   sideEffects: None

--- a/appstudio-controller/go.mod
+++ b/appstudio-controller/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/devfile/api/v2 v2.0.0-20211021164004-dabee4e633ed
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.20.1
-	github.com/redhat-appstudio/application-api v0.0.0-20230116140450-3ef8e0cd2c9e
+	github.com/redhat-appstudio/application-api v0.0.0-20230303141937-394e8c127f03
 	github.com/redhat-appstudio/application-service v0.0.0-20220609190313-7a1a14b575dc
 	github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0
 	k8s.io/apimachinery v0.24.3
@@ -149,8 +149,6 @@ require (
 )
 
 replace (
-	// TODO: GITOPSRVCE-211: This line can be removed, once the application-api PR has merged.
-	// github.com/redhat-appstudio/application-api => github.com/jgwest/application-api v0.0.0-20221123042158-cdfb05b10aac
 	github.com/redhat-appstudio/managed-gitops/backend => ../backend
 	github.com/redhat-appstudio/managed-gitops/backend-shared => ../backend-shared
 	github.com/redhat-appstudio/managed-gitops/utilities/db-migration => ../utilities/db-migration

--- a/appstudio-controller/go.sum
+++ b/appstudio-controller/go.sum
@@ -1808,8 +1808,8 @@ github.com/rboyer/safeio v0.2.1/go.mod h1:Cq/cEPK+YXFn622lsQ0K4KsPZSPtaptHHEldsy
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20190706150252-9beb055b7962/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/redhat-appstudio/application-api v0.0.0-20230116140450-3ef8e0cd2c9e h1:2IFJPbDFEpD0pnyGIbCN0ijzhcsODYLkbuh+DExORzw=
-github.com/redhat-appstudio/application-api v0.0.0-20230116140450-3ef8e0cd2c9e/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
+github.com/redhat-appstudio/application-api v0.0.0-20230303141937-394e8c127f03 h1:1ZzDHNskkAfBHGavZqndj6qWj72P8LXv3XMisWbdgJ4=
+github.com/redhat-appstudio/application-api v0.0.0-20230303141937-394e8c127f03/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
 github.com/redhat-appstudio/application-service v0.0.0-20220609190313-7a1a14b575dc h1:f0fQXsJZR5Du/PQS2SMBinju0b9PAHLEKPbOwg/ERAI=
 github.com/redhat-appstudio/application-service v0.0.0-20220609190313-7a1a14b575dc/go.mod h1:QME/qCjHbFRj7f9Jh5EN0mwXQTR1YVM4jImRXr3KKbk=
 github.com/redhat-appstudio/service-provider-integration-operator v0.4.3/go.mod h1:S7NKaaZ0rhCrmHGqae9i21ROY23LurTtII3eMKqxjBQ=

--- a/appstudio-controller/main.go
+++ b/appstudio-controller/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -133,18 +134,25 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO: GITOPSRVCE-211: Uncomment this block of text, to re-enable webhook.
-	//
 	// // If the webhook is not disabled, start listening on the webhook URL
-	// if !strings.EqualFold(os.Getenv("DISABLE_APPSTUDIO_WEBHOOK"), "true") {
+	if !strings.EqualFold(os.Getenv("DISABLE_APPSTUDIO_WEBHOOK"), "true") {
 
-	// 	setupLog.Info("setting up webhooks")
-	// 	if err = (&applicationv1alpha1.Snapshot{}).SetupWebhookWithManager(mgr); err != nil {
-	// 		setupLog.Error(err, "unable to create webhook", "webhook", "Snapshot")
-	// 		os.Exit(1)
-	// 	}
+		setupLog.Info("setting up webhooks")
+		if err = (&applicationv1alpha1.Snapshot{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "Snapshot")
+			os.Exit(1)
+		}
 
-	// }
+		if err = (&applicationv1alpha1.SnapshotEnvironmentBinding{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "SnapshotEnvironmentBinding")
+			os.Exit(1)
+		}
+
+		if err = (&applicationv1alpha1.PromotionRun{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "PromotionRun")
+			os.Exit(1)
+		}
+	}
 
 	//+kubebuilder:scaffold:builder
 

--- a/manifests/base/crd/overlays/local-dev/kustomization.yaml
+++ b/manifests/base/crd/overlays/local-dev/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/redhat-appstudio/application-api/config/crd?ref=3ef8e0cd2c9ee21c8ce29cdfd5e7069f866ff5db
+- https://github.com/redhat-appstudio/application-api/config/crd?ref=394e8c127f031990838397fcb2d1e10110b2e7ae
 - ../../base

--- a/manifests/overlays/appstudio-staging-cluster/kustomization.yaml
+++ b/manifests/overlays/appstudio-staging-cluster/kustomization.yaml
@@ -4,8 +4,7 @@ kind: Kustomization
 resources:
 - ../../base/crd/overlays/stonesoup
 - ../../base/gitops-namespace
-# TODO: GITOPSRVCE-211: Switch this back from 'default-no-webhook' -> 'default'
-- ../../../appstudio-controller/config/default-no-webhook-no-prometheus
+- ../../../appstudio-controller/config/default
 - ../../../backend/config/default-no-prometheus
 - ../../../cluster-agent/config/default-no-prometheus
 - ../../base/postgresql-staging

--- a/manifests/overlays/k8s-env/kustomization.yaml
+++ b/manifests/overlays/k8s-env/kustomization.yaml
@@ -4,9 +4,7 @@ kind: Kustomization
 resources:
 - ../../base/crd/overlays/local-dev
 - ../../base/gitops-namespace
-
-# TODO: GITOPSRVCE-211: Switch this back from 'default-no-webhook' -> 'default'
-- ../../../appstudio-controller/config/default-no-webhook
+- ../../../appstudio-controller/config/default
 - ../../../backend/config/default
 - ../../../cluster-agent/config/default
 - ../../base/postgresql-staging

--- a/tests-e2e/core/webhook_test.go
+++ b/tests-e2e/core/webhook_test.go
@@ -1,0 +1,179 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
+	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Webhook E2E tests", func() {
+
+	// Run tests in order as next CR depends in previous CR.
+	Context("validate CR Webhooks", Ordered, func() {
+		var err error
+		var ctx context.Context
+		var k8sClient client.Client
+		var snapshot appstudiosharedv1.Snapshot
+		var promotionRun appstudiosharedv1.PromotionRun
+		var binding appstudiosharedv1.SnapshotEnvironmentBinding
+
+		envVariable := os.Getenv("DISABLE_APPSTUDIO_WEBHOOK")
+
+		It("Should validate Snapshot CR Webhooks.", func() {
+
+			// Don't run webhook checks if it is disabled.
+			if envVariable != "" && !strings.EqualFold(envVariable, "true") {
+
+				Expect(fixture.EnsureCleanSlate()).To(Succeed())
+
+				ctx = context.Background()
+
+				k8sClient, err = fixture.GetE2ETestUserWorkspaceKubeClient()
+				Expect(err).To(Succeed())
+
+				By("Create Snapshot.")
+				snapshot = buildSnapshotResource("my-snapshot", "new-demo-app", "Staging Snapshot", "Staging Snapshot", "component-a", "quay.io/jgwest-redhat/sample-workload:latest")
+				err = k8s.Create(&snapshot, k8sClient)
+				Expect(err).To(Succeed())
+
+				By("Validate Snapshot CR Webhooks.")
+
+				// Fetch the latest version
+				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&snapshot), &snapshot)
+				Expect(err).To(Succeed())
+
+				By("Validate Spec.Application field Webhook.")
+
+				temp := snapshot.Spec.Application // Keep old value
+				snapshot.Spec.Application = "new-app-name"
+				err = k8sClient.Update(ctx, &snapshot)
+
+				Expect(err).NotTo(Succeed())
+				Expect(strings.Contains(err.Error(), fmt.Sprintf("application cannot be updated to %s", snapshot.Spec.Application)))
+				snapshot.Spec.Application = temp // Revert value for next test
+
+				By("Validate Spec.Components.Name field Webhook.")
+
+				temp = snapshot.Spec.Components[0].Name // Keep old value
+				snapshot.Spec.Components[0].Name = "new-components-name"
+				err = k8sClient.Update(ctx, &snapshot)
+
+				Expect(err).NotTo(Succeed())
+				Expect(strings.Contains(err.Error(), fmt.Sprintf("components cannot be updated to %s", snapshot.Spec.Components)))
+				snapshot.Spec.Components[0].Name = temp // Revert value for next test
+
+				By("Validate Spec.Components.ContainerImage field Webhook.")
+
+				snapshot.Spec.Components[0].ContainerImage = "new-containerImage-name"
+				err = k8sClient.Update(ctx, &snapshot)
+
+				Expect(err).NotTo(Succeed())
+				Expect(strings.Contains(err.Error(), fmt.Sprintf("components cannot be updated to %s", snapshot.Spec.Components)))
+			}
+		})
+
+		It("Should validate SnapshotEnvironmentBinding CR Webhooks.", func() {
+
+			// Don't run webhook checks if it is disabled.
+			if envVariable != "" && !strings.EqualFold(envVariable, "true") {
+
+				By("Create Binding.")
+
+				binding = buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
+				err = k8s.Create(&binding, k8sClient)
+				Expect(err).To(Succeed())
+
+				By("Validate SnapshotEnvironmentBinding CR Webhooks.")
+
+				// Fetch the latest version
+				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&binding), &binding)
+				Expect(err).To(Succeed())
+
+				By("Validate Spec.Application field Webhook.")
+
+				temp := binding.Spec.Application // Keep old value
+				binding.Spec.Application = "new-app-name"
+				err = k8sClient.Update(ctx, &binding)
+
+				Expect(err).NotTo(Succeed())
+				Expect(strings.Contains(err.Error(), fmt.Sprintf("application cannot be updated to %s", binding.Spec.Application)))
+				binding.Spec.Application = temp // Revert value for next test
+
+				By("Validate Spec.Environment field Webhook.")
+
+				temp = binding.Spec.Environment // Keep old value
+				binding.Spec.Environment = "new-env-name"
+				err = k8sClient.Update(ctx, &binding)
+
+				Expect(err).NotTo(Succeed())
+				Expect(strings.Contains(err.Error(), fmt.Sprintf("environment cannot be updated to %s", binding.Spec.Environment)))
+				binding.Spec.Environment = temp // Revert value for next test
+			}
+		})
+
+		It("Should validate PromotionRun CR Webhooks.", func() {
+
+			// Don't run webhook checks if it is disabled.
+			if envVariable != "" && !strings.EqualFold(envVariable, "true") {
+
+				By("Create PromotionRun CR.")
+
+				promotionRun = buildPromotionRunResource("new-demo-app-manual-promotion", "new-demo-app", "my-snapshot", "prod")
+				err = k8s.Create(&promotionRun, k8sClient)
+				Expect(err).To(Succeed())
+
+				By("Validate PromotionRun CR Webhooks.")
+
+				// Fetch the latest version
+				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&promotionRun), &promotionRun)
+				Expect(err).To(Succeed())
+
+				By("Validate Spec.Application field Webhook.")
+
+				temp := promotionRun.Spec.Application // Keep old value
+				promotionRun.Spec.Application = "new-app-name"
+				err = k8sClient.Update(ctx, &promotionRun)
+
+				Expect(err).NotTo(Succeed())
+				Expect(strings.Contains(err.Error(), fmt.Sprintf("spec cannot be updated to %s", promotionRun.Spec)))
+				promotionRun.Spec.Application = temp // Revert value for next test
+
+				By("Validate Spec.Snapshot field Webhook.")
+
+				temp = promotionRun.Spec.Snapshot // Keep old value
+				promotionRun.Spec.Snapshot = "new-snapshot-name"
+				err = k8sClient.Update(ctx, &promotionRun)
+
+				Expect(err).NotTo(Succeed())
+				Expect(strings.Contains(err.Error(), fmt.Sprintf("spec cannot be updated to %s", promotionRun.Spec)))
+				promotionRun.Spec.Snapshot = temp // Revert value for next test
+
+				By("Validate Spec.ManualPromotion field Webhook.")
+
+				temp = promotionRun.Spec.ManualPromotion.TargetEnvironment // Keep old value
+				promotionRun.Spec.ManualPromotion.TargetEnvironment = "new-env-name"
+				err = k8sClient.Update(ctx, &promotionRun)
+
+				Expect(err).NotTo(Succeed())
+				Expect(strings.Contains(err.Error(), fmt.Sprintf("spec cannot be updated to %s", promotionRun.Spec)))
+				promotionRun.Spec.ManualPromotion.TargetEnvironment = temp // Revert value for next test
+
+				By("Validate Spec.AutomatedPromotion field Webhook.")
+
+				promotionRun.Spec.AutomatedPromotion.InitialEnvironment = "new-env-name"
+				err = k8sClient.Update(ctx, &promotionRun)
+
+				Expect(err).NotTo(Succeed())
+				Expect(strings.Contains(err.Error(), fmt.Sprintf("spec cannot be updated to %s", promotionRun.Spec)))
+			}
+		})
+	})
+})

--- a/tests-e2e/go.mod
+++ b/tests-e2e/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/argoproj/argo-cd/v2 v2.5.4
 	github.com/argoproj/gitops-engine v0.7.1-0.20221004132320-98ccd3d43fd9
 	github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible
-	github.com/redhat-appstudio/application-api v0.0.0-20230116140450-3ef8e0cd2c9e
+	github.com/redhat-appstudio/application-api v0.0.0-20230303141937-394e8c127f03
 	github.com/redhat-appstudio/managed-gitops/appstudio-controller v0.0.0
 	github.com/redhat-appstudio/managed-gitops/backend v0.0.0
 	github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0

--- a/tests-e2e/go.sum
+++ b/tests-e2e/go.sum
@@ -1878,8 +1878,8 @@ github.com/rboyer/safeio v0.2.1/go.mod h1:Cq/cEPK+YXFn622lsQ0K4KsPZSPtaptHHEldsy
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20190706150252-9beb055b7962/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/redhat-appstudio/application-api v0.0.0-20230116140450-3ef8e0cd2c9e h1:2IFJPbDFEpD0pnyGIbCN0ijzhcsODYLkbuh+DExORzw=
-github.com/redhat-appstudio/application-api v0.0.0-20230116140450-3ef8e0cd2c9e/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
+github.com/redhat-appstudio/application-api v0.0.0-20230303141937-394e8c127f03 h1:1ZzDHNskkAfBHGavZqndj6qWj72P8LXv3XMisWbdgJ4=
+github.com/redhat-appstudio/application-api v0.0.0-20230303141937-394e8c127f03/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
 github.com/redhat-appstudio/application-service v0.0.0-20220609190313-7a1a14b575dc h1:f0fQXsJZR5Du/PQS2SMBinju0b9PAHLEKPbOwg/ERAI=
 github.com/redhat-appstudio/application-service v0.0.0-20220609190313-7a1a14b575dc/go.mod h1:QME/qCjHbFRj7f9Jh5EN0mwXQTR1YVM4jImRXr3KKbk=
 github.com/redhat-appstudio/service-provider-integration-operator v0.4.3/go.mod h1:S7NKaaZ0rhCrmHGqae9i21ROY23LurTtII3eMKqxjBQ=


### PR DESCRIPTION
# Description
This PR enables Webhooks which are implemented in `application-api` to avoid changes in immutable fields.

PR to add webhooks in application-api:- https://github.com/redhat-appstudio/application-api/pull/26
**Note**
This PR also removes few existing test cases which are updating Spec fields of CR and now that is not allowed by Webhooks.

# Jira Ticket
https://issues.redhat.com/browse/GITOPSRVCE-211