### PR TITLE
Updated Dockerfile to have db migration binary in the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ COPY --from=builder workspace/backend/bin/manager /usr/local/bin/gitops-service-
 COPY --from=builder workspace/cluster-agent/bin/manager /usr/local/bin/gitops-service-cluster-agent
 COPY --from=builder workspace/appstudio-controller/bin/manager /usr/local/bin/appstudio-controller
 COPY --from=builder workspace/utilities/init-container/bin/init-container /init-container
+COPY --from=builder workspace/utilities/db-migration/bin/db-migrate /usr/local/bin/db-migrate
 
 # Copy the database migration versions
 COPY --from=builder workspace/utilities/db-migration/migrations /migrations

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,12 @@ build-init-container-binary: ## Build init-controller binary
 test-init-container-binary: ## Run test for init-controller binary only
 	cd $(MAKEFILE_ROOT)/utilities/init-container && make test
 
+### --- db - migration  --- ###
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
+
+build-db-migration: ## Build init-controller binary
+	cd $(MAKEFILE_ROOT)/utilities/db-migration && make build
+
 ### --- A r g o C D    W e b   U I --- ###
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 deploy-argocd: ## Install ArgoCD vanilla Web UI
@@ -151,7 +157,7 @@ clean: ## remove the bin and vendor folders from each component
 	cd $(MAKEFILE_ROOT)/tests-e2e && make clean
 	cd $(MAKEFILE_ROOT)/utilities/db-migration && make clean
 
-build: build-backend build-cluster-agent build-appstudio-controller build-init-container-binary ## Build all the components - note: you do not need to do this before running start
+build: build-backend build-cluster-agent build-appstudio-controller build-init-container-binary build-db-migration ## Build all the components - note: you do not need to do this before running start
 
 docker-build: ## Build docker image -- note: you have to change the USERNAME var. Optionally change the BASE_IMAGE or TAG
 	$(DOCKER) build --build-arg ARCH=$(ARCH) -t ${IMG} $(MAKEFILE_ROOT)

--- a/Makefile
+++ b/Makefile
@@ -282,10 +282,15 @@ ensure-workload-gitops-ns-exists:
 	KUBECONFIG=${WORKLOAD_KUBECONFIG} kubectl create namespace gitops 2> /dev/null || true
 
 
-
-KUSTOMIZE = $(shell pwd)/bin/kustomize
+ifeq (, $(shell which kustomize))
+  KUSTOMIZE=$(shell pwd)/bin/kustomize
+else
+  KUSTOMIZE=$(shell which kustomize)
+endif
 kustomize: ## Download kustomize locally if necessary.
+ifeq (, $(shell which kustomize))
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.5)
+endif
 
 # go-get-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/create-dev-env.sh
+++ b/create-dev-env.sh
@@ -32,7 +32,7 @@ wait-until() {
 # Installs 'db-schema.sql' into the PostgreSQL running in Kubernetes cluster
 # With 'kube' is tests if port-forwarding is working and gives you the commands to do it manually
 if [ "$1" = "kube" ]; then
-  exit_if_binary_not_installed "kubectl" "psql"
+  exit_if_binary_not_installed "kubectl"
 
   # Get the secret
   counter=0

--- a/manifests/base/postgresql-staging/db-migration-job.yaml
+++ b/manifests/base/postgresql-staging/db-migration-job.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-migrate-job
+  namespace: gitops
+spec:
+  template:
+    metadata:
+      namespace: gitops
+    spec:
+      containers:
+        - image: quay.io/redhat-appstudio/gitops-service:latest
+          name: db-migrate-job
+          resources: {}
+          command: ["/usr/local/bin/db-migrate"]
+          env:
+            - name: DB_ADDR
+              value: gitops-postgresql-staging.gitops.svc.cluster.local
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: gitops-postgresql-staging
+                  key: postgresql-password
+      restartPolicy: Never

--- a/utilities/db-migration/Makefile
+++ b/utilities/db-migration/Makefile
@@ -1,3 +1,7 @@
+# Get the OS and ARCH values to be used for building the binary.
+OS ?= $(shell go env GOOS)
+ARCH ?= $(shell go env GOARCH)
+
 migration-script:
 	cd migrations && migrate create -ext sql -seq $(filename)
 
@@ -22,5 +26,5 @@ clean:
 	rm -rf vendor/ bin/
 
 .PHONY: build
-build: fmt vet lint ## Build the DB migration binary
-	go build -o bin/db-migrate main.go
+build: fmt vet ## Build the DB migration binary
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/db-migrate main.go

--- a/utilities/db-migration/Makefile
+++ b/utilities/db-migration/Makefile
@@ -20,3 +20,7 @@ vet:
 .PHONY: clean
 clean:
 	rm -rf vendor/ bin/
+
+.PHONY: build
+build: fmt vet lint ## Build the DB migration binary
+	go build -o bin/db-migrate main.go


### PR DESCRIPTION
#### Description:
For doing a test setup with tekton pipelines, creation of a local port-forwarding session did not work as the pipeline tasks were running inside the pod. As part of this PR, I am including the binary in the container image and using a `Job` manifest to create the DB migration that would run from inside the flexy (test) cluster. This will help us to avoid the need to create a port forwarding session.

#### Link to JIRA Story (if applicable):

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
