### PR TITLE
Add new service account behaviour to ManagedEnvironment CR (#328) 

### DIFF
--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_types.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_types.go
@@ -26,9 +26,11 @@ const (
 
 // GitOpsDeploymentManagedEnvironmentSpec defines the desired state of GitOpsDeploymentManagedEnvironment
 type GitOpsDeploymentManagedEnvironmentSpec struct {
-	APIURL                     string `json:"apiURL"`
-	ClusterCredentialsSecret   string `json:"credentialsSecret"`
-	AllowInsecureSkipTLSVerify bool   `json:"allowInsecureSkipTLSVerify"`
+	APIURL                        string `json:"apiURL"`
+	ClusterCredentialsSecret      string `json:"credentialsSecret"`
+	ClusterCredentialsSecretValue string `json:"credentialsSecretValue"`
+	AllowInsecureSkipTLSVerify    bool   `json:"allowInsecureSkipTLSVerify"`
+	CreateNewServiceAccount       bool   `json:"createNewServiceAccount,omitempty"`
 }
 
 type AllowInsecureSkipTLSVerify bool

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_types.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_types.go
@@ -26,11 +26,10 @@ const (
 
 // GitOpsDeploymentManagedEnvironmentSpec defines the desired state of GitOpsDeploymentManagedEnvironment
 type GitOpsDeploymentManagedEnvironmentSpec struct {
-	APIURL                        string `json:"apiURL"`
-	ClusterCredentialsSecret      string `json:"credentialsSecret"`
-	ClusterCredentialsSecretValue string `json:"credentialsSecretValue"`
-	AllowInsecureSkipTLSVerify    bool   `json:"allowInsecureSkipTLSVerify"`
-	CreateNewServiceAccount       bool   `json:"createNewServiceAccount,omitempty"`
+	APIURL                     string `json:"apiURL"`
+	ClusterCredentialsSecret   string `json:"credentialsSecret"`
+	AllowInsecureSkipTLSVerify bool   `json:"allowInsecureSkipTLSVerify"`
+	CreateNewServiceAccount    bool   `json:"createNewServiceAccount,omitempty"`
 }
 
 type AllowInsecureSkipTLSVerify bool
@@ -63,19 +62,20 @@ type GitOpsDeploymentManagedEnvironment struct {
 type ManagedEnvironmentConditionReason string
 
 const (
-	ConditionReasonSucceeded                        ManagedEnvironmentConditionReason = "Succeeded"
-	ConditionReasonKubeError                        ManagedEnvironmentConditionReason = "KubernetesError"
-	ConditionReasonDatabaseError                    ManagedEnvironmentConditionReason = "DatabaseError"
-	ConditionReasonInvalidSecretType                ManagedEnvironmentConditionReason = "InvalidSecretType"
-	ConditionReasonMissingKubeConfigField           ManagedEnvironmentConditionReason = "MissingKubeConfigField"
-	ConditionReasonUnableToCreateClient             ManagedEnvironmentConditionReason = "UnableToCreateClient"
-	ConditionReasonUnableToCreateClusterCredentials ManagedEnvironmentConditionReason = "UnableToCreateClusterCredentials"
-	ConditionReasonUnableToInstallServiceAccount    ManagedEnvironmentConditionReason = "UnableToInstallServiceAccount"
-	ConditionReasonUnableToLocateContext            ManagedEnvironmentConditionReason = "UnableToLocateContext"
-	ConditionReasonUnableToParseKubeconfigData      ManagedEnvironmentConditionReason = "UnableToParseKubeconfigData"
-	ConditionReasonUnableToRetrieveRestConfig       ManagedEnvironmentConditionReason = "UnableToRetrieveRestConfig"
-	ConditionReasonUnknownError                     ManagedEnvironmentConditionReason = "UnknownError"
-	ConditionReasonUnsupportedAPIURL                ManagedEnvironmentConditionReason = "UnsupportedAPIURL"
+	ConditionReasonUnsupportedAPIURL                  ManagedEnvironmentConditionReason = "UnsupportedAPIURL"
+	ConditionReasonSucceeded                          ManagedEnvironmentConditionReason = "Succeeded"
+	ConditionReasonKubeError                          ManagedEnvironmentConditionReason = "KubernetesError"
+	ConditionReasonDatabaseError                      ManagedEnvironmentConditionReason = "DatabaseError"
+	ConditionReasonInvalidSecretType                  ManagedEnvironmentConditionReason = "InvalidSecretType"
+	ConditionReasonMissingKubeConfigField             ManagedEnvironmentConditionReason = "MissingKubeConfigField"
+	ConditionReasonUnableToCreateClient               ManagedEnvironmentConditionReason = "UnableToCreateClient"
+	ConditionReasonUnableToCreateClusterCredentials   ManagedEnvironmentConditionReason = "UnableToCreateClusterCredentials"
+	ConditionReasonUnableToInstallServiceAccount      ManagedEnvironmentConditionReason = "UnableToInstallServiceAccount"
+	ConditionReasonUnableToValidateClusterCredentials ManagedEnvironmentConditionReason = "UnableToValidateClusterCredentials"
+	ConditionReasonUnableToLocateContext              ManagedEnvironmentConditionReason = "UnableToLocateContext"
+	ConditionReasonUnableToParseKubeconfigData        ManagedEnvironmentConditionReason = "UnableToParseKubeconfigData"
+	ConditionReasonUnableToRetrieveRestConfig         ManagedEnvironmentConditionReason = "UnableToRetrieveRestConfig"
+	ConditionReasonUnknownError                       ManagedEnvironmentConditionReason = "UnknownError"
 )
 
 //+kubebuilder:object:root=true

--- a/backend-shared/config/crd/bases/managed-gitops.redhat.com_gitopsdeploymentmanagedenvironments.yaml
+++ b/backend-shared/config/crd/bases/managed-gitops.redhat.com_gitopsdeploymentmanagedenvironments.yaml
@@ -39,6 +39,7 @@ spec:
               state of GitOpsDeploymentManagedEnvironment
             properties:
               allowInsecureSkipTLSVerify:
+                description: ClusterCredentialsSecretValue string `json:"credentialsSecretValue"`
                 type: boolean
               apiURL:
                 type: string
@@ -46,13 +47,10 @@ spec:
                 type: boolean
               credentialsSecret:
                 type: string
-              credentialsSecretValue:
-                type: string
             required:
             - allowInsecureSkipTLSVerify
             - apiURL
             - credentialsSecret
-            - credentialsSecretValue
             type: object
           status:
             description: GitOpsDeploymentManagedEnvironmentStatus defines the observed

--- a/backend-shared/config/crd/bases/managed-gitops.redhat.com_gitopsdeploymentmanagedenvironments.yaml
+++ b/backend-shared/config/crd/bases/managed-gitops.redhat.com_gitopsdeploymentmanagedenvironments.yaml
@@ -42,12 +42,17 @@ spec:
                 type: boolean
               apiURL:
                 type: string
+              createNewServiceAccount:
+                type: boolean
               credentialsSecret:
+                type: string
+              credentialsSecretValue:
                 type: string
             required:
             - allowInsecureSkipTLSVerify
             - apiURL
             - credentialsSecret
+            - credentialsSecretValue
             type: object
           status:
             description: GitOpsDeploymentManagedEnvironmentStatus defines the observed

--- a/backend-shared/config/crd/bases/managed-gitops.redhat.com_gitopsdeploymentmanagedenvironments.yaml
+++ b/backend-shared/config/crd/bases/managed-gitops.redhat.com_gitopsdeploymentmanagedenvironments.yaml
@@ -39,7 +39,6 @@ spec:
               state of GitOpsDeploymentManagedEnvironment
             properties:
               allowInsecureSkipTLSVerify:
-                description: ClusterCredentialsSecretValue string `json:"credentialsSecretValue"`
                 type: boolean
               apiURL:
                 type: string

--- a/backend/eventloop/application_event_loop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_test.go
@@ -1105,6 +1105,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 				Spec: managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironmentSpec{
 					APIURL:                   "https://api.fake-unit-test-data.origin-ci-int-gce.dev.rhcloud.com:6443",
 					ClusterCredentialsSecret: "fake-secret-name",
+					CreateNewServiceAccount:  true,
 				},
 			}
 			err = k8sClient.Create(ctx, &managedEnvCR)
@@ -1905,6 +1906,7 @@ var _ = Describe("application_event_runner_deployments.go Tests", func() {
 				Spec: managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironmentSpec{
 					APIURL:                   "https://api.fake-unit-test-data.origin-ci-int-gce.dev.rhcloud.com:6443",
 					ClusterCredentialsSecret: "fake-secret-name",
+					CreateNewServiceAccount:  true,
 				},
 			}
 			err = k8sClient.Create(ctx, &managedEnvCR)
@@ -2310,6 +2312,7 @@ var _ = Describe("application_event_runner_deployments.go Tests", func() {
 					Spec: managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironmentSpec{
 						APIURL:                   "https://api.fake-unit-test-data.origin-ci-int-gce.dev.rhcloud.com:6443",
 						ClusterCredentialsSecret: managedEnvSecret2.Name,
+						CreateNewServiceAccount:  true,
 					},
 				}
 				err = k8sClient.Create(ctx, &managedEnvCR2)
@@ -2400,6 +2403,7 @@ var _ = Describe("Miscellaneous application_event_runner.go tests", func() {
 				Spec: managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironmentSpec{
 					APIURL:                   "https://api-url",
 					ClusterCredentialsSecret: "fake-secret-name",
+					CreateNewServiceAccount:  true,
 				},
 			}
 			err = k8sClient.Create(ctx, &managedEnvCR)

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv_test.go
@@ -111,6 +111,16 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 		}
 
 		It("should test ReconcileSharedManagedEnvironment: verify create, garbage cleanup, update, and delete, of ManagedEnvironment", func() {
+			// createNewServiceAccount = true
+			testForReconcileSharedManagedEnvironment(true, ctx, k8sClient, dbQueries, log, namespace, mockFactory, verifyResult)
+		})
+
+		It("should test ReconcileSharedManagedEnvironment: verify create, garbage cleanup, update, and delete, of ManagedEnvironment with existing SA", func() {
+			// Same test as above except createNewServiceAccount = false
+			testForReconcileSharedManagedEnvironment(false, ctx, k8sClient, dbQueries, log, namespace, mockFactory, verifyResult)
+		})
+
+		It("should test ReconcileSharedManagedEnvironment: verify create, garbage cleanup, update, and delete, of ManagedEnvironment", func() {
 
 			managedEnv, secret := buildManagedEnvironmentForSRL()
 			managedEnv.UID = "test-" + uuid.NewUUID()
@@ -774,7 +784,127 @@ func (f *SimulateFailingClientMockSRLK8sClientFactory) GetK8sClientForServiceWor
 	return f.realFakeClient, nil
 }
 
+func testForReconcileSharedManagedEnvironment(createNewServiceAccount bool, ctx context.Context, k8sClient client.WithWatch, dbQueries db.AllDatabaseQueries,
+	log logr.Logger, namespace *corev1.Namespace, mockFactory MockSRLK8sClientFactory, verifyResult func(managedEnv managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment, src SharedResourceManagedEnvContainer)) {
+
+	managedEnv, secret := buildManagedEnvironmentForSRLWithOptionalSA(createNewServiceAccount)
+	managedEnv.UID = "test-" + uuid.NewUUID()
+	secret.UID = "test-" + uuid.NewUUID()
+	eventloop_test_util.StartServiceAccountListenerOnFakeClient(ctx, string(managedEnv.UID), k8sClient)
+
+	err := k8sClient.Create(ctx, &managedEnv)
+	Expect(err).To(BeNil())
+
+	err = k8sClient.Create(ctx, &secret)
+	Expect(err).To(BeNil())
+
+	By("calling managed environment for the first time, and verifying the database rows are created")
+
+	src, err := internalProcessMessage_ReconcileSharedManagedEnv(ctx, k8sClient, managedEnv.Name, managedEnv.Namespace,
+		false, *namespace, mockFactory, dbQueries, log)
+	Expect(err).To(BeNil())
+	Expect(src.ManagedEnv).To(Not(BeNil()))
+
+	verifyResult(managedEnv, src)
+
+	By("calling reconcile on an unchanged resource")
+
+	saList := corev1.ServiceAccountList{}
+	err = k8sClient.List(ctx, &saList)
+	Expect(err).To(BeNil())
+
+	src, err = internalProcessMessage_ReconcileSharedManagedEnv(ctx, k8sClient, managedEnv.Name, managedEnv.Namespace,
+		false, *namespace, mockFactory, dbQueries, log)
+	Expect(err).To(BeNil())
+	Expect(src.ManagedEnv).To(Not(BeNil()))
+	verifyResult(managedEnv, src)
+
+	By("ensuring an old APICRToDatabaseMapping that previously had the same name/namespace, is deleted when the new one is reconciled")
+
+	oldAPICRToDBMapping := &db.APICRToDatabaseMapping{
+		APIResourceType:      db.APICRToDatabaseMapping_ResourceType_GitOpsDeploymentManagedEnvironment,
+		APIResourceUID:       string(uuid.NewUUID()),
+		APIResourceName:      managedEnv.Name,
+		APIResourceNamespace: managedEnv.Namespace,
+		NamespaceUID:         string(namespace.UID),
+		DBRelationType:       db.APICRToDatabaseMapping_DBRelationType_ManagedEnvironment,
+		DBRelationKey:        "test-doesnt-exist",
+	}
+	err = dbQueries.CreateAPICRToDatabaseMapping(ctx, oldAPICRToDBMapping)
+	Expect(err).To(BeNil())
+
+	src, err = internalProcessMessage_ReconcileSharedManagedEnv(ctx, k8sClient, managedEnv.Name, managedEnv.Namespace,
+		false, *namespace, mockFactory, dbQueries, log)
+	Expect(err).To(BeNil())
+
+	// Update our copy of the ManagedEnvironment, since the call to reconcile will have added status to it.
+	// This prevents an "object was modified" error when we update it.
+	err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&managedEnv), &managedEnv)
+	Expect(err).To(BeNil())
+
+	By("updating the managed environment, and verifying that the database rows are also updated")
+
+	oldClusterCreds := &db.ClusterCredentials{
+		Clustercredentials_cred_id: src.ManagedEnv.Clustercredentials_id,
+	}
+	err = dbQueries.GetClusterCredentialsById(ctx, oldClusterCreds)
+	Expect(err).To(BeNil())
+
+	managedEnv.Spec.APIURL = "https://api2.fake-unit-test-data.origin-ci-int-gce.dev.rhcloud.com:6443"
+	err = k8sClient.Update(ctx, &managedEnv)
+	Expect(err).To(BeNil())
+	src, err = internalProcessMessage_ReconcileSharedManagedEnv(ctx, k8sClient, managedEnv.Name, managedEnv.Namespace,
+		false, *namespace, mockFactory, dbQueries, log)
+	Expect(err).To(BeNil())
+
+	By("verifying the old cluster credentials have been deleted, after update")
+	err = dbQueries.GetClusterCredentialsById(ctx, oldClusterCreds)
+	Expect(db.IsResultNotFoundError(err)).To(BeTrue())
+
+	By("verifying new cluster credentials exist containing the update")
+	err = dbQueries.GetManagedEnvironmentById(ctx, src.ManagedEnv)
+	Expect(err).To(BeNil())
+	Expect(src.ManagedEnv.Clustercredentials_id).ToNot(BeEmpty())
+	newClusterCreds := &db.ClusterCredentials{
+		Clustercredentials_cred_id: src.ManagedEnv.Clustercredentials_id,
+	}
+
+	err = dbQueries.GetClusterCredentialsById(ctx, newClusterCreds)
+	Expect(err).To(BeNil())
+	Expect(newClusterCreds.Host).To(Equal(managedEnv.Spec.APIURL))
+
+	By("deleting the managed environment, and verifying that the database rows are also removed")
+
+	err = k8sClient.Delete(ctx, &managedEnv)
+	Expect(err).To(BeNil())
+
+	oldManagedEnv := src.ManagedEnv
+
+	src, err = internalProcessMessage_ReconcileSharedManagedEnv(ctx, k8sClient, managedEnv.Name, managedEnv.Namespace,
+		false, *namespace, mockFactory, dbQueries, log)
+	Expect(err).To(BeNil())
+
+	err = dbQueries.GetManagedEnvironmentById(ctx, oldManagedEnv)
+	Expect(db.IsResultNotFoundError(err)).To(BeTrue())
+
+	err = dbQueries.GetClusterCredentialsById(ctx, newClusterCreds)
+	Expect(db.IsResultNotFoundError(err)).To(BeTrue())
+
+	mappings := []db.APICRToDatabaseMapping{}
+	err = dbQueries.UnsafeListAllAPICRToDatabaseMappings(ctx, &mappings)
+	Expect(err).To(BeNil())
+
+	By("Verifying that the API CR to database mapping has been removed.")
+	for _, mapping := range mappings {
+		Expect(mapping.APIResourceUID).ToNot(Equal(managedEnv.UID))
+	}
+}
+
 func buildManagedEnvironmentForSRL() (managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment, corev1.Secret) {
+	return buildManagedEnvironmentForSRLWithOptionalSA(true)
+}
+
+func buildManagedEnvironmentForSRLWithOptionalSA(createNewServiceAccount bool) (managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment, corev1.Secret) {
 
 	kubeConfigContents := generateFakeKubeConfig()
 
@@ -795,8 +925,10 @@ func buildManagedEnvironmentForSRL() (managedgitopsv1alpha1.GitOpsDeploymentMana
 			Namespace: dbutil.DefaultGitOpsEngineSingleInstanceNamespace,
 		},
 		Spec: managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironmentSpec{
-			APIURL:                   "https://api.fake-unit-test-data.origin-ci-int-gce.dev.rhcloud.com:6443",
-			ClusterCredentialsSecret: secret.Name,
+			APIURL:                        "https://api.fake-unit-test-data.origin-ci-int-gce.dev.rhcloud.com:6443",
+			ClusterCredentialsSecret:      secret.Name,
+			ClusterCredentialsSecretValue: "secretvalue",
+			CreateNewServiceAccount:       createNewServiceAccount,
 		},
 	}
 

--- a/tests-e2e/core/managed_environment_status_test.go
+++ b/tests-e2e/core/managed_environment_status_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 			By("creating the GitOpsDeploymentManagedEnvironment with a target cluster that does not exist")
 
 			apiServerURL := "https://api2.fake-e2e-test-data.origin-ci-int-gce.dev.rhcloud.com:6443"
-			managedEnv, secret := buildManagedEnvironment(apiServerURL, generateFakeKubeConfig())
+			managedEnv, secret := buildManagedEnvironment(apiServerURL, generateFakeKubeConfig(), true)
 
 			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
 			Expect(err).To(Succeed())
@@ -49,7 +49,7 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 
 			kubeConfigContents, apiServerURL, err := fixture.ExtractKubeConfigValues()
 			Expect(err).To(BeNil())
-			managedEnv, secret := buildManagedEnvironment(apiServerURL, kubeConfigContents)
+			managedEnv, secret := buildManagedEnvironment(apiServerURL, kubeConfigContents, true)
 			delete(secret.StringData, "kubeconfig")
 
 			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
@@ -79,7 +79,7 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 
 			kubeConfigContents, apiServerURL, err := fixture.ExtractKubeConfigValues()
 			Expect(err).To(BeNil())
-			managedEnv, secret := buildManagedEnvironment(apiServerURL, kubeConfigContents)
+			managedEnv, secret := buildManagedEnvironment(apiServerURL, kubeConfigContents, true)
 			secret.StringData["kubeconfig"] = "badbadbad"
 
 			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
@@ -109,7 +109,7 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 
 			kubeConfigContents, apiServerURL, err := fixture.ExtractKubeConfigValues()
 			Expect(err).To(BeNil())
-			managedEnv, secret := buildManagedEnvironment(apiServerURL, kubeConfigContents)
+			managedEnv, secret := buildManagedEnvironment(apiServerURL, kubeConfigContents, true)
 			secret.StringData["kubeconfig"] = "apiVersion: v1\nkind: Config\n"
 
 			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
@@ -140,7 +140,7 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 			kubeConfigContents, apiServerURL, err := fixture.ExtractKubeConfigValues()
 			Expect(err).To(BeNil())
 
-			managedEnv, secret := buildManagedEnvironment(apiServerURL, kubeConfigContents)
+			managedEnv, secret := buildManagedEnvironment(apiServerURL, kubeConfigContents, true)
 
 			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
 			Expect(err).To(Succeed())

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -2,13 +2,14 @@ package core
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	appv1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appstudioshared "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/db"
 	dbutil "github.com/redhat-appstudio/managed-gitops/backend-shared/db/util"
 	argocdutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util/argocd"
@@ -20,13 +21,21 @@ import (
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/managedenvironment"
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 
 	Context("Create a new GitOpsDeployment targeting a ManagedEnvironment", func() {
+
+		ctx := context.Background()
+
+		BeforeEach(func() {
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+		})
 
 		It("should be healthy and have synced status, and resources should be deployed, when deployed with a ManagedEnv", func() {
 
@@ -41,7 +50,7 @@ var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 			kubeConfigContents, apiServerURL, err := fixture.ExtractKubeConfigValues()
 			Expect(err).To(BeNil())
 
-			managedEnv, secret := buildManagedEnvironment(apiServerURL, kubeConfigContents)
+			managedEnv, secret := buildManagedEnvironment(apiServerURL, kubeConfigContents, true)
 
 			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
 			Expect(err).To(Succeed())
@@ -145,6 +154,322 @@ var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 			Expect(err).To(Succeed())
 
 		})
+
+		It("should be healthy and have synced status, and resources should be deployed, when deployed with a ManagedEnv using an existing SA", func() {
+
+			serviceAccountName := "gitops-managed-environment-test-service-account"
+
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
+
+			serviceAccount := corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceAccountName,
+					Namespace: fixture.GitOpsServiceE2ENamespace,
+				},
+			}
+			err = k8sClient.Create(context.Background(), &serviceAccount)
+			Expect(err).To(Succeed())
+
+			// Now create the cluster role and cluster role binding
+			err = createOrUpdateClusterRoleAndRoleBinding(ctx, "123", k8sClient, serviceAccountName, serviceAccount.Namespace, ArgoCDManagerNamespacePolicyRules)
+			Expect(err).To(BeNil())
+
+			// Create Service Account and wait for bearer token
+			tokenSecret, err := k8s.CreateServiceAccountBearerToken(ctx, k8sClient, serviceAccount.Name, serviceAccount.Namespace)
+			Expect(err).To(BeNil())
+			Expect(tokenSecret).NotTo(BeNil())
+
+			By("creating the GitOpsDeploymentManagedEnvironment")
+
+			_, apiServerURL, err := extractKubeConfigValues()
+			Expect(err).To(BeNil())
+
+			kubeConfigContents := generateKubeConfig(apiServerURL, fixture.GitOpsServiceE2ENamespace, tokenSecret)
+
+			managedEnv, secret := buildManagedEnvironmentWithToken(apiServerURL, kubeConfigContents, false, tokenSecret)
+
+			err = k8s.Create(&secret, k8sClient)
+			Expect(err).To(BeNil())
+
+			err = k8s.Create(&managedEnv, k8sClient)
+			Expect(err).To(BeNil())
+
+			gitOpsDeploymentResource := buildGitOpsDeploymentResource("my-gitops-depl",
+				"https://github.com/redhat-appstudio/managed-gitops",
+				"resources/test-data/sample-gitops-repository/environments/overlays/dev",
+				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
+
+			gitOpsDeploymentResource.Spec.Destination.Environment = managedEnv.Name
+			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
+			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
+			Expect(err).To(BeNil())
+
+			By("ensuring GitOpsDeployment should have expected health and status and reconciledState")
+
+			expectedReconciledStateField := managedgitopsv1alpha1.ReconciledState{
+				Source: managedgitopsv1alpha1.GitOpsDeploymentSource{
+					RepoURL: gitOpsDeploymentResource.Spec.Source.RepoURL,
+					Path:    gitOpsDeploymentResource.Spec.Source.Path,
+				},
+				Destination: managedgitopsv1alpha1.GitOpsDeploymentDestination{
+					Name:      gitOpsDeploymentResource.Spec.Destination.Environment,
+					Namespace: gitOpsDeploymentResource.Spec.Destination.Namespace,
+				},
+			}
+
+			Eventually(gitOpsDeploymentResource, "2m", "1s").Should(
+				SatisfyAll(
+					gitopsDeplFixture.HaveSyncStatusCode(managedgitopsv1alpha1.SyncStatusCodeSynced),
+					gitopsDeplFixture.HaveHealthStatusCode(managedgitopsv1alpha1.HeathStatusCodeHealthy),
+					gitopsDeplFixture.HaveReconciledState(expectedReconciledStateField)))
+
+			secretList := corev1.SecretList{}
+
+			err = k8sClient.List(context.Background(), &secretList, &client.ListOptions{Namespace: dbutil.DefaultGitOpsEngineSingleInstanceNamespace})
+			Expect(err).To(BeNil())
+
+			dbQueries, err := db.NewSharedProductionPostgresDBQueries(false)
+			Expect(err).To(BeNil())
+			defer dbQueries.CloseDatabase()
+
+			mapping := &db.APICRToDatabaseMapping{
+				APIResourceType: db.APICRToDatabaseMapping_ResourceType_GitOpsDeploymentManagedEnvironment,
+				APIResourceUID:  string(managedEnv.UID),
+				DBRelationType:  db.APICRToDatabaseMapping_DBRelationType_ManagedEnvironment,
+			}
+			err = dbQueries.GetDatabaseMappingForAPICR(context.Background(), mapping)
+			Expect(err).To(BeNil())
+
+			argoCDClusterSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      argocdutil.GenerateArgoCDClusterSecretName(db.ManagedEnvironment{Managedenvironment_id: mapping.DBRelationKey}),
+					Namespace: dbutil.DefaultGitOpsEngineSingleInstanceNamespace,
+				},
+			}
+
+			Expect(argoCDClusterSecret).To(k8s.ExistByName(k8sClient))
+
+			By("ensuring the resources of the GitOps repo are successfully deployed")
+
+			componentADepl := &apps.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "component-a", Namespace: fixture.GitOpsServiceE2ENamespace},
+			}
+			componentBDepl := &apps.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "component-b", Namespace: fixture.GitOpsServiceE2ENamespace},
+			}
+			Eventually(componentADepl, "60s", "1s").Should(k8s.ExistByName(k8sClient))
+			Eventually(componentBDepl, "60s", "1s").Should(k8s.ExistByName(k8sClient))
+
+			By("deleting the secret and managed environment")
+			err = k8s.Delete(&secret, k8sClient)
+			Expect(err).To(BeNil())
+
+			err = k8s.Delete(&managedEnv, k8sClient)
+			Expect(err).To(BeNil())
+
+			Eventually(argoCDClusterSecret, "60s", "1s").ShouldNot(k8s.ExistByName(k8sClient),
+				"once the ManagedEnvironment is deleted, the Argo CD cluster secret should be deleted as well.")
+
+			app := appv1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      argocdutil.GenerateArgoCDApplicationName(string(gitOpsDeploymentResource.UID)),
+					Namespace: dbutil.GetGitOpsEngineSingleInstanceNamespace(),
+				},
+			}
+			Eventually(app, "60s", "1s").Should(appFixture.HasDestinationField(appv1alpha1.ApplicationDestination{
+				Namespace: gitOpsDeploymentResource.Spec.Destination.Namespace,
+				Name:      "",
+			}), "the Argo CD Application resource's spec.destination field should have an empty environment field")
+
+			err = k8s.Delete(&serviceAccount, k8sClient)
+			Expect(err).To(Succeed())
+
+			By("deleting the GitOpsDeployment")
+
+			err = k8s.Delete(&gitOpsDeploymentResource, k8sClient)
+			Expect(err).To(Succeed())
+		})
+
+		// Same as previous test but the service account token is not passed through to the managed env
+		It("should be unhealthy with no sync status because the managed env does not have a proper token", func() {
+
+			serviceAccountName := "gitops-managed-environment-test-service-account"
+
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
+
+			serviceAccount := corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceAccountName,
+					Namespace: fixture.GitOpsServiceE2ENamespace,
+				},
+			}
+			err = k8sClient.Create(context.Background(), &serviceAccount)
+			Expect(err).To(Succeed())
+
+			// Now create the cluster role and cluster role binding
+			err = createOrUpdateClusterRoleAndRoleBinding(ctx, "123", k8sClient, serviceAccountName, serviceAccount.Namespace, ArgoCDManagerNamespacePolicyRules)
+			Expect(err).To(BeNil())
+
+			// Create Service Account and wait for bearer token
+			tokenSecret, err := k8s.CreateServiceAccountBearerToken(ctx, k8sClient, serviceAccount.Name, serviceAccount.Namespace)
+			Expect(err).To(BeNil())
+			Expect(tokenSecret).NotTo(BeNil())
+
+			By("creating the GitOpsDeploymentManagedEnvironment")
+
+			_, apiServerURL, err := extractKubeConfigValues()
+			Expect(err).To(BeNil())
+
+			kubeConfigContents := generateKubeConfig(apiServerURL, fixture.GitOpsServiceE2ENamespace, tokenSecret)
+
+			// Set the tokenSecret to be "" to intentionally fail
+			managedEnv, secret := buildManagedEnvironmentWithToken(apiServerURL, kubeConfigContents, false, "FAKE")
+
+			err = k8s.Create(&secret, k8sClient)
+			Expect(err).To(BeNil())
+
+			err = k8s.Create(&managedEnv, k8sClient)
+			Expect(err).To(BeNil())
+
+			gitOpsDeploymentResource := buildGitOpsDeploymentResource("my-gitops-depl",
+				"https://github.com/redhat-appstudio/managed-gitops",
+				"resources/test-data/sample-gitops-repository/environments/overlays/dev",
+				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
+
+			gitOpsDeploymentResource.Spec.Destination.Environment = managedEnv.Name
+			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
+			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
+			Expect(err).To(BeNil())
+
+			By("ensuring GitOpsDeployment should have expected health and status and reconciledState")
+
+			expectedReconciledStateField := managedgitopsv1alpha1.ReconciledState{
+				Source: managedgitopsv1alpha1.GitOpsDeploymentSource{
+					RepoURL: gitOpsDeploymentResource.Spec.Source.RepoURL,
+					Path:    gitOpsDeploymentResource.Spec.Source.Path,
+				},
+				Destination: managedgitopsv1alpha1.GitOpsDeploymentDestination{
+					Name:      gitOpsDeploymentResource.Spec.Destination.Environment,
+					Namespace: gitOpsDeploymentResource.Spec.Destination.Namespace,
+				},
+			}
+
+			// The resulting Argo CD app is healthy but has an unknown sync status
+			Eventually(gitOpsDeploymentResource, "2m", "1s").Should(
+				SatisfyAll(
+					gitopsDeplFixture.HaveSyncStatusCode(managedgitopsv1alpha1.SyncStatusCodeUnknown),
+					gitopsDeplFixture.HaveHealthStatusCode(managedgitopsv1alpha1.HeathStatusCodeHealthy),
+					gitopsDeplFixture.HaveReconciledState(expectedReconciledStateField)))
+
+			By("deleting the secret and managed environment")
+			err = k8s.Delete(&secret, k8sClient)
+			Expect(err).To(BeNil())
+
+			err = k8s.Delete(&managedEnv, k8sClient)
+			Expect(err).To(BeNil())
+
+			err = k8s.Delete(&serviceAccount, k8sClient)
+			Expect(err).To(Succeed())
+
+			By("deleting the GitOpsDeployment")
+
+			err = k8s.Delete(&gitOpsDeploymentResource, k8sClient)
+			Expect(err).To(Succeed())
+		})
+
+		It("should be unhealthy with no sync status because the service account doesn't have sufficient permission", func() {
+
+			serviceAccountName := "gitops-managed-environment-test-service-account"
+
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
+
+			serviceAccount := corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceAccountName,
+					Namespace: fixture.GitOpsServiceE2ENamespace,
+				},
+			}
+			err = k8sClient.Create(context.Background(), &serviceAccount)
+			Expect(err).To(Succeed())
+
+			insufficientPermissions := []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"*"},
+					Resources: []string{"Pods"},
+					Verbs:     []string{"get", "list"},
+				},
+			}
+			// Now create the cluster role and cluster role binding
+			err = createOrUpdateClusterRoleAndRoleBinding(ctx, "123", k8sClient, serviceAccountName, serviceAccount.Namespace, insufficientPermissions)
+			Expect(err).To(BeNil())
+
+			// Create Service Account and wait for bearer token
+			tokenSecret, err := k8s.CreateServiceAccountBearerToken(ctx, k8sClient, serviceAccount.Name, serviceAccount.Namespace)
+			Expect(err).To(BeNil())
+			Expect(tokenSecret).NotTo(BeNil())
+
+			By("creating the GitOpsDeploymentManagedEnvironment")
+
+			_, apiServerURL, err := extractKubeConfigValues()
+			Expect(err).To(BeNil())
+
+			kubeConfigContents := generateKubeConfig(apiServerURL, fixture.GitOpsServiceE2ENamespace, tokenSecret)
+
+			managedEnv, secret := buildManagedEnvironmentWithToken(apiServerURL, kubeConfigContents, false, tokenSecret)
+
+			err = k8s.Create(&secret, k8sClient)
+			Expect(err).To(BeNil())
+
+			err = k8s.Create(&managedEnv, k8sClient)
+			Expect(err).To(BeNil())
+
+			gitOpsDeploymentResource := buildGitOpsDeploymentResource("my-gitops-depl",
+				"https://github.com/redhat-appstudio/managed-gitops",
+				"resources/test-data/sample-gitops-repository/environments/overlays/dev",
+				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
+
+			gitOpsDeploymentResource.Spec.Destination.Environment = managedEnv.Name
+			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
+			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
+			Expect(err).To(BeNil())
+
+			By("ensuring GitOpsDeployment should have expected health and status and reconciledState")
+
+			expectedReconciledStateField := managedgitopsv1alpha1.ReconciledState{
+				Source: managedgitopsv1alpha1.GitOpsDeploymentSource{
+					RepoURL: gitOpsDeploymentResource.Spec.Source.RepoURL,
+					Path:    gitOpsDeploymentResource.Spec.Source.Path,
+				},
+				Destination: managedgitopsv1alpha1.GitOpsDeploymentDestination{
+					Name:      gitOpsDeploymentResource.Spec.Destination.Environment,
+					Namespace: gitOpsDeploymentResource.Spec.Destination.Namespace,
+				},
+			}
+
+			Eventually(gitOpsDeploymentResource, "2m", "1s").Should(
+				SatisfyAll(
+					gitopsDeplFixture.HaveSyncStatusCode(managedgitopsv1alpha1.SyncStatusCodeUnknown),
+					gitopsDeplFixture.HaveHealthStatusCode(managedgitopsv1alpha1.HeathStatusCodeHealthy),
+					gitopsDeplFixture.HaveReconciledState(expectedReconciledStateField)))
+
+			By("deleting the secret and managed environment")
+			err = k8s.Delete(&secret, k8sClient)
+			Expect(err).To(BeNil())
+
+			err = k8s.Delete(&managedEnv, k8sClient)
+			Expect(err).To(BeNil())
+
+			err = k8s.Delete(&serviceAccount, k8sClient)
+			Expect(err).To(Succeed())
+
+			By("deleting the GitOpsDeployment")
+
+			err = k8s.Delete(&gitOpsDeploymentResource, k8sClient)
+			Expect(err).To(Succeed())
+		})
 	})
 })
 
@@ -243,7 +568,95 @@ var _ = Describe("Environment E2E tests", func() {
 	})
 })
 
-func buildManagedEnvironment(apiServerURL string, kubeConfigContents string) (managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment, corev1.Secret) {
+// extractKubeConfigValues returns contents of k8s config from $KUBE_CONFIG, plus server api url (and error)
+func extractKubeConfigValues() (string, string, error) {
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+
+	config, err := loadingRules.Load()
+	if err != nil {
+		return "", "", err
+	}
+
+	context, ok := config.Contexts[config.CurrentContext]
+	if !ok || context == nil {
+		return "", "", fmt.Errorf("no context")
+	}
+
+	cluster, ok := config.Clusters[context.Cluster]
+	if !ok || cluster == nil {
+		return "", "", fmt.Errorf("no cluster")
+	}
+
+	var kubeConfigDefault string
+
+	paths := loadingRules.Precedence
+	{
+
+		for _, path := range paths {
+
+			GinkgoWriter.Println("Attempting to read kube config from", path)
+
+			// homeDir, err := os.UserHomeDir()
+			// if err != nil {
+			// 	return "", "", err
+			// }
+
+			_, err = os.Stat(path)
+			if err != nil {
+				GinkgoWriter.Println("Unable to resolve path", path, err)
+			} else {
+				// Success
+				kubeConfigDefault = path
+				break
+			}
+
+		}
+
+		if kubeConfigDefault == "" {
+			return "", "", fmt.Errorf("unable to retrieve kube config path")
+		}
+	}
+
+	kubeConfigContents, err := os.ReadFile(kubeConfigDefault)
+	if err != nil {
+		return "", "", err
+	}
+
+	return string(kubeConfigContents), cluster.Server, nil
+}
+
+func generateKubeConfig(serverURL string, currentNamespace string, token string) string {
+
+	return `
+apiVersion: v1
+kind: Config
+clusters:
+  - cluster:
+      insecure-skip-tls-verify: true
+      server: ` + serverURL + `
+    name: cluster-name
+contexts:
+  - context:
+      cluster: cluster-name
+      namespace: ` + currentNamespace + `
+      user: user-name
+    name: context-name
+current-context: context-name
+preferences: {}
+users:
+  - name: user-name
+    user:
+      token: ` + token + `
+`
+
+}
+
+func buildManagedEnvironment(apiServerURL string, kubeConfigContents string, createNewServiceAccount bool) (managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment, corev1.Secret) {
+	return buildManagedEnvironmentWithToken(apiServerURL, kubeConfigContents, createNewServiceAccount, "")
+}
+
+func buildManagedEnvironmentWithToken(apiServerURL string, kubeConfigContents string, createNewServiceAccount bool, tokenSecret string) (managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment, corev1.Secret) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-managed-env-secret",
@@ -259,11 +672,69 @@ func buildManagedEnvironment(apiServerURL string, kubeConfigContents string) (ma
 			Namespace: fixture.GitOpsServiceE2ENamespace,
 		},
 		Spec: managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironmentSpec{
-			APIURL:                     apiServerURL,
-			ClusterCredentialsSecret:   secret.Name,
-			AllowInsecureSkipTLSVerify: true,
+			APIURL:                        apiServerURL,
+			ClusterCredentialsSecret:      secret.Name,
+			ClusterCredentialsSecretValue: tokenSecret,
+			AllowInsecureSkipTLSVerify:    true,
+			CreateNewServiceAccount:       createNewServiceAccount,
 		},
 	}
 
 	return *managedEnv, *secret
+}
+
+const (
+	ArgoCDManagerClusterRoleNamePrefix        = "argocd-manager-cluster-role-"
+	ArgoCDManagerClusterRoleBindingNamePrefix = "argocd-manager-cluster-role-binding-"
+)
+
+var (
+	ArgoCDManagerNamespacePolicyRules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+			Verbs:     []string{"*"},
+		},
+	}
+)
+
+func createOrUpdateClusterRoleAndRoleBinding(ctx context.Context, uuid string, k8sClient client.Client,
+	serviceAccountName string, serviceAccountNamespace string, policyRules []rbacv1.PolicyRule) error {
+
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ArgoCDManagerClusterRoleNamePrefix + uuid,
+		},
+	}
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterRole), clusterRole); err != nil {
+
+		clusterRole.Rules = policyRules
+		if err := k8sClient.Create(ctx, clusterRole); err != nil {
+			return fmt.Errorf("unable to create clusterrole: %w", err)
+		}
+	}
+
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ArgoCDManagerClusterRoleBindingNamePrefix + uuid,
+		},
+	}
+
+	clusterRoleBinding.RoleRef = rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "ClusterRole",
+		Name:     clusterRole.Name,
+	}
+
+	clusterRoleBinding.Subjects = []rbacv1.Subject{{
+		Kind:      rbacv1.ServiceAccountKind,
+		Name:      serviceAccountName,
+		Namespace: serviceAccountNamespace,
+	}}
+
+	if err := k8sClient.Create(ctx, clusterRoleBinding); err != nil {
+		return fmt.Errorf("unable to create clusterrole: %w", err)
+	}
+
+	return nil
 }

--- a/tests-e2e/fixture/k8s/fixture.go
+++ b/tests-e2e/fixture/k8s/fixture.go
@@ -198,7 +198,7 @@ func CreateServiceAccountBearerToken(ctx context.Context, k8sClient client.Clien
 	if err := wait.PollImmediate(time.Second*1, time.Second*120, func() (bool, error) {
 
 		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(tokenSecret), tokenSecret); err != nil {
-			fmt.Println("waiting: ", err)
+			fmt.Println("waiting for ServiceAccountTokenSecret to exist: ", err)
 		}
 
 		// Exit the loop if the token has been set by k8s, continue otherwise.


### PR DESCRIPTION
Description:
x--- @jgwest, the e2e tests aren't checked in. But you can run your test and add the boolean flag. Note, the validation of the cluster credentials failed however, even though the test passes. ---x

Update: e2e tests are now checked in and validation using the cluster credentials now pass.

Link to JIRA Story (if applicable):
https://issues.redhat.com/browse/GITOPSRVCE-328
