### PR TITLE
Reduce memory usage by reusing the client from the workspace eventloop

### DIFF
--- a/backend/eventloop/workspace_event_loop.go
+++ b/backend/eventloop/workspace_event_loop.go
@@ -318,7 +318,7 @@ func handleWorkspaceEventLoopMessage(ctx context.Context, event eventlooptypes.E
 	if !exists {
 
 		var err error
-		applicationEntryVal, err = startApplicationEventQueueLoop(ctx, associatedGitOpsDeploymentName, event,
+		applicationEntryVal, err = startApplicationEventQueueLoop(ctx, event.Event.Client, associatedGitOpsDeploymentName, event,
 			state.sharedResourceEventLoop, state.applEventLoopFactory, log)
 		if err != nil {
 			// We already logged the error in startApplicationEventLoop, no need to log here
@@ -423,7 +423,7 @@ func handleStatusTickerMessage(state workspaceEventLoopInternalState) {
 
 }
 
-func startApplicationEventQueueLoop(ctx context.Context, associatedGitOpsDeploymentName string, event eventlooptypes.EventLoopMessage,
+func startApplicationEventQueueLoop(ctx context.Context, k8sClient client.Client, associatedGitOpsDeploymentName string, event eventlooptypes.EventLoopMessage,
 	sharedResourceEventLoop *shared_resource_loop.SharedResourceEventLoop,
 	applEventLoopFactory applicationEventQueueLoopFactory, log logr.Logger) (workspaceEventLoop_applicationEventLoopEntry, error) {
 
@@ -436,6 +436,7 @@ func startApplicationEventQueueLoop(ctx context.Context, associatedGitOpsDeploym
 		SharedResourceEventLoop:   sharedResourceEventLoop,
 		VwsAPIExportName:          "", // this value will be replaced in startApplicationEventQueueLoop, so is blank
 		InputChan:                 make(chan application_event_loop.RequestMessage),
+		Client:                    k8sClient,
 	}
 
 	// Start the application event loop's goroutine

--- a/utilities/load-test/gitops-service/gitops_service_test.go
+++ b/utilities/load-test/gitops-service/gitops_service_test.go
@@ -1,0 +1,131 @@
+package gitopsservice
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
+	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
+
+	corev1 "k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Simulate GitOps Service on RHTAP production environment", func() {
+	Context("create large number of user resources to investigate memory/CPU usage", func() {
+
+		var (
+			k8sClient client.Client
+			ctx       context.Context
+		)
+		BeforeEach(func() {
+			config, err := fixture.GetSystemKubeConfig()
+			Expect(err).To(BeNil())
+
+			k8sClient, err = fixture.GetKubeClient(config)
+			Expect(err).To(BeNil())
+
+			ctx = context.Background()
+		})
+
+		It("should create user namespaces, GitOpsDeployments and secrets", func() {
+
+			numberOfUsers := 291
+
+			createUserResources := func(user int) {
+				defer GinkgoRecover()
+				By("create a namespace")
+				ns := corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf("user-%d", user),
+					},
+				}
+
+				err := k8sClient.Create(ctx, &ns)
+				if !apierr.IsAlreadyExists(err) {
+					Expect(err).To(BeNil())
+				}
+
+				By("create two GitOpsDeployments in the user namespace")
+				depl1 := managedgitopsv1alpha1.GitOpsDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("user-%d", user),
+						Namespace: ns.Name,
+					},
+					Spec: managedgitopsv1alpha1.GitOpsDeploymentSpec{
+						Source: managedgitopsv1alpha1.ApplicationSource{
+							RepoURL:        "https://github.com/managed-gitops-test-data/deployment-permutations-a",
+							Path:           "pathB",
+							TargetRevision: "branchA",
+						},
+						Destination: managedgitopsv1alpha1.ApplicationDestination{},
+						Type:        managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated,
+					},
+				}
+
+				err = k8sClient.Create(ctx, &depl1)
+				if !apierr.IsAlreadyExists(err) {
+					Expect(err).To(BeNil())
+				}
+
+				depl2 := &managedgitopsv1alpha1.GitOpsDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("user-secondary-%d", user),
+						Namespace: ns.Name,
+					},
+					Spec: managedgitopsv1alpha1.GitOpsDeploymentSpec{
+						Source: managedgitopsv1alpha1.ApplicationSource{
+							RepoURL: "https://github.com/redhat-appstudio/managed-gitops",
+							Path:    "resources/test-data/sample-gitops-repository/environments/overlays/dev",
+						},
+						Destination: managedgitopsv1alpha1.ApplicationDestination{},
+						Type:        managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated,
+					},
+				}
+
+				err = k8sClient.Create(ctx, depl2)
+				if !apierr.IsAlreadyExists(err) {
+					Expect(err).To(BeNil())
+				}
+
+				By("create secrets in the user namespace")
+				for i := 0; i < 10; i++ {
+					secret := corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      fmt.Sprintf("user-secret-%d", i),
+							Namespace: ns.Name,
+						},
+						Data: map[string][]byte{
+							"sample-key": []byte(strings.Repeat("samplesecret", 50)),
+						},
+					}
+
+					err := k8sClient.Create(context.Background(), &secret)
+					if !apierr.IsAlreadyExists(err) {
+						Expect(err).To(BeNil())
+					}
+				}
+			}
+
+			runTest := func(user int, wg *sync.WaitGroup) {
+				createUserResources(user)
+				wg.Done()
+			}
+
+			var wg sync.WaitGroup
+			wg.Add(numberOfUsers)
+			for i := 1; i <= numberOfUsers; i++ {
+				go runTest(i, &wg)
+			}
+
+			GinkgoWriter.Println("Waiting for Goroutines to finish")
+			wg.Wait()
+		})
+	})
+})

--- a/utilities/load-test/gitops-service/suite_test.go
+++ b/utilities/load-test/gitops-service/suite_test.go
@@ -1,0 +1,13 @@
+package gitopsservice
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestInitializeValues(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test for investigating memory and CPU usage of GitOps Service")
+}

--- a/utilities/load-test/go.mod
+++ b/utilities/load-test/go.mod
@@ -3,23 +3,31 @@ module github.com/redhat-appstudio/managed-gitops/utilities/load-test
 go 1.18
 
 require (
-	github.com/argoproj/argo-cd/v2 v2.5.1
-	k8s.io/apimachinery v0.24.2
-	k8s.io/client-go v11.0.1-0.20190816222228-6d55c1b1f1ca+incompatible
+	github.com/argoproj/argo-cd/v2 v2.5.4
+	github.com/onsi/ginkgo/v2 v2.1.6
+	github.com/onsi/gomega v1.20.1
+	github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0
+	github.com/redhat-appstudio/managed-gitops/tests-e2e v0.0.0
+	k8s.io/api v0.24.3
+	k8s.io/apimachinery v0.24.3
+	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/metrics v0.24.2
+	sigs.k8s.io/controller-runtime v0.13.0
 )
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
-	github.com/Microsoft/go-winio v0.4.17 // indirect
+	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/argoproj-labs/argocd-operator v0.5.0 // indirect
 	github.com/argoproj/gitops-engine v0.7.1-0.20221004132320-98ccd3d43fd9 // indirect
 	github.com/argoproj/pkg v0.11.1-0.20211203175135-36c59d8fafe0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bombsimon/logrusr/v2 v2.0.1 // indirect
 	github.com/bradleyfalzon/ghinstallation/v2 v2.0.4 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
@@ -29,45 +37,56 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
-	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
+	github.com/fsnotify/fsnotify v1.5.2 // indirect
 	github.com/fvbommel/sortorder v1.0.1 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
-	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
+	github.com/go-errors/errors v1.4.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-git/go-git/v5 v5.4.2 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
-	github.com/go-openapi/swag v0.19.14 // indirect
+	github.com/go-openapi/swag v0.19.15 // indirect
+	github.com/go-pg/pg/extra/pgdebug v0.2.0 // indirect
+	github.com/go-pg/pg/v10 v10.10.6 // indirect
+	github.com/go-pg/zerochecker v0.2.0 // indirect
 	github.com/go-redis/cache/v8 v8.4.2 // indirect
 	github.com/go-redis/redis/v8 v8.11.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.5.7 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/go-github/v41 v41.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.1.2 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/kcp-dev/apimachinery v0.0.0-20221003220612-a61d757411af // indirect
+	github.com/kcp-dev/controller-runtime-example v0.0.0-20220902160817-733db4e9d83a // indirect
+	github.com/kcp-dev/kcp/pkg/apis v0.9.0 // indirect
+	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
-	github.com/klauspost/compress v1.13.5 // indirect
+	github.com/klauspost/compress v1.14.2 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
-	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
@@ -77,60 +96,71 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.12.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.32.1 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/redhat-appstudio/application-api v0.0.0-20230331114710-7a895f1e2fbc // indirect
 	github.com/robfig/cron v1.2.0 // indirect
-	github.com/russross/blackfriday v1.5.2 // indirect
+	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cobra v1.5.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.7.1 // indirect
+	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc // indirect
+	github.com/vmihailenco/bufpool v0.1.11 // indirect
 	github.com/vmihailenco/go-tinylfu v0.2.1 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.4 // indirect
+	github.com/vmihailenco/tagparser v0.1.2 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
 	golang.org/x/exp v0.0.0-20210901193431-a062eea981d2 // indirect
-	golang.org/x/net v0.0.0-20220621193019-9d032be2e588 // indirect
+	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
+	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368 // indirect
+	google.golang.org/genproto v0.0.0-20220207185906-7721543eae58 // indirect
 	google.golang.org/grpc v1.45.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/api v0.24.2 // indirect
-	k8s.io/apiextensions-apiserver v0.24.2 // indirect
-	k8s.io/apiserver v0.24.2 // indirect
-	k8s.io/cli-runtime v0.24.2 // indirect
-	k8s.io/component-base v0.24.2 // indirect
-	k8s.io/component-helpers v0.24.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/apiextensions-apiserver v0.24.3 // indirect
+	k8s.io/apiserver v0.24.3 // indirect
+	k8s.io/cli-runtime v0.24.3 // indirect
+	k8s.io/component-base v0.24.3 // indirect
+	k8s.io/component-helpers v0.24.3 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-aggregator v0.24.2 // indirect
-	k8s.io/kube-openapi v0.0.0-20220627174259-011e075b9cb8 // indirect
+	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
 	k8s.io/kubectl v0.24.2 // indirect
 	k8s.io/kubernetes v1.24.2 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
-	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
+	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
+	mellium.im/sasl v0.2.1 // indirect
+	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/kustomize/api v0.11.4 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.6 // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 replace (
+
 	// All the rest replacements are related to ArgoCD
 	// See: https://github.com/argoproj/argo-cd/blob/81630e6d5075ac53ac60457b51343c2a09a666f4/go.mod#L251)
 	//
@@ -144,6 +174,8 @@ replace (
 	github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.2
 	github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/improbable-eng/grpc-web => github.com/improbable-eng/grpc-web v0.0.0-20181111100011-16092bd1d58a
+	github.com/redhat-appstudio/managed-gitops/backend-shared => ../../backend-shared
+	github.com/redhat-appstudio/managed-gitops/tests-e2e => ../../tests-e2e
 
 	// Avoid CVE-2022-28948
 	gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.1
@@ -174,4 +206,5 @@ replace (
 	k8s.io/mount-utils => k8s.io/mount-utils v0.24.2
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.24.2
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.24.2
+	sigs.k8s.io/controller-runtime => github.com/kcp-dev/controller-runtime v0.12.2-0.20220808200255-4b60fd66e5de
 )


### PR DESCRIPTION
#### Description:
- Instead of creating a new client whenever the `startNewStatusUpdateTimer()` is invoked, we reuse an existing client passed from the workspace event loop.  Thereby we can avoid multiple client objects escaping to the heap.
- Use a predicate in the secrets controllers to filter secrets of type: managed-environment.
- Test to verify memory usage.

#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-508
