### PR TITLE
Update backward compatibility test to use 'go test' instead of ginkgo 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,8 +288,8 @@ test-e2e-kcp-virtual-workspace: ## Test E2E against KCP virtual workspaces
 
 ### --- CI Tests ---
 
-check-backward-compatability: ##  test executed from OpenShift CI
-	ginkgo -focus "GitOpsDeployment Managed Environment E2E tests Create a new GitOpsDeployment targeting a ManagedEnvironment should be healthy and have synced status, and resources should be deployed, when deployed with a ManagedEnv"  -r -v tests-e2e/core
+check-backward-compatibility: ##  test executed from OpenShift CI
+	cd $(MAKEFILE_ROOT)/tests-e2e && make test-backward-compatability
 
 
 ### --- Utilities for other makefile targets ---

--- a/tests-e2e/Makefile
+++ b/tests-e2e/Makefile
@@ -69,3 +69,7 @@ gosec: go_sec ## Run the gosec tool
 .PHONY: clean
 clean: ## Remove the vendor and bin folders
 	rm -rf vendor/ bin/
+
+#required for test execution from OpenShift CI
+test-backward-compatibility:
+	go test ./core -v -ginkgo.focus "GitOpsDeployment Managed Environment E2E tests Create a new GitOpsDeployment targeting a ManagedEnvironment should be healthy and have synced status, and resources should be deployed, when deployed with a ManagedEnv"


### PR DESCRIPTION
#### Description:
Update the 'check-backward-compatibility' target to use 'go test' instead of 'ginkgo focus' as Ginkgo is not installed on OpenshiftCI

#### Link to JIRA Story (if applicable):
https://issues.redhat.com/browse/GITOPSRVCE-453
