### PR TITLE
Chaos Engineering: simulate random restarts of controller processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,10 @@ uninstall-all-k8s: undeploy-k8s-env
 start: ## Start all the components, compile & run (ensure goreman is installed, with 'go install github.com/mattn/goreman@latest')
 	$(GOBIN)/goreman start
 
+start-chaos: ## Start all the components, compile & run (ensure goreman is installed, with 'go install github.com/mattn/goreman@latest')
+	$(GOBIN)/goreman -f Procfile.chaos start
+
+
 clean: ## remove the bin and vendor folders from each component
 	cd $(MAKEFILE_ROOT)/backend-shared && make clean
 	cd $(MAKEFILE_ROOT)/backend && make clean

--- a/Procfile.chaos
+++ b/Procfile.chaos
@@ -1,0 +1,3 @@
+backend: cd backend && make chaos-run
+cluster-agent: cd cluster-agent && make chaos-run
+appstudio-controller: cd appstudio-controller && make chaos-run

--- a/appstudio-controller/Makefile
+++ b/appstudio-controller/Makefile
@@ -119,6 +119,13 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # - more on controller log level configuration: https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/
 # - we disable webhook when running locally, because K8s will not be able to connect to our local process (which is a prereq for webhook supprot)
 
+.PHONY: chaos-run
+chaos-run: manifests generate fmt vet ## Chaos Engineering: Simulate a controller that restarts every ~33 seconds.
+	go build -o /tmp/appstudio-controller-manager-chaos main.go
+	KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/appstudio-controller-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
+	rm /tmp/appstudio-controller-manager-chaos
+
+
 #.PHONY: docker-build
 #docker-build: test ## Build docker image with the manager.
 #	docker build -t ${IMG} .

--- a/appstudio-controller/Makefile
+++ b/appstudio-controller/Makefile
@@ -122,7 +122,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 .PHONY: chaos-run
 chaos-run: manifests generate fmt vet ## Chaos Engineering: Simulate a controller that restarts every ~33 seconds.
 	go build -o /tmp/appstudio-controller-manager-chaos main.go
-	KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/appstudio-controller-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
+	DISABLE_APPSTUDIO_WEBHOOK=true KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/appstudio-controller-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
 	rm /tmp/appstudio-controller-manager-chaos
 
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -62,7 +62,13 @@ build: generate fmt vet ## Build manager binary.
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
+
 # more on controller log level configuration: https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/
+
+chaos-run: manifests generate fmt vet ## Chaos Engineering: Simulate a controller that restarts every ~33 seconds.
+	go build -o /tmp/backend-manager-chaos  main.go
+	KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/backend-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
+	rm /tmp/backend-manager-chaos
 
 ##@ Deployment
 

--- a/cluster-agent/Makefile
+++ b/cluster-agent/Makefile
@@ -119,6 +119,11 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	KUBECONFIG=${WORKLOAD_KUBECONFIG} go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
 # more on controller log level configuration: https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/
 
+chaos-run: manifests generate fmt vet ## Chaos Engineering: Simulate a controller that restarts every ~33 seconds.
+	go build -o /tmp/cluster-agent-manager-chaos main.go
+	KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/cluster-agent-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
+	rm /tmp/cluster-agent-manager-chaos
+
 # docker-build: test ## Build docker image with the manager.
 # 	docker build -t ${IMG} .
 

--- a/docs/chaos-engineering.md
+++ b/docs/chaos-engineering.md
@@ -1,0 +1,107 @@
+# Chaos Engineering
+
+## Introduction
+
+Chaos Engineering is an [industry term](https://en.wikipedia.org/wiki/Chaos_engineering) used to describe testing software under degraded conditions, in order to ensure it continues to perform correctly, and/or degrades gracefully.
+
+A number of existing tools (ChaosMonkey, Litmus Chaos, etc) are available that can integrate with Kubernetes, and simulate failure scenarios like container OOM, poor network condition, and more. However, within the GitOps Service, we are using custom code to simulate failures, rather than relying on these external tools.
+
+## Within the GitOps Service
+
+Within the GitOps Service, there are three types of chaos-engineering-based error scenarios that can be simulated:
+- Simulate an unreliable database by randomly returning errors on database API calls before they can be completed.
+- Simulate unreliable cluster connection by randomly returning errors on k8s client API calls
+- Randomly restarting the gitops controller processes (either 'kill -9' the process, or kill the pod) during the test.
+
+## How to test
+
+The E2E test framework used to test the GitOps Service should be able to be run in a 'chaos engineering' mode, which simulates a variety of error conditions while the normal E2E tests are being run. The tests should still (eventually) pass, despite running in unreliable circumstances.
+
+Furthermore, the test should consistently pass, when looped over-and-and in these conditions. For example, if one sets the E2E tests to run in a loop, for 100 runs, over and over, all 100 should pass, despite the above.
+
+### Simulating an unreliable database
+
+This functionality can be used to simulate unreliable database connections. This code will that randomly inject database errors, which allow us to verify that our service tolerates this and/or fails gracefully.
+
+In order to enable this functionality, the `ENABLE_UNRELIABLE_DB=true` environment variable must be set, before running the GitOps Service controllers.
+
+The `UNRELIABLE_DB_FAILURE_RATE=X` environment variable is used to control what % of database API calls will fail. 
+- For example, `UNRELIABLE_DB_FAILURE_RATE=20` will cause 20% of database calls to fail.
+- Increase this value to increase the simulated severity of failures
+
+To run the E2E tests with this functionality enabled:
+```shell
+# Setup GitOps Service E2E tests pre-requisites on OpenShift cluster
+make setup-e2e-openshift
+
+# Start GitOps Service, in E2E configuration, with database chaos engineering enabled
+ENABLE_UNRELIABLE_DB=true UNRELIABLE_DB_FAILURE_RATE=20  make start
+
+# In a separate terminal window, to run the tests:
+make test-e2e
+```
+
+Even with X% of the database requests failing, the E2E tests should still pass.
+
+
+### Simulating an unreliable cluster connection
+
+This functionaly can be used to simulate the impact of unreliable network conditions, or a flaky K8s API server, on the GitOps Service controllers.
+
+This functionality is enabled via an environment variable, which we enable when running E2E tests with chaos engineering. By running E2E tests with this environment variable set, this will allow us to ensure that our product works even when running in less reliable conditions.
+
+The unreliable K8s client functionality will randomly fail a certain percent of K8s API requests, and that % is controllable via environment variable.
+
+In order to enable this functionality, the `ENABLE_UNRELIABLE_CLIENT=true` environment variable must be set, before running the GitOps Service controllers.
+
+The `UNRELIABLE_CLIENT_FAILURE_RATE=X` environment variable is used to control what % of K8s requests will fail. 
+- For example, `UNRELIABLE_CLIENT_FAILURE_RATE=20` will cause 20% of requests to fail.
+
+To run the E2E tests with this functionality enabled:
+```shell
+# Setup GitOps Service E2E tests pre-requisites on OpenShift cluster
+make setup-e2e-openshift
+
+# Start GitOps Service, in E2E configuration, with K8s client chaos engineering enabled
+ENABLE_UNRELIABLE_CLIENT=true  UNRELIABLE_CLIENT_FAILURE_RATE=20  make start
+
+# In a separate terminal window, to run the tests:
+make test-e2e
+```
+
+
+### Simulating an OOM-ing container process
+
+This functionality can be used to simulate a container that is being restarted by K8s, for example due to the container intermittently OOMing, or panic-ing.
+
+When running `make start-chaos`, the GitOps Service controllers will be started using a special shell script that will randomly kill and restart the controller process. The interval of restarts is controlled via two environment variables:
+- `KILL_INITIAL="10"`: The minimum number of seconds to wait for killing and restarting the process. In this example, 10 seconds.
+- `KILL_INTERVAL="45"`: A random value is chosen between 0, and the `KILL_INTERVAL`. `KILL_INTERVAL` is the maximum length of time to wait (after initial wait) before killing and restarting the process. In this example, 45 seconds.
+
+The average length of time between restarts for any process is thus `KILL_INITIAL + rand(0, KILL_INTERVAL)`
+
+To run the E2E tests with this functionality enabled:
+```shell
+# Setup GitOps Service E2E tests pre-requisites on OpenShift cluster
+make setup-e2e-openshift
+
+# Start GitOps Service, in E2E configuration, with process restart chaos engineering enabled
+make start-chaos
+
+# In a separate terminal window, to run the tests:
+make test-e2e
+```
+
+You will see that every X seconds, the controller processes are killed and restarted. For example:
+```shell
+02:04:10 appstudio-controller | ../utilities/random-kill.sh: line 15: 109177 Killed                  $*
+02:04:10 appstudio-controller | Killing process: 109280
+02:04:10 appstudio-controller | New PID is 109388
+02:04:10 appstudio-controller | Next kill command in 40s
+02:04:12 appstudio-controller | INFO	setup	starting manager
+02:04:12 appstudio-controller | INFO	Starting server	{"kind": "health probe", "addr": "[::]:8085"}
+02:04:12 appstudio-controller | INFO	Starting server	{"path": "/metrics", "kind": "metrics", "addr": "[::]:8084"}
+# (...)
+```
+
+Even with this going on, the E2E tests should still pass.

--- a/tests-e2e/fixture/fixture.go
+++ b/tests-e2e/fixture/fixture.go
@@ -212,6 +212,15 @@ func cleanUpOldGitOpsServiceAPIs(namespace string, k8sClient client.Client) erro
 
 	for idx := range gitopsDeploymentList.Items {
 		gitopsDeployment := gitopsDeploymentList.Items[idx]
+
+		// If the GitOpsDeployment contains a finalizer, remove it before deleting.
+		if len(gitopsDeployment.Finalizers) > 0 {
+			gitopsDeployment.Finalizers = []string{}
+			if err := k8sClient.Update(context.Background(), &gitopsDeployment); err != nil {
+				return fmt.Errorf("unable to remove finalizer from GitOpsDeployment: %v", err)
+			}
+		}
+
 		if err := k8sClient.Delete(context.Background(), &gitopsDeployment); err != nil {
 			return err
 		}

--- a/utilities/random-kill.sh
+++ b/utilities/random-kill.sh
@@ -13,7 +13,7 @@ SIGNAL=KILL
 
 # parameters: maximum time between kills (excluding initial time), initial kill-free startup time internal
 wait_for_timeout () {
-    SLEEP_VAL=$[ ( $RANDOM % $1 ) + $2 ]s
+    SLEEP_VAL=$[ ( $RANDOM % $1 ) + $2 ]
     echo "Next kill command in $SLEEP_VAL"
     sleep $SLEEP_VAL
 }

--- a/utilities/random-kill.sh
+++ b/utilities/random-kill.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# This utility is used to simulate an unreliable K8s controller (as part of our overall chaos engineering test strategy): 
+# For example, this utility can be used to simulate a controller that is constantly running out of memory and being OOMKilled by K8s.
+# Even when running under these conditions, our controllers should still work as expected.
+# 
+# Notes:
+# - This utility should only be used in a test/dev environment. NEVER in staging/production.
+# - If you see any references to this utility in a staging/prod context, someone messed up :).
+# - PRs should never reference utility unless explicitly touching this functionality.
+
+SIGNAL=KILL
+
+# parameters: maximum time between kills (excluding initial time), initial kill-free startup time internal
+wait_for_timeout () {
+    SLEEP_VAL=$[ ( $RANDOM % $1 ) + $2 ]s
+    echo "Next kill command in $SLEEP_VAL"
+    sleep $SLEEP_VAL
+}
+
+# Loop until the user manualy CTRL-C
+while true; do
+
+    # (Re)-launch the provided command
+    $* &
+
+    # Get the PID
+    LAST_PID=$!
+    echo "New PID is $LAST_PID" 
+
+    # Wait a random interval
+    wait_for_timeout $KILL_INTERVAL $KILL_INITIAL
+
+    # Kill the process
+    echo "Killing process: $LAST_PID"
+    kill -$SIGNAL $LAST_PID
+
+done


### PR DESCRIPTION
#### Description:
- This PR adds functionality that simulates the GitOps Service controllers randomly restarting every ~30 seconds.
- This also adds documentation for the other chaos engineering code that went in as part of earlier stories.
- I also fixed an intermittent E2E test bug, where the GitOpsDeployment finalizers added by the resource-deletion finalizer are not properly cleaned up by the EnsureCleanSlate-based test fixture.

#### Link to JIRA Story (if applicable): [GITOPSRVCE-33](https://issues.redhat.com/browse/GITOPSRVCE-33)
