### PR TITLE
KubernetesToDBResourceMapping patch should exit with zero error code if DB has not been initialized

### DIFF
--- a/manifests/overlays/appstudio-staging-cluster/backend-deployment-patch.yaml
+++ b/manifests/overlays/appstudio-staging-cluster/backend-deployment-patch.yaml
@@ -6,21 +6,21 @@ metadata:
 spec:
   template:
     spec:
-      initContainers:
-      - name: init-container
-        command:
-        - /init-container/init-container
-        env:
-        - name: ARGO_CD_NAMESPACE
-          value: gitops-service-argocd
-        - name: DB_ADDR
-          value: gitops-postgresql-staging
-        - name: DB_PASS
-          valueFrom:
-            secretKeyRef:
-              key: postgresql-password
-              name: gitops-postgresql-staging
-        image: ${COMMON_IMAGE}
+      # initContainers:
+      # - name: init-container
+      #   command:
+      #   - /init-container/init-container
+      #   env:
+      #   - name: ARGO_CD_NAMESPACE
+      #     value: gitops-service-argocd
+      #   - name: DB_ADDR
+      #     value: gitops-postgresql-staging
+      #   - name: DB_PASS
+      #     valueFrom:
+      #       secretKeyRef:
+      #         key: postgresql-password
+      #         name: gitops-postgresql-staging
+      #   image: ${COMMON_IMAGE}
       containers:
       - args:
         - --health-probe-bind-address=:18081


### PR DESCRIPTION
#### Description:
- The Stonesoup E2E tests are currently failing on our latest code drop, as the init container code (introduced to fix a bug on staging as part of https://github.com/redhat-appstudio/managed-gitops/pull/287) is returning an error if the database has not been initialized (which is always the case when the E2E tests first run, as part of a PR)
- We can detect if the database has not been initialized by using the exact error code returned by postgresql
- In this case, the init container could should return 0, and allow the backend controller to initialize the database.

#### Link to JIRA Story (if applicable): N/A