### PR TITLE
Refactor backend GitOpsDeployManagedEnvironment status update code

### DIFF
--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_types.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_types.go
@@ -58,6 +58,23 @@ type GitOpsDeploymentManagedEnvironment struct {
 	Status GitOpsDeploymentManagedEnvironmentStatus `json:"status,omitempty"`
 }
 
+type ManagedEnvironmentConditionReason string
+
+const (
+	ConditionReasonSucceeded                        ManagedEnvironmentConditionReason = "Succeeded"
+	ConditionReasonKubeError                        ManagedEnvironmentConditionReason = "KubernetesError"
+	ConditionReasonDatabaseError                    ManagedEnvironmentConditionReason = "DatabaseError"
+	ConditionReasonInvalidSecretType                ManagedEnvironmentConditionReason = "InvalidSecretType"
+	ConditionReasonMissingKubeConfigField           ManagedEnvironmentConditionReason = "MissingKubeConfigField"
+	ConditionReasonUnableToCreateClient             ManagedEnvironmentConditionReason = "UnableToCreateClient"
+	ConditionReasonUnableToCreateClusterCredentials ManagedEnvironmentConditionReason = "UnableToCreateClusterCredentials"
+	ConditionReasonUnableToInstallServiceAccount    ManagedEnvironmentConditionReason = "UnableToInstallServiceAccount"
+	ConditionReasonUnableToLocateContext            ManagedEnvironmentConditionReason = "UnableToLocateContext"
+	ConditionReasonUnableToParseKubeconfigData      ManagedEnvironmentConditionReason = "UnableToParseKubeconfigData"
+	ConditionReasonUnableToRetrieveRestConfig       ManagedEnvironmentConditionReason = "UnableToRetrieveRestConfig"
+	ConditionReasonUnknownError                     ManagedEnvironmentConditionReason = "UnknownError"
+)
+
 //+kubebuilder:object:root=true
 
 // GitOpsDeploymentManagedEnvironmentList contains a list of GitOpsDeploymentManagedEnvironment

--- a/backend-shared/util/log.go
+++ b/backend-shared/util/log.go
@@ -42,7 +42,8 @@ func LogAPIResourceChangeEvent(resourceNamespace string, resourceName string, re
 	jsonRepresentation, err := json.Marshal(resource)
 
 	if err != nil {
-		fmt.Println("Log Marshal error :", err)
+		log.Error(err, "SEVERE: Unable to marshal log to JSON.")
+		return
 	}
 
 	log.Info(fmt.Sprintf("API Resource changed: %s", string(resourceChangeType)), "namespace",

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -109,12 +109,16 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleDeploym
 	}
 
 	if !isGitOpsDeploymentDeleted(gitopsDeployment) {
+		// Perform basic validation of GitOpsDeployment values
+
 		if gitopsDeployment.Spec.Source.Path == "" {
 			userError := managedgitopsv1alpha1.GitOpsDeploymentUserError_PathIsRequired
 			return signalledShutdown_false, nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewUserDevError(userError, err)
+
 		} else if gitopsDeployment.Spec.Source.Path == "/" {
 			userError := managedgitopsv1alpha1.GitOpsDeploymentUserError_InvalidPathSlash
 			return signalledShutdown_false, nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewUserDevError(userError, err)
+
 		}
 	}
 

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
@@ -22,35 +22,48 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerLog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
-	ConditionReasonSucceeded = "Succeeded"
-
-	ConditionReasonKubeError                        = "KubernetesError"
-	ConditionReasonDatabaseError                    = "DatabaseError"
-	ConditionReasonInvalidSecretType                = "InvalidSecretType"
-	ConditionReasonMissingKubeConfigField           = "MissingKubeConfigField"
-	ConditionReasonUnableToCreateClient             = "UnableToCreateClient"
-	ConditionReasonUnableToCreateClusterCredentials = "UnableToCreateClusterCredentials"
-	ConditionReasonUnableToInstallServiceAccount    = "UnableToInstallServiceAccount"
-	ConditionReasonUnableToLocateContext            = "UnableToLocateContext"
-	ConditionReasonUnableToParseKubeconfigData      = "UnableToParseKubeconfigData"
-	ConditionReasonUnableToRetrieveRestConfig       = "UnableToRetrieveRestConfig"
-	KubeconfigKey                                   = "kubeconfig"
+	KubeconfigKey = "kubeconfig"
 )
 
 func internalProcessMessage_ReconcileSharedManagedEnv(ctx context.Context, workspaceClient client.Client,
 	managedEnvironmentCRName string,
-	managedEnvironmentCRNamespace string, isWorkspaceTarget bool,
+	managedEnvironmentCRNamespace string,
+	isWorkspaceTarget bool,
 	workspaceNamespace corev1.Namespace,
 	k8sClientFactory SRLK8sClientFactory,
 	dbQueries db.DatabaseQueries,
 	log logr.Logger) (SharedResourceManagedEnvContainer, error) {
 
+	container, condition, err := internalProcessMessage_internalReconcileSharedManagedEnv(ctx, workspaceClient, managedEnvironmentCRName,
+		managedEnvironmentCRNamespace, isWorkspaceTarget, workspaceNamespace, k8sClientFactory, dbQueries, log)
+
+	if condition.reason != "" && condition.managedEnvCR.Name != "" {
+
+		// If a metav1.Condition{} needs to be set, set it here.
+		updateManagedEnvironmentConnectionStatus(ctx, condition.managedEnvCR, workspaceClient, condition, log)
+
+	}
+
+	return container, err
+
+}
+
+func internalProcessMessage_internalReconcileSharedManagedEnv(ctx context.Context, workspaceClient client.Client,
+	managedEnvironmentCRName string,
+	managedEnvironmentCRNamespace string,
+	isWorkspaceTarget bool,
+	workspaceNamespace corev1.Namespace,
+	k8sClientFactory SRLK8sClientFactory,
+	dbQueries db.DatabaseQueries,
+	log logr.Logger) (SharedResourceManagedEnvContainer, connectionInitializedCondition, error) {
+
 	gitopsEngineClient, err := k8sClientFactory.GetK8sClientForGitOpsEngineInstance(ctx, nil)
 	if err != nil {
-		return newSharedResourceManagedEnvContainer(), err
+		return newSharedResourceManagedEnvContainer(), createUnknownErrorEnvInitCondition(), err
 	}
 
 	// If the GitOpsDeployment's 'target' field has an empty environment field, indicating it is targetting the same
@@ -61,7 +74,7 @@ func internalProcessMessage_ReconcileSharedManagedEnv(ctx context.Context, works
 
 	clusterUser, isNewUser, err := internalGetOrCreateClusterUserByNamespaceUID(ctx, string(workspaceNamespace.UID), dbQueries, log)
 	if err != nil || clusterUser == nil {
-		return newSharedResourceManagedEnvContainer(),
+		return newSharedResourceManagedEnvContainer(), createUnknownErrorEnvInitCondition(),
 			fmt.Errorf("unable to retrieve cluster user in processMessage, '%s': %v", string(workspaceNamespace.UID), err)
 	}
 
@@ -70,10 +83,10 @@ func internalProcessMessage_ReconcileSharedManagedEnv(ctx context.Context, works
 		managedEnvironmentCRNamespace, workspaceClient, workspaceNamespace, k8sClientFactory, dbQueries, *clusterUser, log)
 
 	if err != nil {
-		return newSharedResourceManagedEnvContainer(), err
+		return newSharedResourceManagedEnvContainer(), createUnknownErrorEnvInitCondition(), err
 	}
 	if doesNotExist {
-		return newSharedResourceManagedEnvContainer(), nil
+		return newSharedResourceManagedEnvContainer(), createUnknownErrorEnvInitCondition(), nil
 	}
 
 	// After this point in the code, the API CR necessarily exists.
@@ -82,9 +95,11 @@ func internalProcessMessage_ReconcileSharedManagedEnv(ctx context.Context, works
 	// of managedEnvironmentNew
 	if err := deleteManagedEnvironmentDBByAPINameAndNamespace(ctx, workspaceClient, managedEnvironmentCRName, managedEnvironmentCRNamespace,
 		string(managedEnvironmentCR.UID), workspaceNamespace, k8sClientFactory, dbQueries, *clusterUser, log); err != nil {
-		updateManagedEnvironmentConnectionStatus(&managedEnvironmentCR, ctx, workspaceClient, metav1.ConditionUnknown, ConditionReasonDatabaseError, gitopserrors.UnknownError, log)
-		return SharedResourceManagedEnvContainer{}, fmt.Errorf("unable to delete old managed environments by API name and namespace '%s' in '%s': %w",
-			managedEnvironmentCRName, managedEnvironmentCRNamespace, err)
+
+		return SharedResourceManagedEnvContainer{},
+			createGenericDatabaseErrorEnvInitCondition(managedEnvironmentCR),
+			fmt.Errorf("unable to delete old managed environments by API name and namespace '%s' in '%s': %w",
+				managedEnvironmentCRName, managedEnvironmentCRNamespace, err)
 	}
 
 	apiCRToDBMapping := db.APICRToDatabaseMapping{
@@ -96,8 +111,10 @@ func internalProcessMessage_ReconcileSharedManagedEnv(ctx context.Context, works
 	if err := dbQueries.GetDatabaseMappingForAPICR(ctx, &apiCRToDBMapping); err != nil {
 
 		if !db.IsResultNotFoundError(err) {
-			updateManagedEnvironmentConnectionStatus(&managedEnvironmentCR, ctx, workspaceClient, metav1.ConditionUnknown, ConditionReasonDatabaseError, gitopserrors.UnknownError, log)
-			return newSharedResourceManagedEnvContainer(), fmt.Errorf("unable to retrieve managed environment APICRToDatabaseMapping for %s: %w", apiCRToDBMapping.APIResourceUID, err)
+
+			return newSharedResourceManagedEnvContainer(),
+				createGenericDatabaseErrorEnvInitCondition(managedEnvironmentCR),
+				fmt.Errorf("unable to retrieve managed environment APICRToDatabaseMapping for %s: %w", apiCRToDBMapping.APIResourceUID, err)
 		}
 
 		// A) If there exists no APICRToDatabaseMapping for this Managed Environment resource, then just create a new managed environment
@@ -111,16 +128,18 @@ func internalProcessMessage_ReconcileSharedManagedEnv(ctx context.Context, works
 	if err := dbQueries.GetManagedEnvironmentById(ctx, managedEnv); err != nil {
 
 		if !db.IsResultNotFoundError(err) {
-			updateManagedEnvironmentConnectionStatus(&managedEnvironmentCR, ctx, workspaceClient, metav1.ConditionUnknown, ConditionReasonDatabaseError, gitopserrors.UnknownError, log)
-			return newSharedResourceManagedEnvContainer(), fmt.Errorf("unable to retrieve managed environment '%s", managedEnv.Managedenvironment_id)
+			return newSharedResourceManagedEnvContainer(),
+				createGenericDatabaseErrorEnvInitCondition(managedEnvironmentCR),
+				fmt.Errorf("unable to retrieve managed environment '%s", managedEnv.Managedenvironment_id)
 		}
 
 		// B) The APICRToDBMapping exists, but the managed env doesn't, so delete the mapping, then create the
 		//    managed environment/mapping from scratch.
 		rowsDeleted, err := dbQueries.DeleteAPICRToDatabaseMapping(ctx, &apiCRToDBMapping)
 		if err != nil {
-			updateManagedEnvironmentConnectionStatus(&managedEnvironmentCR, ctx, workspaceClient, metav1.ConditionUnknown, ConditionReasonDatabaseError, gitopserrors.UnknownError, log)
-			return newSharedResourceManagedEnvContainer(), fmt.Errorf("unable to delete APICRToDatabaseMapping for '%s'", apiCRToDBMapping.APIResourceUID)
+			return newSharedResourceManagedEnvContainer(),
+				createGenericDatabaseErrorEnvInitCondition(managedEnvironmentCR),
+				fmt.Errorf("unable to delete APICRToDatabaseMapping for '%s'", apiCRToDBMapping.APIResourceUID)
 		}
 		if rowsDeleted != 1 {
 			// Warn, but continue.
@@ -136,15 +155,17 @@ func internalProcessMessage_ReconcileSharedManagedEnv(ctx context.Context, works
 	if err := dbQueries.GetClusterCredentialsById(ctx, clusterCreds); err != nil {
 
 		if !db.IsResultNotFoundError(err) {
-			updateManagedEnvironmentConnectionStatus(&managedEnvironmentCR, ctx, workspaceClient, metav1.ConditionUnknown, ConditionReasonDatabaseError, gitopserrors.UnknownError, log)
-			return newSharedResourceManagedEnvContainer(), fmt.Errorf("unable to retrieve cluster credentials for '%s': %w", clusterCreds.Clustercredentials_cred_id, err)
+			return newSharedResourceManagedEnvContainer(),
+				createGenericDatabaseErrorEnvInitCondition(managedEnvironmentCR),
+				fmt.Errorf("unable to retrieve cluster credentials for '%s': %w", clusterCreds.Clustercredentials_cred_id, err)
 		}
 
 		// Sanity test:
 		// Cluster credentials referenced by managed environment doesn't exist.
 		// However, this really shouldn't be possible, since there is a foreign key from managed environment to cluster credentials.
-		updateManagedEnvironmentConnectionStatus(&managedEnvironmentCR, ctx, workspaceClient, metav1.ConditionUnknown, ConditionReasonDatabaseError, gitopserrors.UnknownError, log)
-		return newSharedResourceManagedEnvContainer(), fmt.Errorf("SEVERE: managed environment referenced cluster credentials value which doens't exist: %w", err)
+		return newSharedResourceManagedEnvContainer(),
+			createGenericDatabaseErrorEnvInitCondition(managedEnvironmentCR),
+			fmt.Errorf("SEVERE: managed environment referenced cluster credentials value which doesn't exist: %w", err)
 
 	}
 
@@ -173,12 +194,10 @@ func internalProcessMessage_ReconcileSharedManagedEnv(ctx context.Context, works
 		*managedEnv, workspaceNamespace, *clusterUser, gitopsEngineClient, dbQueries, log)
 
 	if uerr != nil {
-		updateManagedEnvironmentConnectionStatus(&managedEnvironmentCR, ctx, workspaceClient, metav1.ConditionUnknown, uerr.ConditionReason(), uerr.UserError(), log)
-		return newSharedResourceManagedEnvContainer(), fmt.Errorf("unable to wrap managed environment, on existing managed env, for %s: %w", apiCRToDBMapping.APIResourceUID, uerr.DevError())
+		return newSharedResourceManagedEnvContainer(),
+			convertConditionErrorToConnInitCondition(uerr, managedEnvironmentCR),
+			fmt.Errorf("unable to wrap managed environment, on existing managed env, for %s: %w", apiCRToDBMapping.APIResourceUID, uerr.DevError())
 	}
-
-	// Ensure the managed environment CR has a connection status of "Succeeded"
-	updateManagedEnvironmentConnectionStatus(&managedEnvironmentCR, ctx, workspaceClient, metav1.ConditionTrue, ConditionReasonSucceeded, "", log)
 
 	res := SharedResourceManagedEnvContainer{
 		ClusterUser:          clusterUser,
@@ -192,34 +211,8 @@ func internalProcessMessage_ReconcileSharedManagedEnv(ctx context.Context, works
 		GitopsEngineCluster:  engineCluster,
 	}
 
-	return res, nil
-}
-
-// Updates the given managed environment's connection status condition to match the given status, reason and message.
-// If there is an existing status condition with the exact same status, reason and message, no update is made in order
-// to preserve the LastTransitionTime (see https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition.LastTransitionTime )
-func updateManagedEnvironmentConnectionStatus(managedEnvironment *managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment, ctx context.Context, client client.Client, status metav1.ConditionStatus, reason string, message string, log logr.Logger) {
-	const conditionType = managedgitopsv1alpha1.ManagedEnvironmentStatusConnectionInitializationSucceeded
-	var condition *metav1.Condition = nil
-	for i := range managedEnvironment.Status.Conditions {
-		if managedEnvironment.Status.Conditions[i].Type == conditionType {
-			condition = &managedEnvironment.Status.Conditions[i]
-			break
-		}
-	}
-	if condition == nil {
-		managedEnvironment.Status.Conditions = append(managedEnvironment.Status.Conditions, metav1.Condition{Type: conditionType})
-		condition = &managedEnvironment.Status.Conditions[len(managedEnvironment.Status.Conditions)-1]
-	}
-	if condition.Reason != reason || condition.Message != message || condition.Status != status {
-		condition.Reason = reason
-		condition.Message = message
-		condition.LastTransitionTime = metav1.Now()
-		condition.Status = status
-		if err := client.Status().Update(ctx, managedEnvironment); err != nil {
-			log.Error(err, "updating managed environment status condition")
-		}
-	}
+	// Ensure the managed environment CR has a connection status of "Succeeded"
+	return res, createSuccessEnvInitCondition(managedEnvironmentCR), nil
 }
 
 // getManagedEnvironmentCRs retrieves the Managed Environment and Secret CRs.
@@ -360,14 +353,14 @@ func replaceExistingManagedEnv(ctx context.Context,
 	workspaceNamespace corev1.Namespace,
 	k8sClientFactory SRLK8sClientFactory,
 	dbQueries db.DatabaseQueries,
-	log logr.Logger) (SharedResourceManagedEnvContainer, error) {
+	log logr.Logger) (SharedResourceManagedEnvContainer, connectionInitializedCondition, error) {
 
 	oldClusterCredentialsPrimaryKey := managedEnvironmentDB.Clustercredentials_id
 
 	// 1) Create new cluster creds, based on secret
-	clusterCredentials, err := createNewClusterCredentials(ctx, managedEnvironmentCR, secret, k8sClientFactory, dbQueries, log, workspaceClient)
+	clusterCredentials, connInitCondition, err := createNewClusterCredentials(ctx, managedEnvironmentCR, secret, k8sClientFactory, dbQueries, log, workspaceClient)
 	if err != nil {
-		return SharedResourceManagedEnvContainer{},
+		return SharedResourceManagedEnvContainer{}, connInitCondition,
 			fmt.Errorf("unable to create new cluster credentials for managed env, while replacing existing managed env: %v", err)
 	}
 
@@ -377,8 +370,9 @@ func replaceExistingManagedEnv(ctx context.Context,
 	if err := dbQueries.UpdateManagedEnvironment(ctx, &managedEnvironmentDB); err != nil {
 		log.Error(err, "Unable to update ManagedEnvironment with new cluster credentials ID", managedEnvironmentDB.GetAsLogKeyValues()...)
 
-		updateManagedEnvironmentConnectionStatus(&managedEnvironmentCR, ctx, workspaceClient, metav1.ConditionUnknown, ConditionReasonDatabaseError, gitopserrors.UnknownError, log)
-		return SharedResourceManagedEnvContainer{}, fmt.Errorf("unable to update managed environment with new credentials: %w", err)
+		return SharedResourceManagedEnvContainer{},
+			createGenericDatabaseErrorEnvInitCondition(managedEnvironmentCR),
+			fmt.Errorf("unable to update managed environment with new credentials: %w", err)
 	}
 	log.Info("Updated ManagedEnvironment with new cluster credentials ID", managedEnvironmentDB.GetAsLogKeyValues()...)
 
@@ -386,14 +380,15 @@ func replaceExistingManagedEnv(ctx context.Context,
 	rowsDeleted, err := dbQueries.DeleteClusterCredentialsById(ctx, oldClusterCredentialsPrimaryKey)
 	if err != nil {
 		log.Error(err, "Unable to delete old ClusterCredentials row which is no longer used by ManagedEnv", "clusterCredentials", oldClusterCredentialsPrimaryKey)
-		updateManagedEnvironmentConnectionStatus(&managedEnvironmentCR, ctx, workspaceClient, metav1.ConditionUnknown, ConditionReasonDatabaseError, gitopserrors.UnknownError, log)
-		return SharedResourceManagedEnvContainer{}, fmt.Errorf("unable to delete old cluster credentials '%s': %w", oldClusterCredentialsPrimaryKey, err)
+
+		return SharedResourceManagedEnvContainer{},
+			createGenericDatabaseErrorEnvInitCondition(managedEnvironmentCR),
+			fmt.Errorf("unable to delete old cluster credentials '%s': %w", oldClusterCredentialsPrimaryKey, err)
 	}
 	if rowsDeleted != 1 {
 		log.V(sharedutil.LogLevel_Warn).Info("unexpected number of rows deleted when deleting cluster credentials",
 			"clusterCredentialsID", oldClusterCredentialsPrimaryKey)
-		updateManagedEnvironmentConnectionStatus(&managedEnvironmentCR, ctx, workspaceClient, metav1.ConditionUnknown, ConditionReasonDatabaseError, gitopserrors.UnknownError, log)
-		return SharedResourceManagedEnvContainer{}, nil
+		return SharedResourceManagedEnvContainer{}, createGenericDatabaseErrorEnvInitCondition(managedEnvironmentCR), nil
 	}
 	log.Info("Deleted old ClusterCredentials row which is no longer used by ManagedEnv", "clusterCredentials", oldClusterCredentialsPrimaryKey)
 
@@ -403,8 +398,9 @@ func replaceExistingManagedEnv(ctx context.Context,
 		managedEnvironmentDB, workspaceNamespace, clusterUser, gitopsEngineClient, dbQueries, log)
 
 	if uerr != nil {
-		updateManagedEnvironmentConnectionStatus(&managedEnvironmentCR, ctx, workspaceClient, metav1.ConditionUnknown, uerr.ConditionReason(), uerr.UserError(), log)
-		return newSharedResourceManagedEnvContainer(), fmt.Errorf("unable to wrap managed environment for %s: %w", managedEnvironmentCR.UID, uerr.DevError())
+		return newSharedResourceManagedEnvContainer(),
+			convertConditionErrorToConnInitCondition(uerr, managedEnvironmentCR),
+			fmt.Errorf("unable to wrap managed environment for %s: %w", managedEnvironmentCR.UID, uerr.DevError())
 	}
 
 	res := SharedResourceManagedEnvContainer{
@@ -419,7 +415,7 @@ func replaceExistingManagedEnv(ctx context.Context,
 		GitopsEngineCluster:  engineCluster,
 	}
 
-	return res, nil
+	return res, createSuccessEnvInitCondition(managedEnvironmentCR), nil
 }
 
 // constructNewManagedEnv creates a new ManagedEnvironment using the provided parameters, then creates ClusterAccess/GitOpsEngineInstance,
@@ -427,17 +423,18 @@ func replaceExistingManagedEnv(ctx context.Context,
 func constructNewManagedEnv(ctx context.Context,
 	gitopsEngineClient client.Client,
 	workspaceClient client.Client,
-	clusterUser db.ClusterUser, isNewUser bool,
+	clusterUser db.ClusterUser,
+	isNewUser bool,
 	managedEnvironment managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment,
 	secret corev1.Secret,
 	workspaceNamespace corev1.Namespace,
 	k8sClientFactory SRLK8sClientFactory,
 	dbQueries db.DatabaseQueries,
-	log logr.Logger) (SharedResourceManagedEnvContainer, error) {
+	log logr.Logger) (SharedResourceManagedEnvContainer, connectionInitializedCondition, error) {
 
-	managedEnvDB, err := createNewManagedEnv(ctx, managedEnvironment, secret, clusterUser, workspaceNamespace, k8sClientFactory, dbQueries, log, workspaceClient)
+	managedEnvDB, connInitErr, err := createNewManagedEnv(ctx, managedEnvironment, secret, clusterUser, workspaceNamespace, k8sClientFactory, dbQueries, log, workspaceClient)
 	if err != nil {
-		return newSharedResourceManagedEnvContainer(),
+		return newSharedResourceManagedEnvContainer(), connInitErr,
 			fmt.Errorf("unable to create managed environment for %s: %w", managedEnvironment.UID, err)
 	}
 
@@ -446,8 +443,9 @@ func constructNewManagedEnv(ctx context.Context,
 		*managedEnvDB, workspaceNamespace, clusterUser, gitopsEngineClient, dbQueries, log)
 
 	if uerr != nil {
-		updateManagedEnvironmentConnectionStatus(&managedEnvironment, ctx, workspaceClient, metav1.ConditionUnknown, uerr.ConditionReason(), uerr.UserError(), log)
-		return newSharedResourceManagedEnvContainer(), fmt.Errorf("unable to wrap managed environment for %s: %w", managedEnvironment.UID, uerr.DevError())
+		return newSharedResourceManagedEnvContainer(),
+			convertConditionErrorToConnInitCondition(uerr, managedEnvironment),
+			fmt.Errorf("unable to wrap managed environment for %s: %w", managedEnvironment.UID, uerr.DevError())
 	}
 
 	res := SharedResourceManagedEnvContainer{
@@ -462,7 +460,7 @@ func constructNewManagedEnv(ctx context.Context,
 		GitopsEngineCluster:  engineCluster,
 	}
 
-	return res, nil
+	return res, createSuccessEnvInitCondition(managedEnvironment), nil
 }
 
 // wrapManagedEnv creates (or gets) a GitOpsEngineInstance, GitOpsEngineCluster, and ClusterAccess, for the provided 'managedEnv' param
@@ -489,7 +487,7 @@ func wrapManagedEnv(ctx context.Context, managedEnv db.ManagedEnvironment, works
 	if err1 != nil {
 		log.Error(err1, "unable to create cluster access")
 		msg := gitopserrors.UnknownError
-		return nil, false, nil, false, nil, gitopserrors.NewUserConditionError(msg, err1, ConditionReasonDatabaseError)
+		return nil, false, nil, false, nil, gitopserrors.NewUserConditionError(msg, err1, string(managedgitopsv1alpha1.ConditionReasonDatabaseError))
 	}
 
 	return engineInstance,
@@ -503,11 +501,13 @@ func wrapManagedEnv(ctx context.Context, managedEnv db.ManagedEnvironment, works
 
 func createNewManagedEnv(ctx context.Context, managedEnvironment managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment,
 	secret corev1.Secret, clusterUser db.ClusterUser, workspaceNamespace corev1.Namespace,
-	k8sClientFactory SRLK8sClientFactory, dbQueries db.DatabaseQueries, log logr.Logger, workspaceClient client.Client) (*db.ManagedEnvironment, error) {
+	k8sClientFactory SRLK8sClientFactory, dbQueries db.DatabaseQueries, log logr.Logger,
+	workspaceClient client.Client) (*db.ManagedEnvironment, connectionInitializedCondition, error) {
 
-	clusterCredentials, err := createNewClusterCredentials(ctx, managedEnvironment, secret, k8sClientFactory, dbQueries, log, workspaceClient)
+	clusterCredentials, connInitCondition, err := createNewClusterCredentials(ctx, managedEnvironment, secret, k8sClientFactory, dbQueries, log, workspaceClient)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create new cluster credentials for managed env, while creating new managed env: %v", err)
+		return nil, connInitCondition,
+			fmt.Errorf("unable to create new cluster credentials for managed env, while creating new managed env: %v", err)
 	}
 
 	managedEnv := &db.ManagedEnvironment{
@@ -517,8 +517,8 @@ func createNewManagedEnv(ctx context.Context, managedEnvironment managedgitopsv1
 
 	if err := dbQueries.CreateManagedEnvironment(ctx, managedEnv); err != nil {
 		log.Error(err, "Unable to create new ManagedEnvironment", managedEnv.GetAsLogKeyValues()...)
-		updateManagedEnvironmentConnectionStatus(&managedEnvironment, ctx, workspaceClient, metav1.ConditionUnknown, ConditionReasonDatabaseError, gitopserrors.UnknownError, log)
-		return nil, fmt.Errorf("unable to create managed environment for env obj '%s': %w", managedEnvironment.UID, err)
+		return nil, createGenericDatabaseErrorEnvInitCondition(managedEnvironment),
+			fmt.Errorf("unable to create managed environment for env obj '%s': %w", managedEnvironment.UID, err)
 	}
 	log.Info("Created new ManagedEnvironment", managedEnv.GetAsLogKeyValues()...)
 
@@ -533,13 +533,12 @@ func createNewManagedEnv(ctx context.Context, managedEnvironment managedgitopsv1
 	}
 	if err := dbQueries.CreateAPICRToDatabaseMapping(ctx, apiCRToDBMapping); err != nil {
 		log.Error(err, "Unable to create new APICRToDatabaseMapping", apiCRToDBMapping.GetAsLogKeyValues()...)
-		updateManagedEnvironmentConnectionStatus(&managedEnvironment, ctx, workspaceClient, metav1.ConditionUnknown, ConditionReasonDatabaseError, gitopserrors.UnknownError, log)
-		err2 := fmt.Errorf("unable to create APICRToDatabaseMapping for managed environment: %w", err)
-		return nil, err2
+		err := fmt.Errorf("unable to create APICRToDatabaseMapping for managed environment: %w", err)
+		return nil, createGenericDatabaseErrorEnvInitCondition(managedEnvironment), err
 	}
 	log.Info("Created new APICRToDatabaseMapping", apiCRToDBMapping.GetAsLogKeyValues()...)
 
-	return managedEnv, nil
+	return managedEnv, createSuccessEnvInitCondition(managedEnvironment), err
 }
 
 func DeleteManagedEnvironmentResources(ctx context.Context, managedEnvID string, managedEnvCR *db.ManagedEnvironment, user db.ClusterUser,
@@ -716,56 +715,70 @@ func (DefaultK8sClientFactory) BuildK8sClient(restConfig *rest.Config) (client.C
 }
 
 func createNewClusterCredentials(ctx context.Context, managedEnvironment managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment,
-	secret corev1.Secret, k8sClientFactory SRLK8sClientFactory, dbQueries db.DatabaseQueries, log logr.Logger, workspaceClient client.Client) (db.ClusterCredentials, error) {
+	secret corev1.Secret, k8sClientFactory SRLK8sClientFactory, dbQueries db.DatabaseQueries, log logr.Logger,
+	workspaceClient client.Client) (db.ClusterCredentials, connectionInitializedCondition, error) {
 
 	if secret.Type != sharedutil.ManagedEnvironmentSecretType {
 		err := fmt.Errorf("invalid secret type: %s", secret.Type)
-		updateManagedEnvironmentConnectionStatus(&managedEnvironment, ctx, workspaceClient, metav1.ConditionFalse, ConditionReasonInvalidSecretType, err.Error(), log)
-		return db.ClusterCredentials{}, err
+		return db.ClusterCredentials{},
+			convertErrToEnvInitCondition(managedgitopsv1alpha1.ConditionReasonInvalidSecretType, err, managedEnvironment),
+			err
 	}
 
 	kubeconfig, exists := secret.Data[KubeconfigKey]
 	if !exists {
 		err := fmt.Errorf("missing %s field in Secret", KubeconfigKey)
-		updateManagedEnvironmentConnectionStatus(&managedEnvironment, ctx, workspaceClient, metav1.ConditionFalse, ConditionReasonMissingKubeConfigField, err.Error(), log)
-		return db.ClusterCredentials{}, err
+
+		return db.ClusterCredentials{},
+			convertErrToEnvInitCondition(managedgitopsv1alpha1.ConditionReasonMissingKubeConfigField, err, managedEnvironment),
+			err
 	}
 
 	// Load the kubeconfig from the field
 	config, err := clientcmd.Load(kubeconfig)
 	if err != nil {
-		err2 := fmt.Errorf("unable to parse kubeconfig data: %w", err)
-		updateManagedEnvironmentConnectionStatus(&managedEnvironment, ctx, workspaceClient, metav1.ConditionFalse, ConditionReasonUnableToParseKubeconfigData, err2.Error(), log)
-		return db.ClusterCredentials{}, err2
+		err := fmt.Errorf("unable to parse kubeconfig data: %w", err)
+
+		return db.ClusterCredentials{},
+			convertErrToEnvInitCondition(managedgitopsv1alpha1.ConditionReasonUnableToParseKubeconfigData, err, managedEnvironment),
+			err
+
 	}
 
 	matchingContextName, err := locateContextThatMatchesAPIURL(config, managedEnvironment.Spec.APIURL)
 	if err != nil {
-		updateManagedEnvironmentConnectionStatus(&managedEnvironment, ctx, workspaceClient, metav1.ConditionFalse, ConditionReasonUnableToLocateContext, err.Error(), log)
-		return db.ClusterCredentials{}, err
+		return db.ClusterCredentials{},
+			convertErrToEnvInitCondition(managedgitopsv1alpha1.ConditionReasonUnableToLocateContext, err, managedEnvironment),
+			err
 	}
 
 	clientConfig := clientcmd.NewNonInteractiveClientConfig(*config, matchingContextName, &clientcmd.ConfigOverrides{}, nil)
 
 	restConfig, err := clientConfig.ClientConfig()
 	if err != nil {
-		err2 := fmt.Errorf("unable to retrive restConfig from managed environment secret: %w", err)
-		updateManagedEnvironmentConnectionStatus(&managedEnvironment, ctx, workspaceClient, metav1.ConditionFalse, ConditionReasonUnableToRetrieveRestConfig, err2.Error(), log)
-		return db.ClusterCredentials{}, err2
+		err := fmt.Errorf("unable to retrive restConfig from managed environment secret: %w", err)
+
+		return db.ClusterCredentials{},
+			convertErrToEnvInitCondition(managedgitopsv1alpha1.ConditionReasonUnableToRetrieveRestConfig, err, managedEnvironment),
+			err
 	}
 
 	k8sClient, err := k8sClientFactory.BuildK8sClient(restConfig)
 	if err != nil {
-		err2 := fmt.Errorf("unable to create k8s client from restConfig from managed environment secret: %w", err)
-		updateManagedEnvironmentConnectionStatus(&managedEnvironment, ctx, workspaceClient, metav1.ConditionFalse, ConditionReasonUnableToCreateClient, err2.Error(), log)
-		return db.ClusterCredentials{}, err2
+		err := fmt.Errorf("unable to create k8s client from restConfig from managed environment secret: %w", err)
+
+		return db.ClusterCredentials{},
+			convertErrToEnvInitCondition(managedgitopsv1alpha1.ConditionReasonUnableToCreateClient, err, managedEnvironment),
+			err
 	}
 
 	bearerToken, _, err := sharedutil.InstallServiceAccount(ctx, k8sClient, string(managedEnvironment.UID), serviceAccountNamespaceKubeSystem, log)
 	if err != nil {
-		err2 := fmt.Errorf("unable to install service account from secret '%s': %w", secret.Name, err)
-		updateManagedEnvironmentConnectionStatus(&managedEnvironment, ctx, workspaceClient, metav1.ConditionFalse, ConditionReasonUnableToInstallServiceAccount, err2.Error(), log)
-		return db.ClusterCredentials{}, err2
+		err := fmt.Errorf("unable to install service account from secret '%s': %w", secret.Name, err)
+
+		return db.ClusterCredentials{},
+			convertErrToEnvInitCondition(managedgitopsv1alpha1.ConditionReasonUnableToInstallServiceAccount, err, managedEnvironment),
+			err
 	}
 
 	insecureVerifyTLS := managedEnvironment.Spec.AllowInsecureSkipTLSVerify
@@ -781,13 +794,15 @@ func createNewClusterCredentials(ctx context.Context, managedEnvironment managed
 
 	if err := dbQueries.CreateClusterCredentials(ctx, &clusterCredentials); err != nil {
 		log.Error(err, "Unable to create ClusterCredentials for ManagedEnvironment", clusterCredentials.GetAsLogKeyValues()...)
-		updateManagedEnvironmentConnectionStatus(&managedEnvironment, ctx, workspaceClient, metav1.ConditionFalse, ConditionReasonUnableToCreateClusterCredentials, gitopserrors.UnknownError, log)
-		return db.ClusterCredentials{}, fmt.Errorf("unable to create cluster credentials for host '%s': %w", clusterCredentials.Host, err)
+
+		return db.ClusterCredentials{},
+			createUnknownInitConditionWithManagedEnv(managedEnvironment),
+			fmt.Errorf("unable to create cluster credentials for host '%s': %w", clusterCredentials.Host, err)
+
 	}
 	log.Info("Created ClusterCredentials for ManagedEnvironment", clusterCredentials.GetAsLogKeyValues()...)
 
-	updateManagedEnvironmentConnectionStatus(&managedEnvironment, ctx, workspaceClient, metav1.ConditionTrue, ConditionReasonSucceeded, "", log)
-	return clusterCredentials, nil
+	return clusterCredentials, createSuccessEnvInitCondition(managedEnvironment), nil
 
 }
 
@@ -867,4 +882,122 @@ func verifyClusterCredentials(ctx context.Context, clusterCreds db.ClusterCreden
 
 	// Success!
 	return true, nil
+}
+
+// connectionInitializedCondition is returned by functions in this file, to indicate that a Condition should be set in the
+// .status.conditions field of the ManagedEnvironment CR, of type ManagedEnvironmentStatusConnectionInitializationSucceeded.
+type connectionInitializedCondition struct {
+	// managedEnvCR is the API Resource we need to update the condition on
+	managedEnvCR managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment
+
+	// type is ManagedEnvironmentStatusConnectionInitializationSucceeded
+	status  metav1.ConditionStatus
+	reason  managedgitopsv1alpha1.ManagedEnvironmentConditionReason
+	message string
+}
+
+func convertErrToEnvInitCondition(reason managedgitopsv1alpha1.ManagedEnvironmentConditionReason, err error, managedEnvironment managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment) connectionInitializedCondition {
+
+	errMsg := gitopserrors.UnknownError
+
+	if err != nil {
+		errMsg = err.Error()
+	}
+
+	return connectionInitializedCondition{
+		managedEnvCR: managedEnvironment,
+		status:       metav1.ConditionFalse,
+		reason:       reason,
+		message:      errMsg,
+	}
+
+}
+
+func convertConditionErrorToConnInitCondition(conditionError gitopserrors.ConditionError, managedEnvironmentCR managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment) connectionInitializedCondition {
+
+	msg := gitopserrors.UnknownError
+	reason := managedgitopsv1alpha1.ConditionReasonUnknownError
+	if conditionError != nil {
+		msg = conditionError.UserError()
+		reason = managedgitopsv1alpha1.ManagedEnvironmentConditionReason(conditionError.ConditionReason())
+	} else {
+		// This shouldn't happen under any circumstances, so sanity test and log as severe
+		controllerLog.FromContext(context.Background()).Error(nil, "SEVERE: nil error passed to convertConditionErrorToConnInitCondition")
+	}
+
+	return connectionInitializedCondition{
+		managedEnvCR: managedEnvironmentCR,
+		status:       metav1.ConditionFalse,
+		reason:       reason,
+		message:      msg,
+	}
+}
+
+func createSuccessEnvInitCondition(managedEnvironmentCR managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment) connectionInitializedCondition {
+
+	return connectionInitializedCondition{
+		managedEnvCR: managedEnvironmentCR,
+		status:       metav1.ConditionTrue,
+		reason:       managedgitopsv1alpha1.ConditionReasonSucceeded,
+		message:      "",
+	}
+}
+
+func createGenericDatabaseErrorEnvInitCondition(managedEnvironmentCR managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment) connectionInitializedCondition {
+	return connectionInitializedCondition{
+		managedEnvCR: managedEnvironmentCR,
+		status:       metav1.ConditionUnknown,
+		reason:       managedgitopsv1alpha1.ConditionReasonDatabaseError,
+		message:      gitopserrors.UnknownError,
+	}
+}
+
+func createUnknownErrorEnvInitCondition() connectionInitializedCondition {
+	return connectionInitializedCondition{
+		managedEnvCR: managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment{},
+		status:       metav1.ConditionUnknown,
+		reason:       managedgitopsv1alpha1.ConditionReasonUnknownError,
+		message:      gitopserrors.UnknownError,
+	}
+}
+
+func createUnknownInitConditionWithManagedEnv(managedEnv managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment) connectionInitializedCondition {
+	return connectionInitializedCondition{
+		managedEnvCR: managedEnv,
+		status:       metav1.ConditionUnknown,
+		reason:       managedgitopsv1alpha1.ConditionReasonUnknownError,
+		message:      gitopserrors.UnknownError,
+	}
+}
+
+// Updates the given managed environment's connection status condition to match the given status, reason and message.
+// If there is an existing status condition with the exact same status, reason and message, no update is made in order
+// to preserve the LastTransitionTime (see https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition.LastTransitionTime )
+func updateManagedEnvironmentConnectionStatus(ctx context.Context,
+	managedEnvironment managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment,
+	client client.Client, connInitCondition connectionInitializedCondition, log logr.Logger) {
+
+	const conditionType = managedgitopsv1alpha1.ManagedEnvironmentStatusConnectionInitializationSucceeded
+	var condition *metav1.Condition = nil
+	for i := range managedEnvironment.Status.Conditions {
+		if managedEnvironment.Status.Conditions[i].Type == conditionType {
+			condition = &managedEnvironment.Status.Conditions[i]
+			break
+		}
+	}
+	if condition == nil {
+		managedEnvironment.Status.Conditions = append(managedEnvironment.Status.Conditions, metav1.Condition{Type: conditionType})
+		condition = &managedEnvironment.Status.Conditions[len(managedEnvironment.Status.Conditions)-1]
+	}
+	if condition.Reason != string(connInitCondition.reason) || condition.Message != connInitCondition.message ||
+		condition.Status != connInitCondition.status {
+
+		condition.Reason = string(connInitCondition.reason)
+		condition.Message = connInitCondition.message
+		condition.LastTransitionTime = metav1.Now()
+		condition.Status = connInitCondition.status
+		if err := client.Status().Update(ctx, &managedEnvironment); err != nil {
+			log.Error(err, "updating managed environment status condition")
+		}
+	}
 }

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
@@ -795,9 +795,12 @@ func createNewClusterCredentials(ctx context.Context, managedEnvironment managed
 	if err := dbQueries.CreateClusterCredentials(ctx, &clusterCredentials); err != nil {
 		log.Error(err, "Unable to create ClusterCredentials for ManagedEnvironment", clusterCredentials.GetAsLogKeyValues()...)
 
-		return db.ClusterCredentials{},
-			createUnknownInitConditionWithManagedEnv(managedEnvironment),
-			fmt.Errorf("unable to create cluster credentials for host '%s': %w", clusterCredentials.Host, err)
+		return db.ClusterCredentials{}, connectionInitializedCondition{
+			managedEnvCR: managedEnvironment,
+			status:       metav1.ConditionUnknown,
+			reason:       managedgitopsv1alpha1.ConditionReasonUnableToCreateClusterCredentials,
+			message:      gitopserrors.UnknownError,
+		}, fmt.Errorf("unable to create cluster credentials for host '%s': %w", clusterCredentials.Host, err)
 
 	}
 	log.Info("Created ClusterCredentials for ManagedEnvironment", clusterCredentials.GetAsLogKeyValues()...)

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
@@ -964,15 +964,6 @@ func createUnknownErrorEnvInitCondition() connectionInitializedCondition {
 	}
 }
 
-func createUnknownInitConditionWithManagedEnv(managedEnv managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment) connectionInitializedCondition {
-	return connectionInitializedCondition{
-		managedEnvCR: managedEnv,
-		status:       metav1.ConditionUnknown,
-		reason:       managedgitopsv1alpha1.ConditionReasonUnknownError,
-		message:      gitopserrors.UnknownError,
-	}
-}
-
 // Updates the given managed environment's connection status condition to match the given status, reason and message.
 // If there is an existing status condition with the exact same status, reason and message, no update is made in order
 // to preserve the LastTransitionTime (see https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition.LastTransitionTime )

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv_test.go
@@ -66,7 +66,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 				fakeClient: k8sClient,
 			}
 
-			dbQueries, err = db.NewUnsafePostgresDBQueries(true, true)
+			dbQueries, err = db.NewUnsafePostgresDBQueries(false, true)
 			Expect(err).To(BeNil())
 
 		})
@@ -290,7 +290,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			Expect(len(managedEnv.Status.Conditions)).To(Equal(1))
 			Expect(managedEnv.Status.Conditions[0].Type).To(Equal(managedgitopsv1alpha1.ManagedEnvironmentStatusConnectionInitializationSucceeded))
 			Expect(managedEnv.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(ConditionReasonSucceeded))
+			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(string(managedgitopsv1alpha1.ConditionReasonSucceeded)))
 
 			By("ensuring the LastTransitionTime is not updated if nothing has changed")
 			lastTransitionTime := managedEnv.Status.Conditions[0].LastTransitionTime
@@ -304,7 +304,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			Expect(managedEnv.Status.Conditions[0].LastTransitionTime).To(Equal(lastTransitionTime))
 			Expect(managedEnv.Status.Conditions[0].Type).To(Equal(managedgitopsv1alpha1.ManagedEnvironmentStatusConnectionInitializationSucceeded))
 			Expect(managedEnv.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(ConditionReasonSucceeded))
+			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(string(managedgitopsv1alpha1.ConditionReasonSucceeded)))
 		})
 
 		It("should ensure the condition ConnectionInitializationSucceeded status is True when reconciling and nothing changed", func() {
@@ -331,7 +331,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			Expect(len(managedEnv.Status.Conditions)).To(Equal(1))
 			Expect(managedEnv.Status.Conditions[0].Type).To(Equal(managedgitopsv1alpha1.ManagedEnvironmentStatusConnectionInitializationSucceeded))
 			Expect(managedEnv.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(ConditionReasonSucceeded))
+			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(string(managedgitopsv1alpha1.ConditionReasonSucceeded)))
 
 			By("removing the status condition and reconciling")
 			managedEnv.Status.Conditions = []metav1.Condition{}
@@ -348,7 +348,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			Expect(len(managedEnv.Status.Conditions)).To(Equal(1))
 			Expect(managedEnv.Status.Conditions[0].Type).To(Equal(managedgitopsv1alpha1.ManagedEnvironmentStatusConnectionInitializationSucceeded))
 			Expect(managedEnv.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(ConditionReasonSucceeded))
+			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(string(managedgitopsv1alpha1.ConditionReasonSucceeded)))
 
 			By("setting the status condition false and reconciling")
 			managedEnv.Status.Conditions[0].Status = metav1.ConditionFalse
@@ -365,7 +365,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			Expect(len(managedEnv.Status.Conditions)).To(Equal(1))
 			Expect(managedEnv.Status.Conditions[0].Type).To(Equal(managedgitopsv1alpha1.ManagedEnvironmentStatusConnectionInitializationSucceeded))
 			Expect(managedEnv.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(ConditionReasonSucceeded))
+			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(string(managedgitopsv1alpha1.ConditionReasonSucceeded)))
 		})
 
 		It("should set the condition ConnectionInitializationSucceeded status to False when the connection fails for new environment", func() {
@@ -406,7 +406,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			Expect(len(managedEnv.Status.Conditions)).To(Equal(1))
 			Expect(managedEnv.Status.Conditions[0].Type).To(Equal(managedgitopsv1alpha1.ManagedEnvironmentStatusConnectionInitializationSucceeded))
 			Expect(managedEnv.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
-			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(ConditionReasonUnableToInstallServiceAccount))
+			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(string(managedgitopsv1alpha1.ConditionReasonUnableToInstallServiceAccount)))
 		})
 
 		It("should set the condition ConnectionInitializationSucceeded status to False when the connection fails for existing environment", func() {
@@ -452,7 +452,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			Expect(len(managedEnv.Status.Conditions)).To(Equal(1))
 			Expect(managedEnv.Status.Conditions[0].Type).To(Equal(managedgitopsv1alpha1.ManagedEnvironmentStatusConnectionInitializationSucceeded))
 			Expect(managedEnv.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
-			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(ConditionReasonUnableToInstallServiceAccount))
+			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(string(managedgitopsv1alpha1.ConditionReasonUnableToInstallServiceAccount)))
 		})
 
 		It("should test the case where we are unable to connect to a managed env, so new credentials are acquired, and old ones are deleted", func() {
@@ -501,7 +501,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			Expect(len(managedEnv.Status.Conditions)).To(Equal(1))
 			Expect(managedEnv.Status.Conditions[0].Type).To(Equal(managedgitopsv1alpha1.ManagedEnvironmentStatusConnectionInitializationSucceeded))
 			Expect(managedEnv.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(ConditionReasonSucceeded))
+			Expect(managedEnv.Status.Conditions[0].Reason).To(Equal(string(managedgitopsv1alpha1.ConditionReasonSucceeded)))
 
 			By("verifying the old credentials have been deleted, since we simulated them being invalid")
 			clusterCreds := &db.ClusterCredentials{Clustercredentials_cred_id: oldClusterCredentials}

--- a/tests-e2e/core/managed_environment_status_test.go
+++ b/tests-e2e/core/managed_environment_status_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
-	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/shared_resource_loop"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/managedenvironment"
@@ -39,7 +38,7 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 			Expect(managedEnv.Status.Conditions).To(HaveLen(1))
 			condition := managedEnv.Status.Conditions[0]
 			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(shared_resource_loop.ConditionReasonUnableToCreateClient))
+			Expect(condition.Reason).To(Equal(managedgitopsv1alpha1.ConditionReasonUnableToCreateClient))
 			Expect(condition.Message).To(ContainSubstring("no such host"))
 		})
 
@@ -69,7 +68,7 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 			Expect(managedEnv.Status.Conditions).To(HaveLen(1))
 			condition := managedEnv.Status.Conditions[0]
 			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(shared_resource_loop.ConditionReasonMissingKubeConfigField))
+			Expect(condition.Reason).To(Equal(managedgitopsv1alpha1.ConditionReasonMissingKubeConfigField))
 			Expect(condition.Message).To(ContainSubstring("missing kubeconfig field in Secret"))
 		})
 
@@ -99,7 +98,7 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 			Expect(managedEnv.Status.Conditions).To(HaveLen(1))
 			condition := managedEnv.Status.Conditions[0]
 			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(shared_resource_loop.ConditionReasonUnableToParseKubeconfigData))
+			Expect(condition.Reason).To(Equal(managedgitopsv1alpha1.ConditionReasonUnableToParseKubeconfigData))
 			Expect(condition.Message).To(ContainSubstring("json parse error"))
 		})
 
@@ -129,7 +128,7 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 			Expect(managedEnv.Status.Conditions).To(HaveLen(1))
 			condition := managedEnv.Status.Conditions[0]
 			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(shared_resource_loop.ConditionReasonUnableToLocateContext))
+			Expect(condition.Reason).To(Equal(managedgitopsv1alpha1.ConditionReasonUnableToLocateContext))
 			Expect(condition.Message).To(ContainSubstring("the kubeconfig did not have a cluster entry that matched the API URL"))
 		})
 

--- a/tests-e2e/core/managed_environment_status_test.go
+++ b/tests-e2e/core/managed_environment_status_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 			Expect(managedEnv.Status.Conditions).To(HaveLen(1))
 			condition := managedEnv.Status.Conditions[0]
 			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(managedgitopsv1alpha1.ConditionReasonUnableToCreateClient))
+			Expect(condition.Reason).To(Equal(string(managedgitopsv1alpha1.ConditionReasonUnableToCreateClient)))
 			Expect(condition.Message).To(ContainSubstring("no such host"))
 		})
 
@@ -68,7 +68,7 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 			Expect(managedEnv.Status.Conditions).To(HaveLen(1))
 			condition := managedEnv.Status.Conditions[0]
 			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(managedgitopsv1alpha1.ConditionReasonMissingKubeConfigField))
+			Expect(condition.Reason).To(Equal(string(managedgitopsv1alpha1.ConditionReasonMissingKubeConfigField)))
 			Expect(condition.Message).To(ContainSubstring("missing kubeconfig field in Secret"))
 		})
 
@@ -98,7 +98,7 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 			Expect(managedEnv.Status.Conditions).To(HaveLen(1))
 			condition := managedEnv.Status.Conditions[0]
 			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(managedgitopsv1alpha1.ConditionReasonUnableToParseKubeconfigData))
+			Expect(condition.Reason).To(Equal(string(managedgitopsv1alpha1.ConditionReasonUnableToParseKubeconfigData)))
 			Expect(condition.Message).To(ContainSubstring("json parse error"))
 		})
 
@@ -128,7 +128,7 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 			Expect(managedEnv.Status.Conditions).To(HaveLen(1))
 			condition := managedEnv.Status.Conditions[0]
 			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(managedgitopsv1alpha1.ConditionReasonUnableToLocateContext))
+			Expect(condition.Reason).To(Equal(string(managedgitopsv1alpha1.ConditionReasonUnableToLocateContext)))
 			Expect(condition.Message).To(ContainSubstring("the kubeconfig did not have a cluster entry that matched the API URL"))
 		})
 

--- a/tests-e2e/core/operation_namespace_test.go
+++ b/tests-e2e/core/operation_namespace_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/db"
 	dbutil "github.com/redhat-appstudio/managed-gitops/backend-shared/db/util"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/operations"
-	dboperations "github.com/redhat-appstudio/managed-gitops/backend-shared/util/operations"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
 	"gopkg.in/yaml.v2"
@@ -157,7 +156,7 @@ var _ = Describe("Operation CR namespace E2E tests", func() {
 			}
 
 			Eventually(func() bool {
-				isComplete, _ := dboperations.IsOperationComplete(ctx, operationDB, dbQueries)
+				isComplete, _ := operations.IsOperationComplete(ctx, operationDB, dbQueries)
 				fmt.Println("- Operation state result achieved : ", isComplete)
 				return isComplete
 			}, "1m", "5s").Should(BeTrue())
@@ -256,7 +255,7 @@ var _ = Describe("Operation CR namespace E2E tests", func() {
 			}
 
 			Consistently(func() bool {
-				isComplete, _ := dboperations.IsOperationComplete(ctx, operationDB, dbQueries)
+				isComplete, _ := operations.IsOperationComplete(ctx, operationDB, dbQueries)
 				fmt.Println("- Operation state result achieved : ", isComplete)
 				return isComplete
 			}, "1m", "5s").Should(BeFalse())


### PR DESCRIPTION
#### Description:
- This PR has no logic changes, just refactoring of existing code as follows:
- Rather than calling `updateManagedEnvironmentConnectionStatus` at a bunch of places in the code, instead we should just return a struct, `connectionInitializedCondition`, from functions, and set the status in a single central location `internalProcessMessage_ReconcileSharedManagedEnv`.
- Utility functions for creating various conditions, to reduce code duplication
- Moving the conditions into backend-shared, so they can be consumed by other components.

#### Link to JIRA Story (if applicable): N/A
