### PR TITLE
Add support for RDS on app-interface member cluster, and refactor CRD YAML to remove application-api CRs

### DIFF
--- a/manifests/base/crd/base/kustomization.yaml
+++ b/manifests/base/crd/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../../backend-shared/config/crd

--- a/manifests/base/crd/overlays/local-dev/kustomization.yaml
+++ b/manifests/base/crd/overlays/local-dev/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 
 resources:
 - https://github.com/redhat-appstudio/application-api/config/crd?ref=3ef8e0cd2c9ee21c8ce29cdfd5e7069f866ff5db
-- ../../../backend-shared/config/crd
+- ../../base

--- a/manifests/base/crd/overlays/stonesoup/kustomization.yaml
+++ b/manifests/base/crd/overlays/stonesoup/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base

--- a/manifests/overlays/k8s-env/kustomization.yaml
+++ b/manifests/overlays/k8s-env/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../base/crd
+- ../../base/crd/overlays/local-dev
 - ../../base/gitops-namespace
 
 # TODO: GITOPSRVCE-211: Switch this back from 'default-no-webhook' -> 'default'

--- a/manifests/overlays/local-dev-env-with-k8s-db/kustomization.yaml
+++ b/manifests/overlays/local-dev-env-with-k8s-db/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../base/crd
+- ../../base/crd/overlays/local-dev
 - ../../base/gitops-namespace
 - ../../base/postgresql-staging
 # - ../../base/gitops-service-argocd

--- a/manifests/overlays/local-dev-env/kustomization.yaml
+++ b/manifests/overlays/local-dev-env/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../base/crd
+- ../../base/crd/overlays/local-dev
 - ../../base/gitops-namespace
 # - ../../base/gitops-service-argocd
 

--- a/manifests/overlays/stonesoup-member-cluster/appstudio-controller-deployment-patch.yaml
+++ b/manifests/overlays/stonesoup-member-cluster/appstudio-controller-deployment-patch.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gitops-appstudio-service-controller-manager
+  namespace: gitops
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --zap-time-encoding=rfc3339nano
+        - --health-probe-bind-address=:8085
+        - --metrics-bind-address=:8080
+        command:
+        - appstudio-controller
+        image: ${COMMON_IMAGE}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8085
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8085
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1024Mi
+          requests:
+            cpu: 50m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File

--- a/manifests/overlays/stonesoup-member-cluster/backend-deployment-patch.yaml
+++ b/manifests/overlays/stonesoup-member-cluster/backend-deployment-patch.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gitops-core-service-controller-manager
+  namespace: gitops
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --health-probe-bind-address=:18081
+        - --metrics-bind-address=:8080
+        - --leader-elect
+        - --zap-time-encoding=rfc3339nano
+        command:
+        - gitops-service-backend
+        env:
+        - name: ARGO_CD_NAMESPACE
+          value: gitops-service-argocd
+        - name: DB_ADDR
+          value: ""
+          valueFrom:
+            secretKeyRef:
+              key: db.name
+              name: gitops-service-postgres-rds-config
+        - name: DB_PASS
+          value: ""
+          valueFrom:
+            secretKeyRef:
+              key: db.password
+              name: gitops-service-postgres-rds-config
+        image: ${COMMON_IMAGE}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 18081
+          initialDelaySeconds: 120
+          periodSeconds: 60
+        name: manager
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 18081
+          initialDelaySeconds: 180
+          periodSeconds: 30
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 4800Mi
+          requests:
+            cpu: 1000m
+            memory: 2400Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File

--- a/manifests/overlays/stonesoup-member-cluster/backend-deployment-patch.yaml
+++ b/manifests/overlays/stonesoup-member-cluster/backend-deployment-patch.yaml
@@ -21,7 +21,7 @@ spec:
           value: ""
           valueFrom:
             secretKeyRef:
-              key: db.name
+              key: db.host
               name: gitops-service-postgres-rds-config
         - name: DB_PASS
           value: ""

--- a/manifests/overlays/stonesoup-member-cluster/cluster-agent-deployment-patch.yaml
+++ b/manifests/overlays/stonesoup-member-cluster/cluster-agent-deployment-patch.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: cluster-agent-controller-manager
+  name: gitops-service-agent-controller-manager
+  namespace: gitops
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --health-probe-bind-address=:8083
+        - --metrics-bind-address=:8080
+        - --leader-elect
+        - --zap-time-encoding=rfc3339nano
+        command:
+        - gitops-service-cluster-agent
+        env:
+        - name: ARGO_CD_NAMESPACE
+          value: gitops-service-argocd
+        - name: DB_ADDR
+          value: ""
+          valueFrom:
+            secretKeyRef:
+              key: db.name
+              name: gitops-service-postgres-rds-config
+        - name: DB_PASS
+          value: ""
+          valueFrom:
+            secretKeyRef:
+              key: db.password
+              name: gitops-service-postgres-rds-config
+        image: ${COMMON_IMAGE}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8083
+          initialDelaySeconds: 45
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8083
+          initialDelaySeconds: 45
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 300m
+            memory: 1000Mi
+          requests:
+            cpu: 200m
+            memory: 300Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File

--- a/manifests/overlays/stonesoup-member-cluster/cluster-agent-deployment-patch.yaml
+++ b/manifests/overlays/stonesoup-member-cluster/cluster-agent-deployment-patch.yaml
@@ -23,7 +23,7 @@ spec:
           value: ""
           valueFrom:
             secretKeyRef:
-              key: db.name
+              key: db.host
               name: gitops-service-postgres-rds-config
         - name: DB_PASS
           value: ""

--- a/manifests/overlays/stonesoup-member-cluster/kustomization.yaml
+++ b/manifests/overlays/stonesoup-member-cluster/kustomization.yaml
@@ -8,9 +8,8 @@ resources:
 - ../../../appstudio-controller/config/default-no-webhook-no-prometheus
 - ../../../backend/config/default-no-prometheus
 - ../../../cluster-agent/config/default-no-prometheus
-- ../../base/postgresql-staging
 - ../../base/gitops-service-argocd/base
-- prometheus/
+- ../appstudio-staging-cluster/prometheus
 
 patchesStrategicMerge:
 - backend-deployment-patch.yaml


### PR DESCRIPTION
#### Description:
- Add a new overlay specific to deploying to the app-interface member cluster, including reading from RDS secret
- Refactor CRDs: in the AppStudio/Stonesoup case, we shouldn't be deploying the application-api-defined CRDs

#### Link to JIRA Story (if applicable):
- [GITOPSRVCE-401](https://issues.redhat.com/browse/GITOPSRVCE-401)
- [GITOPSRVCE-402](https://issues.redhat.com/browse/GITOPSRVCE-402)

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
