### PR TITLE
Temporarily disable deletion of ManagedEnviroment resources by database reconciler.

### DIFF
--- a/backend/eventloop/db_reconciler.go
+++ b/backend/eventloop/db_reconciler.go
@@ -634,6 +634,8 @@ func cleanOrphanedEntriesfromTable_SyncOperation(ctx context.Context, dbQueries 
 	}
 }
 
+// TODO: GITOPSRVCE-457: Remove this nolint, once 457 is fixed.
+//nolint:unused
 // cleanOrphanedEntriesfromTable_ManagedEnvironment loops through ManagedEnvironments in database and verifies they are still valid (Having entry in ACTDM). If not, the resources are deleted.
 func cleanOrphanedEntriesfromTable_ManagedEnvironment(ctx context.Context, dbQueries db.DatabaseQueries, client client.Client, listOfAppsIdsInDTAM []string, k8sClientFactory sharedresourceloop.SRLK8sClientFactory, log logr.Logger) {
 

--- a/backend/eventloop/db_reconciler.go
+++ b/backend/eventloop/db_reconciler.go
@@ -490,8 +490,10 @@ func cleanOrphanedEntriesfromTable(ctx context.Context, dbQueries db.DatabaseQue
 	// Loop through SyncOperations and delete those which are missing entry in ACTDM.
 	cleanOrphanedEntriesfromTable_SyncOperation(ctx, dbQueries, client, listOfAppsIdsInDTAM[dbType_SyncOperation], log)
 
-	// Loop through ManagedEnvironments and delete those which are missing entry in ACTDM.
-	cleanOrphanedEntriesfromTable_ManagedEnvironment(ctx, dbQueries, client, listOfAppsIdsInDTAM[dbType_ManagedEnvironment], k8sClientFactory, log)
+	// TODO: GITOPSRVCE-457: Re-enable this.
+
+	// // Loop through ManagedEnvironments and delete those which are missing entry in ACTDM.
+	// cleanOrphanedEntriesfromTable_ManagedEnvironment(ctx, dbQueries, client, listOfAppsIdsInDTAM[dbType_ManagedEnvironment], k8sClientFactory, log)
 }
 
 // cleanOrphanedEntriesfromTable_RepositoryCredential loops through RepositoryCredentials in database and verifies they are still valid (Having entry in ACTDM). If not, the resources are deleted.

--- a/backend/eventloop/db_reconciler_test.go
+++ b/backend/eventloop/db_reconciler_test.go
@@ -1511,6 +1511,9 @@ var _ = Describe("DB Clean-up Function Tests", func() {
 
 		It("Should not delete ManagedEnvironment entry if its ACTDM entry is available.", func() {
 
+			// TODO: GITOPSRVCE-457: re-enable once 457 is fixed.
+			Skip("GITOPSRVCE-457: re-enable once 457 is fixed.")
+
 			defer dbq.CloseDatabase()
 
 			By("Call clean-up function.")
@@ -1524,6 +1527,10 @@ var _ = Describe("DB Clean-up Function Tests", func() {
 		})
 
 		It("Should delete ManagedEnvironment entry if its ACTDM entry is not available.", func() {
+
+			// TODO: GITOPSRVCE-457: re-enable once 457 is fixed.
+			Skip("GITOPSRVCE-457: re-enable once 457 is fixed.")
+
 			defer dbq.CloseDatabase()
 
 			By("Create ManagedEnvironment row without DTAM entry.")
@@ -1563,6 +1570,9 @@ var _ = Describe("DB Clean-up Function Tests", func() {
 		})
 
 		It("Should not delete ManagedEnvironment entry if its ACTDM entry is not available, but created time is less than wait time for deletion.", func() {
+
+			// TODO: GITOPSRVCE-457: re-enable once 457 is fixed.
+			Skip("GITOPSRVCE-457: re-enable once 457 is fixed.")
 
 			defer dbq.CloseDatabase()
 


### PR DESCRIPTION
#### Description:
- Temporarily disable deletion of ManagedEnviroment resources by database reconciler.

#### Link to JIRA Story (if applicable): [GITOPSRVCE-457](https://issues.redhat.com/browse/GITOPSRVCE-457)

