### PR TITLE
feat: add script to install/upgrade managed service

### DIFF
--- a/utilities/upgrade-service/README.md
+++ b/utilities/upgrade-service/README.md
@@ -1,17 +1,17 @@
 This document describes the steps to install/upgrade your service using `install-upgrade.sh` script.
 
-*Pre-requisites:*
+**Pre-requisites:**
 
 To execute the script, we would need to have some basic requirements:
 - The script is being executed on an Openshift cluster
 - The image being used is available on quay.io
 
-*Avaialable flag options:*
+**Avaialable flag options:**
 - `-i` : provide gitops service image (default: `quay.io/${QUAY_USERNAME}/gitops-service:latest`, QUAY_USERNAME = `redhat-appstudio`)
 - `-u` : provide QUAY registry username (default: `redhat-appstudio`). This will replace the value of QUAY_USERNAME in `quay.io/${QUAY_USERNAME}/gitops-service:latest`
 
 
-*Steps to execute the script:*
+**Steps to execute the script:**
 
 To execute the script using default image (`quay.io/redhat-appstudio/gitops-service:latest`) with the below command:
 ```bash

--- a/utilities/upgrade-service/README.md
+++ b/utilities/upgrade-service/README.md
@@ -1,3 +1,34 @@
 This document describes the steps to install/upgrade your service using `install-upgrade.sh` script.
 
+*Pre-requisites:*
+
+To execute the script, we would need to have some basic requirements:
+- The script is being executed on an Openshift cluster
+- The image being used is available on quay.io
+
+*Avaialable flag options:*
+- `-i` : provide gitops service image (default: `quay.io/${QUAY_USERNAME}/gitops-service:latest`, QUAY_USERNAME = `redhat-appstudio`)
+- `-u` : provide QUAY registry username (default: `redhat-appstudio`). This will replace the value of QUAY_USERNAME in `quay.io/${QUAY_USERNAME}/gitops-service:latest`
+
+
+*Steps to execute the script:*
+
+To execute the script using default image (`quay.io/redhat-appstudio/gitops-service:latest`) with the below command:
+```bash
+$ sh install-upgrade.sh
+```
+
+To execute the script with a specific image:
+```bash
+$ sh install-upgrade.sh -i <image_url>
+
+# e.g. sh install-upgrade.sh -i quay.io/isequeir/gitops-service:latest
+```
+
+To execute the script using image with latest tag but from custom quay registry:
+```bash
+$ sh install-upgrade.sh -u <QUAY_USERNAME>
+
+e.g. if QUAY_USERNAME is isequeir, this will use the image quay.io/isequeir/gitops-service:latest
+```
 

--- a/utilities/upgrade-service/README.md
+++ b/utilities/upgrade-service/README.md
@@ -1,0 +1,3 @@
+This document describes the steps to install/upgrade your service using `install-upgrade.sh` script.
+
+

--- a/utilities/upgrade-service/install-upgrade.sh
+++ b/utilities/upgrade-service/install-upgrade.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+GOBIN=$(go env GOPATH)/bin
+
+# Checks if a binary is present on the local system
+exit_if_binary_not_installed() {
+  for binary in "$@"; do
+    command -v $binary >/dev/null 2>&1 || {
+      echo >&2 'Script requires $binary command-line utility to be installed on your local machine. Aborting...'
+      exit 1
+    }
+  done
+}
+
+# Check if a pod is ready, if it fails to get ready, rollback to PREV_IMAGE
+check_pod_status_ready() {
+  for binary in "$@"; do
+    echo "Binary $binary";
+    pod_name=$(kubectl get pods --no-headers -o custom-columns=":metadata.name" -n gitops | grep "$binary");
+    echo "Pod name : $pod_name";
+    kubectl wait pod --for=condition=Ready $pod_name -n gitops --timeout=150s;
+    if [ $? -ne 0 ]; then
+      echo "Pod '$pod_name' failed to become Ready in desired time. Logs from the pod:"
+      kubectl logs $pod_name -n gitops;
+      echo "\n\nPerforming rollback to $PREV_IMAGE";      
+      rollback
+    fi
+  done
+}
+
+rollback() {
+  make install-all-k8s IMG=$PREV_IMAGE
+  cleanup;
+  echo "Upgrade Unsuccessful!!";
+  exit 1;
+}
+
+cleanup() {
+  rm -rf /tmp/managed-gitops
+}
+
+exit_if_binary_not_installed kubectl
+
+QUAY_USERNAME=redhat-appstudio
+
+while getopts ':i:u:' OPTION; do
+  case "$OPTION" in
+    i) IMG=${OPTARG};;
+    u) QUAY_USERNAME=${OPTARG};;
+    ?) echo "Available flag options are:\n[-i] to provide gitops service image (default: quay.io/${QUAY_USERNAME}/gitops-service:latest)\n[-u] to provide QUAY registry username (default: redhat-appstudio)"; exit;
+  esac
+done
+
+if [ -z $IMG ]; then
+  IMG="quay.io/${QUAY_USERNAME}/gitops-service:latest"
+fi
+
+echo "IMAGE $IMG";
+
+PREV_IMAGE=$(kubectl get deploy/gitops-appstudio-service-controller-manager -n gitops -o jsonpath='{..image}');
+echo "PREV IMAGE : $PREV_IMAGE";
+
+if [ "$PREV_IMAGE" = "$IMG" ]; then
+  echo "Currently deployed image matches the new image '$IMG'. No need to upgrade. Exiting.."
+  exit 
+fi
+
+echo "Upgrading from $PREV_IMAGE to $IMG";
+
+mkdir -p /tmp/managed-gitops
+cd /tmp/managed-gitops
+
+git clone git@github.com:redhat-appstudio/managed-gitops.git 
+cd managed-gitops
+
+make install-all-k8s IMG=$IMG
+
+echo 'Wait until pods are running';
+
+check_pod_status_ready postgres appstudio gitops-core-service-controller gitops-service-agent
+
+cleanup
+
+echo "Upgrade Successful!"
+exit 0;


### PR DESCRIPTION
#### Description:
The PR adds a script for users to be able to install or upgrade Managed Gitops Service to a specific version. The version of managed-service is identified using the image passed to the script using `-i` flag.

The script provide 2 optional flags for users. If no flag is provided, the script will try to fetch `quay.io/redhat-appstudio/gitops-service:latest` as the default image. The available options are:

- `-i` : provide gitops service image (default: `quay.io/${QUAY_USERNAME}/gitops-service:latest`, QUAY_USERNAME = `redhat-appstudio`)
- `-u`: provide QUAY registry username (default: `redhat-appstudio`). This will replace the value of QUAY_USERNAME in `quay.io/${QUAY_USERNAME}/gitops-service:latest`.

#### Link to JIRA Story (if applicable):
[GITOPSRVCE-316](https://issues.redhat.com/browse/GITOPSRVCE-316)

We are working on pushing images to quay.io using a different JIRA story ([GITOPSRVCE-315](https://issues.redhat.com/browse/GITOPSRVCE-315)).