### PR TITLE
Simplify install script

### DIFF
--- a/utilities/upgrade-service/install-upgrade.sh
+++ b/utilities/upgrade-service/install-upgrade.sh
@@ -74,6 +74,7 @@ kind: Kustomization
 resources:
   - https://github.com/redhat-appstudio/managed-gitops/manifests/base/crd/overlays/local-dev?ref=$GIT_REVISION
   - https://github.com/redhat-appstudio/managed-gitops/manifests/base/gitops-namespace?ref=$GIT_REVISION
+  - https://github.com/redhat-appstudio/managed-gitops/manifests/base/gitops-service-argocd?ref=$GIT_REVISION
   - https://github.com/redhat-appstudio/managed-gitops/manifests/base/postgresql-staging?ref=$GIT_REVISION
   - https://github.com/redhat-appstudio/managed-gitops/appstudio-controller/config/default?ref=$GIT_REVISION
   - https://github.com/redhat-appstudio/managed-gitops/backend/config/default?ref=$GIT_REVISION


### PR DESCRIPTION
#### Description:
- Remove dependency on `go` and `make` for the installation and just use `kustomize` and `kubectl`
- Fixed a bug where the namespace `gitops-service-argocd` and the `ArgoCD` instance was not created in `gitops-service-argocd` namespace.

#### Link to JIRA Story (if applicable):

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
