### PR TITLE
GITOPSRVCE-449: update known bad values on stonesoup clusters, via init-container

### DIFF
--- a/manifests/overlays/stonesoup-member-cluster/backend-deployment-patch.yaml
+++ b/manifests/overlays/stonesoup-member-cluster/backend-deployment-patch.yaml
@@ -6,6 +6,27 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+      - name: init-container
+        command:
+        - /init-container/init-container
+        env:
+        - name: ARGO_CD_NAMESPACE
+          value: gitops-service-argocd
+        - name: DB_ADDR
+          value: ""
+          valueFrom:
+            secretKeyRef:
+              key: db.host
+              name: gitops-service-postgres-rds-config
+        - name: DB_PASS
+          value: ""
+          valueFrom:
+            secretKeyRef:
+              key: db.password
+              name: gitops-service-postgres-rds-config
+        image: ${COMMON_IMAGE}
+
       containers:
       - args:
         - --health-probe-bind-address=:18081

--- a/utilities/init-container/main.go
+++ b/utilities/init-container/main.go
@@ -14,20 +14,41 @@ func main() {
 
 	fmt.Println("* Running the init-container")
 
-	// February 8th, 2023 - Fix an issue with incorrect GitOpsEngineInstance on Stonesoup staging cluster
+	// March 6th, 2023 - Fix an issue with incorrect GitOpsEngineInstance on Stonesoup prod member clusters
 	// - Jonathan West
+
+	patchMultitenantCluster()
+	patchRHTenantCluster()
+
+	os.Exit(0)
+}
+
+func patchMultitenantCluster() {
+
+	// KubernetesToDBResourceMapping entry:
+	// Pre:
+
+	//  kubernetes_resource_type |       kubernetes_resource_uid        |   db_relation_type   |           db_relation_key            | seq_id
+	// --------------------------+--------------------------------------+----------------------+--------------------------------------+--------
+	//  Namespace                | 7b907c12-81ad-4661-bff7-c3030b26111b | GitopsEngineInstance | 4c1470c7-fefd-4911-8bc1-0cf5e2298411 |     28
+
+	// Post:
+
+	//  kubernetes_resource_type |       kubernetes_resource_uid        |   db_relation_type   |           db_relation_key            | seq_id
+	// --------------------------+--------------------------------------+----------------------+--------------------------------------+--------
+	//  Namespace                | 7dcba8c2-88d3-4960-865a-9b0eb691cba5 | GitopsEngineInstance | 4c1470c7-fefd-4911-8bc1-0cf5e2298411 |     28
 
 	// The target DB entry to update
 	targetKDB := db.KubernetesToDBResourceMapping{
 		KubernetesResourceType: "Namespace",
 		DBRelationType:         "GitopsEngineInstance",
-		DBRelationKey:          "701632d3-dd8b-4173-88c3-84306579a156",
+		DBRelationKey:          "4c1470c7-fefd-4911-8bc1-0cf5e2298411",
 	}
 
 	// Old and new values for the K8sToDBResourceMapping
 	const (
-		oldK8sResourceUID = "9dc321a8-aab6-4482-ac71-3c16be1e7c47"
-		newK8ResourceUID  = "6c91e02f-b6d6-40cf-aa57-7478694f660b"
+		oldK8sResourceUID = "7b907c12-81ad-4661-bff7-c3030b26111b"
+		newK8ResourceUID  = "7dcba8c2-88d3-4960-865a-9b0eb691cba5"
 	)
 
 	// We shouldn't panic: this will return a non-zero error code, and prevent the controller from starting.
@@ -43,8 +64,49 @@ func main() {
 
 	if outerErr != nil {
 		os.Exit(1)
-	} else {
-		os.Exit(0)
 	}
 
+}
+
+func patchRHTenantCluster() {
+
+	// KubernetesToDBResourceMapping entry:
+
+	// Pre:
+	//
+	// kubernetes_resource_type |       kubernetes_resource_uid        |   db_relation_type   |           db_relation_key            | seq_id
+	// --------------------------+--------------------------------------+----------------------+--------------------------------------+--------
+	// Namespace                | f5820fe1-7347-41c6-9a6a-1b62b6c5567b | GitopsEngineInstance | 8fb948f8-5602-46f5-9656-804661c7229c |      3
+
+	//
+	// Post:
+	// Namespace                | cc240bc3-3a91-400c-8f42-b46af32697f6 | GitopsEngineInstance | 8fb948f8-5602-46f5-9656-804661c7229c |      3
+
+	// The target DB entry to update
+	targetKDB := db.KubernetesToDBResourceMapping{
+		KubernetesResourceType: "Namespace",
+		DBRelationType:         "GitopsEngineInstance",
+		DBRelationKey:          "8fb948f8-5602-46f5-9656-804661c7229c",
+	}
+
+	// Old and new values for the K8sToDBResourceMapping
+	const (
+		oldK8sResourceUID = "f5820fe1-7347-41c6-9a6a-1b62b6c5567b"
+		newK8ResourceUID  = "cc240bc3-3a91-400c-8f42-b46af32697f6"
+	)
+
+	// We shouldn't panic: this will return a non-zero error code, and prevent the controller from starting.
+	_, outerErr := util.CatchPanic(func() error {
+		err := hotfix.HotfixK8sResourceUIDOfKubernetesResourceToDBResourceMapping(context.Background(), targetKDB, oldK8sResourceUID,
+			newK8ResourceUID)
+		return err
+	})
+
+	if outerErr != nil {
+		fmt.Println("Error return by hotfix function:", outerErr)
+	}
+
+	if outerErr != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
#### Description:
- See [GITOPSRVCE-449](https://issues.redhat.com//browse/GITOPSRVCE-449) for details of the problem, and the fix.
- This fix detects if the database contains the problematic field values, and if so, updates them, before the GitOps Service backend container starts, via an init container.
- If the problematic field values are not detected, this is a no-op.

#### Link to JIRA Story (if applicable): [GITOPSRVCE-449](https://issues.redhat.com/browse/GITOPSRVCE-449)
