### PR TITLE
Add application/component/environment labels to GitOpsDeployment resources

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
@@ -412,6 +412,11 @@ func generateExpectedGitOpsDeployment(component appstudioshared.BindingComponent
 		}
 	}
 
+	// Append labels to identify the Application, Component and Environment associated with this GitOpsDeployment
+	res.ObjectMeta.Labels[appstudioLabelKey+"/application"] = binding.Spec.Application
+	res.ObjectMeta.Labels[appstudioLabelKey+"/component"] = component.Name
+	res.ObjectMeta.Labels[appstudioLabelKey+"/environment"] = binding.Spec.Environment
+
 	// Ensures that this method only adds 'appstudio.openshift.io' labels
 	// - Note: If you remove this line, you need to search for other uses of 'removeNonAppStudioLabelsFromMap' in the
 	// code, as you may break the logic here.

--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
@@ -435,7 +435,7 @@ func limitLength(str string, logger logr.Logger) string {
 	if len(str) <= 63 {
 		return str
 	}
-	logger.Error(nil, "label value should be at most 63 characters", "value", str)
+	logger.Error(nil, "SEVERE: label value in SnapshotEnvironmentBinding should be at most 63 characters", "value", str)
 	return str[:63]
 }
 

--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller_test.go
@@ -432,7 +432,12 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			err = bindingReconciler.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
 			Expect(err).To(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels).ToNot(BeNil())
-			Expect(gitopsDeployment.ObjectMeta.Labels).To(Equal(map[string]string{appstudioLabelKey: "testing"}))
+			Expect(gitopsDeployment.ObjectMeta.Labels).To(Equal(map[string]string{
+				appstudioLabelKey:                  "testing",
+				appstudioLabelKey + "/application": binding.Spec.Application,
+				appstudioLabelKey + "/component":   binding.Spec.Components[0].Name,
+				appstudioLabelKey + "/environment": binding.Spec.Environment,
+			}))
 		})
 
 		It("should not append ASEB label without key appstudio.openshift.io into the GitopsDeployment Label", func() {
@@ -454,7 +459,11 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			err = bindingReconciler.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
 			Expect(err).To(BeNil())
 
-			Expect(gitopsDeployment.ObjectMeta.Labels).To(BeNil())
+			Expect(gitopsDeployment.ObjectMeta.Labels).To(Equal(map[string]string{
+				appstudioLabelKey + "/application": binding.Spec.Application,
+				appstudioLabelKey + "/component":   binding.Spec.Components[0].Name,
+				appstudioLabelKey + "/environment": binding.Spec.Environment,
+			}))
 		})
 
 		It("should update gitopsDeployment label if ASEB label gets updated", func() {
@@ -479,7 +488,12 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			err = bindingReconciler.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
 			Expect(err).To(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels).ToNot(BeNil())
-			Expect(gitopsDeployment.ObjectMeta.Labels).To(Equal(map[string]string{appstudioLabelKey: "testing"}))
+			Expect(gitopsDeployment.ObjectMeta.Labels).To(Equal(map[string]string{
+				appstudioLabelKey:                  "testing",
+				appstudioLabelKey + "/application": binding.Spec.Application,
+				appstudioLabelKey + "/component":   binding.Spec.Components[0].Name,
+				appstudioLabelKey + "/environment": binding.Spec.Environment,
+			}))
 
 			err = bindingReconciler.Get(ctx, types.NamespacedName{Namespace: binding.Namespace, Name: binding.Name}, binding)
 			Expect(err).To(Succeed())
@@ -498,7 +512,12 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			err = bindingReconciler.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
 			Expect(err).To(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels).ToNot(BeNil())
-			Expect(gitopsDeployment.ObjectMeta.Labels).To(Equal(map[string]string{appstudioLabelKey: "testing-update"}))
+			Expect(gitopsDeployment.ObjectMeta.Labels).To(Equal(map[string]string{
+				appstudioLabelKey:                  "testing-update",
+				appstudioLabelKey + "/application": binding.Spec.Application,
+				appstudioLabelKey + "/component":   binding.Spec.Components[0].Name,
+				appstudioLabelKey + "/environment": binding.Spec.Environment,
+			}))
 
 			err = bindingReconciler.Get(ctx, types.NamespacedName{Namespace: binding.Namespace, Name: binding.Name}, binding)
 			Expect(err).To(Succeed())
@@ -516,8 +535,12 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			By("verifying whether gitopsDeployment.ObjectMeta.Label `appstudio.openshift.io` is removed from gitopsDeployment")
 			err = bindingReconciler.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
 			Expect(err).To(BeNil())
-			Expect(gitopsDeployment.ObjectMeta.Labels).To(BeEmpty())
-			Expect(gitopsDeployment.ObjectMeta.Labels).ToNot(Equal(map[string]string{appstudioLabelKey: "testing-update"}))
+			Expect(gitopsDeployment.ObjectMeta.Labels).ToNot(BeEmpty())
+			Expect(gitopsDeployment.ObjectMeta.Labels).To(Equal(map[string]string{
+				appstudioLabelKey + "/application": binding.Spec.Application,
+				appstudioLabelKey + "/component":   binding.Spec.Components[0].Name,
+				appstudioLabelKey + "/environment": binding.Spec.Environment,
+			}))
 
 		})
 
@@ -545,7 +568,10 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			Expect(err).To(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels).ToNot(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels).To(Equal(map[string]string{
-				appstudioLabelKey: "testing",
+				appstudioLabelKey:                  "testing",
+				appstudioLabelKey + "/application": binding.Spec.Application,
+				appstudioLabelKey + "/component":   binding.Spec.Components[0].Name,
+				appstudioLabelKey + "/environment": binding.Spec.Environment,
 			}), "reconciler should only copy appstudio labels to the gitops deployment")
 
 			err = bindingReconciler.Get(ctx, types.NamespacedName{Namespace: binding.Namespace, Name: binding.Name}, binding)
@@ -566,7 +592,10 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			Expect(err).To(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels).ToNot(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels).To(Equal(map[string]string{
-				appstudioLabelKey: "testing-update",
+				appstudioLabelKey:                  "testing-update",
+				appstudioLabelKey + "/application": binding.Spec.Application,
+				appstudioLabelKey + "/component":   binding.Spec.Components[0].Name,
+				appstudioLabelKey + "/environment": binding.Spec.Environment,
 			}))
 
 			err = bindingReconciler.Get(ctx, types.NamespacedName{Namespace: binding.Namespace, Name: binding.Name}, binding)
@@ -586,8 +615,81 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 				"gitopsDeployment, but the non-appstudio label is still present")
 			err = bindingReconciler.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
 			Expect(err).To(BeNil())
+			Expect(gitopsDeployment.ObjectMeta.Labels).To(Equal(map[string]string{
+				appstudioLabelKey + "/application": binding.Spec.Application,
+				appstudioLabelKey + "/component":   binding.Spec.Components[0].Name,
+				appstudioLabelKey + "/environment": binding.Spec.Environment,
+			}))
+
+		})
+
+		It("should add labels identifying the application, environment and component to a new GitOpsDeployment's labels", func() {
+			By("creating SnapshotEnvironmentBinding CR")
+			err := bindingReconciler.Create(ctx, binding)
+			Expect(err).To(BeNil())
+
+			By("triggering Reconciler")
+			_, err = bindingReconciler.Reconcile(ctx, request)
+			Expect(err).To(BeNil())
+
+			By("fetching the GitOpsDeployment object to check if the GitOpsDeployment label field has been updated")
+			gitopsDeploymentKey := client.ObjectKey{
+				Namespace: binding.Namespace,
+				Name:      GenerateBindingGitOpsDeploymentName(*binding, binding.Spec.Components[0].Name),
+			}
+
+			gitopsDeployment := &apibackend.GitOpsDeployment{}
+			err = bindingReconciler.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
+			Expect(err).To(BeNil())
+			Expect(gitopsDeployment.ObjectMeta.Labels).ToNot(BeEmpty())
+			Expect(gitopsDeployment.ObjectMeta.Labels).To(Equal(map[string]string{
+				appstudioLabelKey + "/application": binding.Spec.Application,
+				appstudioLabelKey + "/component":   binding.Spec.Components[0].Name,
+				appstudioLabelKey + "/environment": binding.Spec.Environment,
+			}))
+		})
+
+		It("should add labels identifying the application, environment and component to an existing GitOpsDeployment's labels", func() {
+			By("creating the GitOpsDeployment by creating a SnapshotEnvironmentBinding CR and reconciling")
+			err := bindingReconciler.Create(ctx, binding)
+			Expect(err).To(BeNil())
+			_, err = bindingReconciler.Reconcile(ctx, request)
+			Expect(err).To(BeNil())
+			gitopsDeploymentKey := client.ObjectKey{
+				Namespace: binding.Namespace,
+				Name:      GenerateBindingGitOpsDeploymentName(*binding, binding.Spec.Components[0].Name),
+			}
+			gitopsDeployment := &apibackend.GitOpsDeployment{}
+			err = bindingReconciler.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
+			Expect(err).To(BeNil())
+			Expect(gitopsDeployment.ObjectMeta.Labels).ToNot(BeEmpty())
+
+			By("removing the labels from the GitOpsDeployment resource")
+			delete(gitopsDeployment.ObjectMeta.Labels, appstudioLabelKey+"/application")
+			delete(gitopsDeployment.ObjectMeta.Labels, appstudioLabelKey+"/component")
+			delete(gitopsDeployment.ObjectMeta.Labels, appstudioLabelKey+"/environment")
+			bindingReconciler.Update(ctx, gitopsDeployment)
+
+			By("check that the labels have really been removed")
+			gitopsDeployment = &apibackend.GitOpsDeployment{}
+			err = bindingReconciler.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
+			Expect(err).To(BeNil())
 			Expect(gitopsDeployment.ObjectMeta.Labels).To(BeEmpty())
 
+			By("triggering Reconciler")
+			_, err = bindingReconciler.Reconcile(ctx, request)
+			Expect(err).To(BeNil())
+
+			By("fetching the GitOpsDeployment object to check if the GitOpsDeployment label field has been updated correctly")
+			gitopsDeployment = &apibackend.GitOpsDeployment{}
+			err = bindingReconciler.Get(ctx, gitopsDeploymentKey, gitopsDeployment)
+			Expect(err).To(BeNil())
+			Expect(gitopsDeployment.ObjectMeta.Labels).ToNot(BeEmpty())
+			Expect(gitopsDeployment.ObjectMeta.Labels).To(Equal(map[string]string{
+				appstudioLabelKey + "/application": binding.Spec.Application,
+				appstudioLabelKey + "/component":   binding.Spec.Components[0].Name,
+				appstudioLabelKey + "/environment": binding.Spec.Environment,
+			}))
 		})
 
 	})

--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller_test.go
@@ -642,7 +642,8 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			delete(gitopsDeployment.ObjectMeta.Labels, appstudioLabelKey+"/application")
 			delete(gitopsDeployment.ObjectMeta.Labels, appstudioLabelKey+"/component")
 			delete(gitopsDeployment.ObjectMeta.Labels, appstudioLabelKey+"/environment")
-			bindingReconciler.Update(ctx, gitopsDeployment)
+			err = bindingReconciler.Update(ctx, gitopsDeployment)
+			Expect(err).To(BeNil())
 
 			By("check that the labels have really been removed")
 			gitopsDeployment = &apibackend.GitOpsDeployment{}

--- a/tests-e2e/Makefile
+++ b/tests-e2e/Makefile
@@ -33,7 +33,7 @@ help: ## Display this help.
 
 .PHONY: test
 test: ## Run E2E tests.
-	go test -v -p=1 -timeout=60m -race -count=1 -coverprofile=coverage.out ./...
+	go test -v -p=1 -timeout=100m -race -count=1 -coverprofile=coverage.out ./...
 	
 
 # go-get-tool will 'go install' any package $2 and install it to $1.

--- a/tests-e2e/core/core_suite_test.go
+++ b/tests-e2e/core/core_suite_test.go
@@ -16,10 +16,12 @@ var _ = BeforeSuite(func() {
 })
 
 func TestCore(t *testing.T) {
-	_, reporterConfig := GinkgoConfiguration()
+	suiteConfig, reporterConfig := GinkgoConfiguration()
 	// A test is "slow" if it takes longer than a few minutes
 	reporterConfig.SlowSpecThreshold = time.Duration(6 * time.Minute)
 
+	suiteConfig.Timeout = time.Duration(90 * time.Minute)
+
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Core Suite", reporterConfig)
+	RunSpecs(t, "Core Suite", suiteConfig, reporterConfig)
 }

--- a/tests-e2e/core/snapshotenvironmentbinding_test.go
+++ b/tests-e2e/core/snapshotenvironmentbinding_test.go
@@ -620,6 +620,72 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 			Eventually(gitopsDeployment, "2m", "10s").Should(gitopsDeplFixture.HaveLabel("appstudio.openshift.io/environment", binding.Spec.Environment))
 		})
 
+		It("Should ensure the associated GitOpsDeployment adds back the labels identifying the application, component and environment if they are removed", func() {
+			By("Create SnapshotEnvironmentBindingResource")
+
+			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
+
+			binding := buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
+			err = k8s.Create(&binding, k8sClient)
+			Expect(err).To(Succeed())
+
+			By("Update Status field of SnapshotEnvironmentBindingResource")
+			// Update the status field
+			err = buildAndUpdateBindingStatus(binding.Spec.Components,
+				"https://github.com/redhat-appstudio/managed-gitops", "main", "adcda66",
+				[]string{"resources/test-data/component-based-gitops-repository/components/componentA/overlays/staging"}, &binding)
+			Expect(err).To(Succeed())
+
+			By("Verify that Status.GitOpsDeployments field of Binding is having Component and GitOpsDeployment name.")
+			gitOpsDeploymentName := appstudiocontroller.GenerateBindingGitOpsDeploymentName(binding, binding.Spec.Components[0].Name)
+
+			expectedGitOpsDeployments := []appstudiosharedv1.BindingStatusGitOpsDeployment{{
+				ComponentName:                binding.Spec.Components[0].Name,
+				GitOpsDeployment:             gitOpsDeploymentName,
+				GitOpsDeploymentSyncStatus:   string(managedgitopsv1alpha1.SyncStatusCodeSynced),
+				GitOpsDeploymentHealthStatus: string(managedgitopsv1alpha1.HeathStatusCodeHealthy),
+				GitOpsDeploymentCommitID:     "CurrentlyIDIsUnknownInTestcase",
+			}}
+
+			Eventually(binding, "2m", "1s").Should(bindingFixture.HaveGitOpsDeploymentsWithStatusProperties(expectedGitOpsDeployments))
+
+			By("Verify whether `gitopsDeployment.ObjectMeta.Labels` contains labels identifying the application, component and environment")
+			gitopsDeployment := managedgitopsv1alpha1.GitOpsDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gitOpsDeploymentName,
+					Namespace: binding.Namespace,
+				},
+			}
+			err = k8s.Get(&gitopsDeployment, k8sClient)
+			Expect(err).To(BeNil())
+			Eventually(gitopsDeployment, "2m", "10s").Should(gitopsDeplFixture.HaveLabel("appstudio.openshift.io/application", binding.Spec.Application))
+			Eventually(gitopsDeployment, "2m", "10s").Should(gitopsDeplFixture.HaveLabel("appstudio.openshift.io/component", binding.Spec.Components[0].Name))
+			Eventually(gitopsDeployment, "2m", "10s").Should(gitopsDeplFixture.HaveLabel("appstudio.openshift.io/environment", binding.Spec.Environment))
+
+			By("Removing the labels")
+			err = k8s.Get(&gitopsDeployment, k8sClient)
+			Expect(err).To(BeNil())
+			delete(gitopsDeployment.ObjectMeta.Labels, "appstudio.openshift.io/application")
+			delete(gitopsDeployment.ObjectMeta.Labels, "appstudio.openshift.io/component")
+			delete(gitopsDeployment.ObjectMeta.Labels, "appstudio.openshift.io/environment")
+			err = k8s.Update(&gitopsDeployment, k8sClient)
+			Expect(err).To(BeNil())
+
+			By("Verifying the labels have been added back")
+			gitopsDeployment = managedgitopsv1alpha1.GitOpsDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gitOpsDeploymentName,
+					Namespace: binding.Namespace,
+				},
+			}
+			err = k8s.Get(&gitopsDeployment, k8sClient)
+			Expect(err).To(BeNil())
+			Eventually(gitopsDeployment, "2m", "10s").Should(gitopsDeplFixture.HaveLabel("appstudio.openshift.io/application", binding.Spec.Application))
+			Eventually(gitopsDeployment, "2m", "10s").Should(gitopsDeplFixture.HaveLabel("appstudio.openshift.io/component", binding.Spec.Components[0].Name))
+			Eventually(gitopsDeployment, "2m", "10s").Should(gitopsDeplFixture.HaveLabel("appstudio.openshift.io/environment", binding.Spec.Environment))
+		})
+
 		It("Should append ASEB labels with key `appstudio.openshift.io` to GitopsDeployment label", func() {
 			By("Create SnapshotEnvironmentBindingResource")
 


### PR DESCRIPTION
#### Description:
- Added labels to GitOpsDeployment resources to identify the associated application, component and environment

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-497

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
