### PR TITLE
Malicious Git repositories as input to GitOpsDeployment (#150)

### DIFF
--- a/manifests/base/gitops-service-argocd/base/argo-cd.yaml
+++ b/manifests/base/gitops-service-argocd/base/argo-cd.yaml
@@ -144,6 +144,9 @@ spec:
         memory: 128Mi
   repo:
     logLevel: "debug"
+    extraRepoCommandArgs:
+      - --max-combined-directory-manifests-size
+      - 10M
     resources:
       limits:
         cpu: "1"


### PR DESCRIPTION
#### Description:
The only way this will work is if we move to the latest channel at this time, OR, the 1.8 release is promoted to the stable channel.  See screenshots in jira.

#### Link to JIRA Story (if applicable):

See https://issues.redhat.com/browse/GITOPSRVCE-150
