### PR TITLE
Support for pprof profiling

### DIFF
--- a/appstudio-controller/main.go
+++ b/appstudio-controller/main.go
@@ -60,12 +60,15 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var apiExportName string
+	var profilerAddr string
 	flag.StringVar(&apiExportName, "api-export-name", "gitopsrvc-appstudio-shared", "The name of the APIExport.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8084", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8085", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&profilerAddr, "profiler-address", ":6062", "The address for serving pprof profiles")
+
 	opts := zap.Options{
 		Development: true,
 	}
@@ -73,6 +76,11 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	if sharedutil.IsProfilingEnabled() {
+		setupLog.Info("Starting pprof profiler server", "address", profilerAddr)
+		go sharedutil.StartProfilers(profilerAddr)
+	}
 
 	ctx := ctrl.SetupSignalHandler()
 

--- a/backend-shared/util/profiling.go
+++ b/backend-shared/util/profiling.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"log"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"strings"
+)
+
+const (
+	// ENABLE_PROFILING is set to True to start profilers.
+	enableProfilingEnv string = "ENABLE_PROFILING"
+)
+
+// IsProfilingEnabled checks if profiling is enabled.
+func IsProfilingEnabled() bool {
+	val, found := os.LookupEnv(enableProfilingEnv)
+	if !found {
+		return false
+	}
+
+	return strings.ToLower(val) == "true"
+}
+
+// StartProfilers starts a pprof profiling server at the given address.
+func StartProfilers(addr string) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	// #nosec G114
+	log.Fatal(http.ListenAndServe(addr, mux))
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -65,12 +65,14 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var apiExportName string
+	var profilerAddr string
 	flag.StringVar(&apiExportName, "api-export-name", "gitopsrvc-backend-shared", "The name of the APIExport.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":18080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":18081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&profilerAddr, "profiler-address", ":6060", "The address for serving pprof profiles")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -78,6 +80,11 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	if sharedutil.IsProfilingEnabled() {
+		setupLog.Info("Starting pprof profiler server", "address", profilerAddr)
+		go sharedutil.StartProfilers(profilerAddr)
+	}
 
 	ctx := ctrl.SetupSignalHandler()
 

--- a/cluster-agent/main.go
+++ b/cluster-agent/main.go
@@ -62,11 +62,13 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var profilerAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8082", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8083", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&profilerAddr, "profiler-address", ":6061", "The address for serving pprof profiles")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -74,6 +76,11 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	if sharedutil.IsProfilingEnabled() {
+		setupLog.Info("Starting pprof profiler server", "address", profilerAddr)
+		go sharedutil.StartProfilers(profilerAddr)
+	}
 
 	restConfig, err := sharedutil.GetRESTConfig()
 	if err != nil {

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,70 @@
+# Profiling
+
+[Profiling](https://go.dev/doc/diagnostics) is an important technique to diagnose logic and performance problems in a program. Profiling tools analyze the complexity and costs of a Go program such as its memory usage and frequently called functions to identify the expensive sections of a Go program.
+
+GitOps Service exposes the pprof endpoints via the [http/pprof](https://pkg.go.dev/net/http/pprof) package and can be enabled with `ENABLE_PROFILING=true` environment variable. The profiling data can then be used by pprof visualization tools for analyzing the performance issues. The pprof endpoints for GitOps service components are listed below:
+
+| Component                |    Endpoint                |
+|--------------------------|----------------------------|
+| Backend Controller       | localhost:6060/debug/pprof |
+| Cluster-Agent Controller | localhost:6061/debug/pprof |
+| AppStudio Controller     | localhost:6062/debug/pprof |
+
+## Profiling using `go tool pprof`
+
+Go provides in-built support for profiling via the go tool pprof command. You can see the full list of profiles at `localhost:<port>/debug/pprof`
+
+To analyze a particular profile:
+
+```shell
+go tool pprof http://localhost:<pprof>/debug/pprof/<profile>
+```
+
+For example, run the below command to investigate heap allocations of the backend controller
+
+```shell
+go tool pprof http://localhost:6060/debug/pprof/heap
+```
+
+## Continous Profiling using Parca
+
+[Parca](https://www.parca.dev/) is an Open Source continous profiling tool to analyze the profiles of services deployed on Kubernetes. Follow the below steps to use Parca with GitOps Service
+
+1. Create a `parca.yaml` to configure Parca to target GitOps Service pprof endpoints.  
+
+```yaml
+object_storage:
+  bucket:
+    type: "FILESYSTEM"
+    config:
+      directory: "./tmp"
+
+scrape_configs:
+  - job_name: "backend"
+    scrape_interval: "3s"
+    static_configs:
+      - targets: [ '127.0.0.1:6060' ]
+  - job_name: "cluster-agent"
+    scrape_interval: "3s"
+    static_configs:
+      - targets: [ '127.0.0.1:6061' ]
+  - job_name: "appstudio-controller"
+    scrape_interval: "3s"
+    static_configs:
+      - targets: [ '127.0.0.1:6062' ]
+
+```
+
+2. Run Parca in a container
+
+```shell
+docker run --rm -it --network="host" -v $HOME/managed-gitops/parca.yaml:/parca.yaml ghcr.io/parca-dev/parca:v0.16.2 /parca --config-path="parca.yaml"
+```
+
+3. Navigate to `http://localhost:7070/targets` and verify if all the targets are in "Good" health status.
+
+4. Select a profile from the dropdown menu to visualize the icicle graph.
+
+### Reference
+
+1. [Profiling HAS](https://docs.google.com/document/d/1LqLeDEhYXDK07lz_p582c1LRVwxwFCdqFLk1fh33Dn8/edit#heading=h.852ozrf8sxek)


### PR DESCRIPTION
#### Description:
- Add support for serving profiles for GitOps service controllers. The generated profiles could either be used by `go tool pprof` or a continuous profiling tool for debugging performance issues.

### How to test:

1. Start the controllers by enabling profiling
`ENABLE_PROFILING=true make start`

2. Go to locahost:6060/6061/6062 to verify the profiles

![Screenshot from 2023-03-17 13-54-59](https://user-images.githubusercontent.com/21128732/225853078-4a88839e-936d-43c3-b266-565e90f593e3.png)

#### Link to JIRA Story (if applicable):

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
