### PR TITLE
chore: remove deprecated getK8sClientForGitopsEngineInstance function

### DIFF
--- a/backend/eventloop/application_event_loop/application_event_runner.go
+++ b/backend/eventloop/application_event_loop/application_event_runner.go
@@ -125,14 +125,13 @@ func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent
 			_, err := sharedutil.CatchPanic(func() error {
 
 				action := applicationEventLoopRunner_Action{
-					getK8sClientForGitOpsEngineInstance: eventlooptypes.GetK8sClientForGitOpsEngineInstance,
-					eventResourceName:                   newEvent.Request.Name,
-					eventResourceNamespace:              newEvent.Request.Namespace,
-					workspaceClient:                     newEvent.Client,
-					sharedResourceEventLoop:             sharedResourceEventLoop,
-					log:                                 log,
-					workspaceID:                         namespaceID,
-					k8sClientFactory:                    shared_resource_loop.DefaultK8sClientFactory{},
+					eventResourceName:       newEvent.Request.Name,
+					eventResourceNamespace:  newEvent.Request.Namespace,
+					workspaceClient:         newEvent.Client,
+					sharedResourceEventLoop: sharedResourceEventLoop,
+					log:                     log,
+					workspaceID:             namespaceID,
+					k8sClientFactory:        shared_resource_loop.DefaultK8sClientFactory{},
 				}
 
 				var err error
@@ -343,14 +342,13 @@ func handleManagedEnvironmentModified(ctx context.Context, expectedResourceName 
 		// Update the existing action, but change the 'eventResourceName' and 'eventResourceNamespace' to point
 		// to the GitOpsDeployment.
 		newAction := applicationEventLoopRunner_Action{
-			getK8sClientForGitOpsEngineInstance: eventlooptypes.GetK8sClientForGitOpsEngineInstance,
-			eventResourceName:                   gitopsDeployment.Name,
-			eventResourceNamespace:              gitopsDeployment.Namespace,
-			workspaceClient:                     action.workspaceClient,
-			sharedResourceEventLoop:             action.sharedResourceEventLoop,
-			log:                                 action.log,
-			workspaceID:                         action.workspaceID,
-			k8sClientFactory:                    shared_resource_loop.DefaultK8sClientFactory{},
+			eventResourceName:       gitopsDeployment.Name,
+			eventResourceNamespace:  gitopsDeployment.Namespace,
+			workspaceClient:         action.workspaceClient,
+			sharedResourceEventLoop: action.sharedResourceEventLoop,
+			log:                     action.log,
+			workspaceID:             action.workspaceID,
+			k8sClientFactory:        shared_resource_loop.DefaultK8sClientFactory{},
 		}
 
 		signalledShutdown, err := handleDeploymentModified(ctx, newEvent, newAction, dbQueries, log)
@@ -419,11 +417,6 @@ type applicationEventLoopRunner_Action struct {
 	// The UID of the API namespace (namespace containing GitOps API types)
 	workspaceID string
 
-	// getK8sClientForGitOpsEngineInstance returns the K8s client that corresponds to the gitops engine instance.
-	// As of this writing, only one Argo CD instance is supported, so this is trivial, but should have
-	// more complex logic in the future.
-	getK8sClientForGitOpsEngineInstance func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error)
-
 	// sharedResourceEventLoop can be used to invoke the shared resource event loop, in order to
 	// create or retrieve shared database resources.
 	sharedResourceEventLoop *shared_resource_loop.SharedResourceEventLoop
@@ -433,5 +426,6 @@ type applicationEventLoopRunner_Action struct {
 	// have a cluster-agent running alongside it.
 	testOnlySkipCreateOperation bool
 
+	// k8sClientFactory enabled the creation of K8s API clients to target various environments
 	k8sClientFactory shared_resource_loop.SRLK8sClientFactory
 }

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -340,7 +340,7 @@ func (a applicationEventLoopRunner_Action) handleNewGitOpsDeplEvent(ctx context.
 		Resource_type: db.OperationResourceType_Application,
 	}
 
-	gitopsEngineClient, err := a.getK8sClientForGitOpsEngineInstance(ctx, engineInstance)
+	gitopsEngineClient, err := a.k8sClientFactory.GetK8sClientForGitOpsEngineInstance(ctx, engineInstance)
 	if err != nil {
 		return nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewDevOnlyError(err)
 	}
@@ -661,7 +661,7 @@ func (a applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplEvent(ctx cont
 	log.Info("Processed GitOpsDeployment event: Application updated in database from latest API changes")
 
 	// Create the operation
-	gitopsEngineClient, err := a.getK8sClientForGitOpsEngineInstance(ctx, engineInstance)
+	gitopsEngineClient, err := a.k8sClientFactory.GetK8sClientForGitOpsEngineInstance(ctx, engineInstance)
 	if err != nil {
 		log.Error(err, "unable to retrieve gitopsengineinstance for updated gitopsdepl", "gitopsEngineInstance", engineInstance.EngineCluster_id)
 		return nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewDevOnlyError(err)
@@ -789,7 +789,7 @@ func (a applicationEventLoopRunner_Action) cleanOldGitOpsDeploymentEntry(ctx con
 
 	// 5) Now that we've deleted the Application row, create the operation that will cause the Argo CD application
 	// to be deleted.
-	gitopsEngineClient, err := a.getK8sClientForGitOpsEngineInstance(ctx, gitopsEngineInstance)
+	gitopsEngineClient, err := a.k8sClientFactory.GetK8sClientForGitOpsEngineInstance(ctx, gitopsEngineInstance)
 	if err != nil {
 		log.Error(err, "could not retrieve client for gitops engine instance", "instance", gitopsEngineInstance.Gitopsengineinstance_id)
 		return false, err

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments_test.go
@@ -166,9 +166,6 @@ var _ = Describe("Application Event Runner Deployments to check SyncPolicy.SyncO
 			Expect(err).To(BeNil())
 
 			appEventLoopRunnerAction = applicationEventLoopRunner_Action{
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
@@ -386,7 +386,7 @@ func (a *applicationEventLoopRunner_Action) handleDeletedGitOpsDeplSyncRunEvent(
 	}
 
 	// 2) Create the operation, in order to inform the cluster agent it needs to cancel the sync operation
-	operationClient, err := a.getK8sClientForGitOpsEngineInstance(ctx, gitopsEngineInstance)
+	operationClient, err := a.k8sClientFactory.GetK8sClientForGitOpsEngineInstance(ctx, gitopsEngineInstance)
 	if err != nil {
 		log.Error(err, "unable to retrieve gitopsengine instance from handleSyncRunModified, when resource was deleted")
 		return gitopserrors.NewDevOnlyError(err)
@@ -490,7 +490,7 @@ func (a *applicationEventLoopRunner_Action) handleNewGitOpsDeplSyncRunEvent(ctx 
 	log.Info(fmt.Sprintf("Created a ApiCRToDBMapping: (APIResourceType: %s, APIResourceUID: %s, DBRelationType: %s)", newApiCRToDBMapping.APIResourceType, newApiCRToDBMapping.APIResourceUID, newApiCRToDBMapping.DBRelationType))
 	createdResources = append(createdResources, &newApiCRToDBMapping)
 
-	operationClient, err := a.getK8sClientForGitOpsEngineInstance(ctx, gitopsEngineInstance)
+	operationClient, err := a.k8sClientFactory.GetK8sClientForGitOpsEngineInstance(ctx, gitopsEngineInstance)
 	if err != nil {
 		log.Error(err, "unable to retrieve gitopsengine instance from handleSyncRunModified")
 

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns_test.go
@@ -75,9 +75,6 @@ var _ = Describe("Application Event Runner SyncRuns", func() {
 			Expect(err).To(BeNil())
 
 			applicationAction = applicationEventLoopRunner_Action{
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				sharedResourceEventLoop:     shared_resource_loop.NewSharedResourceLoop(),

--- a/backend/eventloop/application_event_loop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_test.go
@@ -110,9 +110,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			Expect(err).To(BeNil())
 
 			appEventLoopRunnerAction = applicationEventLoopRunner_Action{
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,
@@ -175,9 +172,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			}
 
 			appEventLoopRunnerActionSecond := applicationEventLoopRunner_Action{
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,
@@ -300,9 +294,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 		It("Should not deploy application, as request data is not valid.", func() {
 
 			appEventLoopRunnerAction = applicationEventLoopRunner_Action{
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				workspaceClient:             k8sClient,
 				log:                         log.FromContext(context.Background()),
@@ -363,9 +354,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			}
 
 			appEventLoopRunnerActionSecond := applicationEventLoopRunner_Action{
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,
@@ -550,10 +538,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			Expect(err).To(BeNil())
 
 			a := applicationEventLoopRunner_Action{
-				// When the code asks for a new k8s client, give it our fake client
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,
@@ -606,9 +590,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			Expect(err).To(BeNil())
 
 			appEventLoopRunnerAction = applicationEventLoopRunner_Action{
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				workspaceClient:             k8sClient,
 				log:                         log.FromContext(context.Background()),
@@ -684,10 +665,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 
 			// 1) send a deployment modified event, to ensure the deployment is added to the database, and processed
 			a := applicationEventLoopRunner_Action{
-				// When the code asks for a new k8s client, give it our fake client
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,
@@ -704,10 +681,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 
 			// 2) add a sync run modified event, to ensure the sync run is added to the database, and processed
 			a = applicationEventLoopRunner_Action{
-				// When the code asks for a new k8s client, give it our fake client
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:       gitopsDeplSyncRun.Name,
 				eventResourceNamespace:  gitopsDeplSyncRun.Namespace,
 				workspaceClient:         k8sClient,
@@ -771,10 +744,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 
 			// 1) send a deployment modified event, to ensure the deployment is added to the database, and processed
 			a := applicationEventLoopRunner_Action{
-				// When the code asks for a new k8s client, give it our fake client
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,
@@ -791,10 +760,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 
 			// 2) add a sync run modified event, to ensure the sync run is added to the database, and processed
 			a = applicationEventLoopRunner_Action{
-				// When the code asks for a new k8s client, give it our fake client
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:       gitopsDeplSyncRun.Name,
 				eventResourceNamespace:  gitopsDeplSyncRun.Namespace,
 				workspaceClient:         k8sClient,
@@ -863,10 +828,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 				Build()
 
 			a := applicationEventLoopRunner_Action{
-				// When the code asks for a new k8s client, give it our fake client
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,
@@ -1042,10 +1003,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 				Build()
 
 			a := applicationEventLoopRunner_Action{
-				// When the code asks for a new k8s client, give it our fake client
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,
@@ -1209,10 +1166,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			}
 
 			a := applicationEventLoopRunner_Action{
-				// When the code asks for a new k8s client, give it our fake client
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,
@@ -1394,9 +1347,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 			a := applicationEventLoopRunner_Action{
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           "dummy-deployment",
 				eventResourceNamespace:      workspace.Namespace,
 				workspaceClient:             k8sClient,
@@ -1445,10 +1395,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			}
 
 			a := applicationEventLoopRunner_Action{
-				// When the code asks for a new k8s client, give it our fake client
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,
@@ -1511,10 +1457,6 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			}
 
 			a := applicationEventLoopRunner_Action{
-				// When the code asks for a new k8s client, give it our fake client
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,
@@ -2098,10 +2040,6 @@ var _ = Describe("application_event_runner_deployments.go Tests", func() {
 			}
 
 			appEventLoopRunnerAction := applicationEventLoopRunner_Action{
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					// TODO: GITOPSRVCE-66: Replace this with the new interface: SRLK8sClientFactory
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,
@@ -2174,10 +2112,6 @@ var _ = Describe("application_event_runner_deployments.go Tests", func() {
 			}
 
 			appEventLoopRunnerAction := applicationEventLoopRunner_Action{
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					// TODO: GITOPSRVCE-66: Replace this with new interface: SRLK8sClientFactory
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,
@@ -2257,10 +2191,6 @@ var _ = Describe("application_event_runner_deployments.go Tests", func() {
 			}
 
 			appEventLoopRunnerAction := applicationEventLoopRunner_Action{
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					// TODO: GITOPSRVCE-66: Replace this with new interface: SRLK8sClientFactory
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,
@@ -2324,10 +2254,6 @@ var _ = Describe("application_event_runner_deployments.go Tests", func() {
 			}
 
 			appEventLoopRunnerAction := applicationEventLoopRunner_Action{
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					// TODO: GITOPSRVCE-66: Replace this with new interface: SRLK8sClientFactory
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,

--- a/backend/eventloop/application_event_loop/metrics_test.go
+++ b/backend/eventloop/application_event_loop/metrics_test.go
@@ -89,9 +89,6 @@ var _ = Describe("Test for Gitopsdeployment metrics counter", func() {
 			Expect(err).To(BeNil())
 
 			appEventLoopRunnerAction = applicationEventLoopRunner_Action{
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,
@@ -191,9 +188,6 @@ var _ = Describe("Test for Gitopsdeployment metrics counter", func() {
 			Expect(err).To(BeNil())
 
 			appEventLoopRunnerAction = applicationEventLoopRunner_Action{
-				getK8sClientForGitOpsEngineInstance: func(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
-					return k8sClient, nil
-				},
 				eventResourceName:           gitopsDepl.Name,
 				eventResourceNamespace:      gitopsDepl.Namespace,
 				workspaceClient:             k8sClient,


### PR DESCRIPTION
#### Description:
- The `getK8sClientForGitOpsEngineInstance` field has long since been deprecated by the newer `k8sClientFactory` field.
- The `k8sClientFactory` interface is a superset of the `getK8sClientForGitOpsEngineInstance`  functionality
- This deprecated field likely should have been removed as part of my original ManagedEnvironment PR, but better late than never :grinning: 

#### Link to JIRA Story (if applicable): N/A
