### PR TITLE
Remove unnecessary uses of GetOrCreateManagedEnvironmentByNamespaceUID, and add additional comments around its purpose

### DIFF
--- a/backend-shared/db/util/utils.go
+++ b/backend-shared/db/util/utils.go
@@ -44,7 +44,11 @@ func GetGitOpsEngineSingleInstanceNamespace() string {
 }
 
 // GetOrCreateManagedEnvironmentByNamespaceUID returns the managed environment database entry that
-// corresponds to given namespace.
+// corresponds to given API namespace.
+// - this is used in the case where a user is targetting their own API namespace, for example with
+//   a GitOpsDeployment with a 'nil' destination field (which then defaults to deploying to the same
+//   namespace as the GitOpsDeployment CR.)
+// - in this case, a ManagedEnv <-KubernetesDBToResourceMapping-> user's API namespace relationship will be created
 //
 // The bool return value is 'true' if ManagedEnvironment is created; 'false' if it already exists in DB or in case of failure.
 func GetOrCreateManagedEnvironmentByNamespaceUID(ctx context.Context, namespace corev1.Namespace,

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
@@ -470,7 +470,7 @@ func wrapManagedEnv(ctx context.Context, managedEnv db.ManagedEnvironment, works
 	bool, *db.ClusterAccess, bool, *db.GitopsEngineCluster, gitopserrors.ConditionError) {
 
 	engineInstance, isNewInstance, gitopsEngineCluster, err :=
-		internalDetermineGitOpsEngineInstanceForNewApplication(ctx, clusterUser, managedEnv, gitopsEngineClient, dbQueries, log)
+		internalDetermineGitOpsEngineInstance(ctx, clusterUser, gitopsEngineClient, dbQueries, log)
 
 	if err != nil {
 		log.Error(err.DevError(), "unable to determine gitops engine instance")


### PR DESCRIPTION
#### Description:
- Minor cleanup: 
    - Rename `internalDetermineGitOpsEngineInstance` to make it's purpose more
    - Remove managedEnvironment as an input to `internalDetermineGitOpsEngineInstance` API: using a ManagedEnv as an input into what GitOpsEngineInstance to use is an idea that is not fully baked.
    - Remove uses of `GetOrCreateManagedEnvironmentByNamespaceUID` that are no longer needed, base on above.
    - Add additional comment explaining why `GetOrCreateManagedEnvironmentByNamespaceUID` exists

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
