### PR TITLE
Add managedEnvironment query parameter to the Argo CD cluster secret

### DIFF
--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_types.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_types.go
@@ -73,6 +73,7 @@ const (
 	ConditionReasonUnableToParseKubeconfigData      ManagedEnvironmentConditionReason = "UnableToParseKubeconfigData"
 	ConditionReasonUnableToRetrieveRestConfig       ManagedEnvironmentConditionReason = "UnableToRetrieveRestConfig"
 	ConditionReasonUnknownError                     ManagedEnvironmentConditionReason = "UnknownError"
+	ConditionReasonUnsupportedAPIURL                ManagedEnvironmentConditionReason = "UnsupportedAPIURL"
 )
 
 //+kubebuilder:object:root=true

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
@@ -89,6 +89,14 @@ func internalProcessMessage_internalReconcileSharedManagedEnv(ctx context.Contex
 		return newSharedResourceManagedEnvContainer(), createUnknownErrorEnvInitCondition(), nil
 	}
 
+	if strings.Contains(managedEnvironmentCR.Spec.APIURL, "?") || strings.Contains(managedEnvironmentCR.Spec.APIURL, "&") {
+
+		// TODO: JGW - Make sure this gets included after PR #397 is merged.
+		updateManagedEnvironmentConnectionStatus(&managedEnvironmentCR, ctx, workspaceClient, metav1.ConditionUnknown,
+			ConditionReasonUnsupportedAPIURL, "the API URL must not have ? or & values", log)
+		return newSharedResourceManagedEnvContainer(), nil
+	}
+
 	// After this point in the code, the API CR necessarily exists.
 
 	// Retrieve all existing APICRToDatabaseMappings for this resource name/namespace, and clean up the ones that don't match the UID

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
@@ -91,10 +91,12 @@ func internalProcessMessage_internalReconcileSharedManagedEnv(ctx context.Contex
 
 	if strings.Contains(managedEnvironmentCR.Spec.APIURL, "?") || strings.Contains(managedEnvironmentCR.Spec.APIURL, "&") {
 
-		// TODO: JGW - Make sure this gets included after PR #397 is merged.
-		updateManagedEnvironmentConnectionStatus(&managedEnvironmentCR, ctx, workspaceClient, metav1.ConditionUnknown,
-			ConditionReasonUnsupportedAPIURL, "the API URL must not have ? or & values", log)
-		return newSharedResourceManagedEnvContainer(), nil
+		return newSharedResourceManagedEnvContainer(), connectionInitializedCondition{
+			managedEnvCR: managedEnvironmentCR,
+			status:       metav1.ConditionUnknown,
+			reason:       managedgitopsv1alpha1.ConditionReasonUnsupportedAPIURL,
+			message:      "the API URL must not have ? or & values",
+		}, nil
 	}
 
 	// After this point in the code, the API CR necessarily exists.

--- a/backend/eventloop/workspace_event_loop_test.go
+++ b/backend/eventloop/workspace_event_loop_test.go
@@ -545,10 +545,9 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 				messagesReceived[string(gitopsDeployment.UID)] = []application_event_loop.RequestMessage{}
 				mutex.Lock()
 				defer mutex.Unlock()
-				for idx := range eventLoopMsgsReceived {
-					messagesReceived[string(gitopsDeployment.UID)] = append(messagesReceived[string(gitopsDeployment.UID)],
-						eventLoopMsgsReceived[idx])
-				}
+
+				messagesReceived[string(gitopsDeployment.UID)] = append(messagesReceived[string(gitopsDeployment.UID)], eventLoopMsgsReceived...)
+
 			}
 
 			for _, existingGitOpsDeployment := range gitopsDeployments {

--- a/tests-e2e/core/managed_environment_status_test.go
+++ b/tests-e2e/core/managed_environment_status_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 			Expect(condition.Message).To(ContainSubstring("json parse error"))
 		})
 
-		It("should have a connection status condition of False when there is no current contex in the kubeconfig", func() {
+		It("should have a connection status condition of False when there is no current context in the kubeconfig", func() {
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			By("creating the GitOpsDeploymentManagedEnvironment with a secret that lacks a kubeconfig context")


### PR DESCRIPTION
#### Description:
- `updateGenerateExpectedClusterSecret` with the new logic
- Add unit tests to verify the functionality (plus other related functionality)
- E2E tests will be handled by the other story

Done: ~Merge #397 first, before this PR.~

#### Link to JIRA Story (if applicable): [GITOPSRVCE-473](https://issues.redhat.com/browse/GITOPSRVCE-473)

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
