### PR TITLE
Remove unnecessary logging of SnapshotEnvBinding .status changes

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
@@ -229,10 +229,9 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 			return ctrl.Result{}, nil
 		}
 
-		log.Error(err, "unable to update gitopsdeployments status for Binding")
-		return ctrl.Result{}, fmt.Errorf("unable to update gitopsdeployments status for SnapshotEnvironmentBinding. Error: %w", err)
+		log.Error(err, "unable to update SnapshotEnvironmentBinding status")
+		return ctrl.Result{}, fmt.Errorf("unable to update SnapshotEnvironmentBinding status. Error: %w", err)
 	}
-	sharedutil.LogAPIResourceChangeEvent(binding.Namespace, binding.Name, binding, sharedutil.ResourceModified, log)
 
 	if allErrors != nil {
 		return ctrl.Result{RequeueAfter: time.Second * 10}, fmt.Errorf("unable to process expected GitOpsDeployment: %w", allErrors)


### PR DESCRIPTION
#### Description:
- In appstudio-controller on live cluster,  we're seeing SnapshotEnvironmentBinding controller logs about ~1 per second, related to updates to SnapshotEnvironmentBinding resource.
- However, in most cases, these logs are only updates to the `.status` field of the SnapshotEnvironmentBinding, for which there is little value in logging (e.g. for auditing purposes).
- We can thus remove that log statement for this case.

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
