### PR TITLE
Reduce log verbosity of backend and appstudio-controller components

### DIFF
--- a/backend/eventloop/application_event_loop/application_event_runner.go
+++ b/backend/eventloop/application_event_loop/application_event_runner.go
@@ -166,7 +166,7 @@ func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent
 					err = action.applicationEventRunner_handleSyncRunModified(ctx, scopedDBQueries)
 
 				} else if newEvent.EventType == eventlooptypes.UpdateDeploymentStatusTick {
-					err = action.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDeploymentName, gitopsDeploymentNamespace, scopedDBQueries)
+					_, err = action.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDeploymentName, gitopsDeploymentNamespace, scopedDBQueries)
 
 				} else if newEvent.EventType == eventlooptypes.ManagedEnvironmentModified {
 

--- a/backend/eventloop/application_event_loop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_test.go
@@ -958,7 +958,8 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			By("Call applicationEventRunner_handleUpdateDeploymentStatusTick function to update Health/Sync status.")
 			// ----------------------------------------------------------------------------
 
-			err = a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDepl.Name, gitopsDepl.Namespace, dbQueries)
+			updated, err := a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDepl.Name, gitopsDepl.Namespace, dbQueries)
+			Expect(updated).To(BeTrue())
 			Expect(err).To(BeNil())
 
 			// ----------------------------------------------------------------------------
@@ -1002,8 +1003,9 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			By("Verify whether status condition of syncError is true")
 			Expect(gitopsDeployment.Status.Conditions[0].Status).To(Equal(managedgitopsv1alpha1.GitOpsConditionStatusTrue))
 
-			err = a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDepl.Name, gitopsDepl.Namespace, dbQueries)
+			updated, err = a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDepl.Name, gitopsDepl.Namespace, dbQueries)
 			Expect(err).To(BeNil())
+			Expect(updated).To(BeTrue())
 
 			clientErr = a.workspaceClient.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
 			Expect(clientErr).To(BeNil())
@@ -1012,6 +1014,11 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			matchingCondition, _ = conditions.NewConditionManager().FindCondition(&gitopsDeployment.Status.Conditions, managedgitopsv1alpha1.GitOpsDeploymentConditionSyncError)
 			Expect(matchingCondition).ToNot(BeNil())
 			Expect(matchingCondition.Status).To(Equal(managedgitopsv1alpha1.GitOpsConditionStatusFalse))
+
+			By("attempting to update the deployment status tick, even though nothing has changed.")
+			updated, err = a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDepl.Name, gitopsDepl.Namespace, dbQueries)
+			Expect(err).To(BeNil())
+			Expect(updated).To(BeFalse(), "since nothing has changed, the GitOpsDeployment should not have been updated")
 
 			// ----------------------------------------------------------------------------
 			By("Delete GitOpsDepl to clean resources.")
@@ -1316,7 +1323,8 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			By("Call applicationEventRunner_handleUpdateDeploymentStatusTick function to update Health/Sync status and reconciledState")
 			// ----------------------------------------------------------------------------
 
-			err = a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDeployment.Name, gitopsDeployment.Namespace, dbQueries)
+			updated, err := a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDeployment.Name, gitopsDeployment.Namespace, dbQueries)
+			Expect(updated).To(BeTrue())
 			Expect(err).To(BeNil())
 
 			// ----------------------------------------------------------------------------
@@ -1413,8 +1421,9 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			By("Call applicationEventRunner_handleUpdateDeploymentStatusTick function to update Health/Sync status of a deployment that doesn't exist.")
 			// ----------------------------------------------------------------------------
 
-			err = a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, a.eventResourceName, a.eventResourceNamespace, dbQueries)
+			updated, err := a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, a.eventResourceName, a.eventResourceNamespace, dbQueries)
 			Expect(err).To(BeNil())
+			Expect(updated).To(BeFalse())
 		})
 
 		It("Should not return error, if GitOpsDeployment doesn't exist in given namespace.", func() {
@@ -1473,8 +1482,9 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			// ----------------------------------------------------------------------------
 			By("Call applicationEventRunner_handleUpdateDeploymentStatusTick function to update Health/Sync status for a deployment which doesn'r exist in given namespace.")
 			// ----------------------------------------------------------------------------
-			err = a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDepl.Name, gitopsDepl.Namespace, dbQueries)
+			updated, err := a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDepl.Name, gitopsDepl.Namespace, dbQueries)
 			Expect(err).To(BeNil())
+			Expect(updated).To(BeFalse())
 
 			// ----------------------------------------------------------------------------
 			By("Deployment is already been deleted in previous step, now delete related db entries and clean resources.")
@@ -1534,8 +1544,9 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			By("Call applicationEventRunner_handleUpdateDeploymentStatusTick function to update Health/Sync status for deployment which is missing ApplicationState entries.")
 			// ----------------------------------------------------------------------------
 
-			err = a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDepl.Name, gitopsDepl.Namespace, dbQueries)
+			updated, err := a.applicationEventRunner_handleUpdateDeploymentStatusTick(ctx, gitopsDepl.Name, gitopsDepl.Namespace, dbQueries)
 			Expect(err).To(BeNil())
+			Expect(updated).To(BeFalse())
 
 			// ----------------------------------------------------------------------------
 			By("Retrieve latest version of GitOpsDeployment and check Health/Sync, it should not have any Health/Sync status.")

--- a/manifests/overlays/stonesoup-member-cluster/appstudio-controller-deployment-patch.yaml
+++ b/manifests/overlays/stonesoup-member-cluster/appstudio-controller-deployment-patch.yaml
@@ -12,6 +12,7 @@ spec:
         - --zap-time-encoding=rfc3339nano
         - --health-probe-bind-address=:8085
         - --metrics-bind-address=:8080
+        - --zap-log-level info        
         command:
         - appstudio-controller
         image: ${COMMON_IMAGE}

--- a/manifests/overlays/stonesoup-member-cluster/backend-deployment-patch.yaml
+++ b/manifests/overlays/stonesoup-member-cluster/backend-deployment-patch.yaml
@@ -33,6 +33,7 @@ spec:
         - --metrics-bind-address=:8080
         - --leader-elect
         - --zap-time-encoding=rfc3339nano
+        - --zap-log-level info
         command:
         - gitops-service-backend
         env:

--- a/manifests/overlays/stonesoup-member-cluster/cluster-agent-deployment-patch.yaml
+++ b/manifests/overlays/stonesoup-member-cluster/cluster-agent-deployment-patch.yaml
@@ -14,6 +14,7 @@ spec:
         - --metrics-bind-address=:8080
         - --leader-elect
         - --zap-time-encoding=rfc3339nano
+        - --zap-log-level info        
         command:
         - gitops-service-cluster-agent
         env:


### PR DESCRIPTION
#### Description:
- Disable logging of API Resource changes when the only thing that has changed is the GitOpsDeployment.status field: there's no audit purpose to us logging these.
- Disable logging of SnapshotEnvironmentBinding Reconciles when the resource has not changed after Reconcile.
- Switch Stonesoup cluster to run at INFO level (when we have a staging server, we can switch _it_ to run at DEBUG, and also look at reducing/customizing the verbosity of DEBUG)

#### Link to JIRA Story (if applicable): [GITOPSRVCE-463](https://issues.redhat.com/browse/GITOPSRVCE-463)

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
