### PR TITLE
Updates to ManagedEnv API documentation and Go struct comments

### DIFF
--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_types.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_types.go
@@ -24,14 +24,54 @@ const (
 	ManagedEnvironmentStatusConnectionInitializationSucceeded = "ConnectionInitializationSucceeded"
 )
 
-// GitOpsDeploymentManagedEnvironmentSpec defines the desired state of GitOpsDeploymentManagedEnvironment
+// The GitOpsDeploymentManagedEnvironment CR describes a remote cluster which the GitOps Service will deploy to, via Argo CD.
+// This resource references a Secret resource, of type managed-gitops.redhat.com/managed-environment, that contains the cluster credentials.
+// The Secret should contain credentials to a ServiceAccount/User account on the target cluster.
+// This is referred to as the Argo CD 'ServiceAccount' below.
 type GitOpsDeploymentManagedEnvironmentSpec struct {
-	APIURL                     string   `json:"apiURL"`
-	ClusterCredentialsSecret   string   `json:"credentialsSecret"`
-	AllowInsecureSkipTLSVerify bool     `json:"allowInsecureSkipTLSVerify"`
-	CreateNewServiceAccount    bool     `json:"createNewServiceAccount,omitempty"`
-	Namespaces                 []string `json:"namespaces,omitempty"`
-	ClusterResources           bool     `json:"clusterResources,omitempty"`
+
+	// APIURL is the URL of the cluster to connect to
+	APIURL string `json:"apiURL"`
+
+	// ClusterCredentialsSecret is a reference to a Secret that contains cluster connection details. The cluster details should be in the form of a kubeconfig file.
+	ClusterCredentialsSecret string `json:"credentialsSecret"`
+
+	// AllowInsecureSkipTLSVerify controls whether Argo CD will accept a Kubernetes API URL with untrusted-TLS certificate.
+	// Optional: If true, the GitOps Service will allow Argo CD to connect to the specified cluster even if it is using an invalid or self-signed TLS certificate.
+	// Defaults to false.
+	AllowInsecureSkipTLSVerify bool `json:"allowInsecureSkipTLSVerify"`
+
+	// CreateNewServiceAccount controls whether Argo CD will use the ServiceAccount provided by the user in the Secret, or if a new ServiceAccount
+	// should be created.
+	//
+	// Optional, default to false.
+	//
+	// - If true, the GitOps Service will automatically create a ServiceAccount/ClusterRole/ClusterRoleBinding on the target cluster,
+	//   using the credentials provided by the user in the secret.
+	//   - Argo CD will then be configured to deploy with that new ServiceAccount.
+	//
+	// - Default: If false, it is assumed that the credentials provided by the user in the Secret are for a ServiceAccount on the cluster, and
+	//   Argo CD will be configred to use the ServiceAccount referenced by the Secret of the user. No new ServiceAccount will be created.
+	//   - This should be used, for example, when the ServiceAccount Argo CD is using will not full cluster access (*/*/* at cluster scope)
+	CreateNewServiceAccount bool `json:"createNewServiceAccount,omitempty"`
+
+	// Namespaces allows one to restrict indicate which Namespaces the Secret's ServiceAccount has access to.
+	//
+	// Optional, defaults to empty. If empty, it is assumed that the ServiceAccount has access to all Namespaces.
+	//
+	// The ServiceAccount that GitOps Service/Argo CD uses to deploy may not have access to all of the Namespaces on a cluster.
+	// If not specified, it is assumed that the Argo CD ServiceAccount has read/write at cluster-scope.
+	// - If you are familiar with Argo CD: this field is equivalent to the field of the same name in the Argo CD Cluster Secret.
+	Namespaces []string `json:"namespaces,omitempty"`
+
+	// ClusterResources is used in conjuction with the Namespace field.
+	// If the .spec.namespaces field is non-empty, this field will be used to determine whether Argo CD should
+	// attempt to manage cluster-scoped resources.
+	// - If .spec.namespaces field is empty, this field is not used.
+	// - If you are familiar with Argo CD: this field is equivalent to the field of the same name in the Argo CD Cluster Secret.
+	//
+	// Optional, default to false.
+	ClusterResources bool `json:"clusterResources,omitempty"`
 }
 
 type AllowInsecureSkipTLSVerify bool

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_types.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_types.go
@@ -52,10 +52,10 @@ type GitOpsDeploymentManagedEnvironmentSpec struct {
 	//
 	// - Default: If false, it is assumed that the credentials provided by the user in the Secret are for a ServiceAccount on the cluster, and
 	//   Argo CD will be configred to use the ServiceAccount referenced by the Secret of the user. No new ServiceAccount will be created.
-	//   - This should be used, for example, when the ServiceAccount Argo CD is using will not full cluster access (*/*/* at cluster scope)
+	//   - This should be used, for example, when the ServiceAccount Argo CD does not have full cluster access (*/*/* at cluster scope)
 	CreateNewServiceAccount bool `json:"createNewServiceAccount,omitempty"`
 
-	// Namespaces allows one to restrict indicate which Namespaces the Secret's ServiceAccount has access to.
+	// Namespaces allows one to indicate which Namespaces the Secret's ServiceAccount has access to.
 	//
 	// Optional, defaults to empty. If empty, it is assumed that the ServiceAccount has access to all Namespaces.
 	//
@@ -67,7 +67,7 @@ type GitOpsDeploymentManagedEnvironmentSpec struct {
 	// ClusterResources is used in conjuction with the Namespace field.
 	// If the .spec.namespaces field is non-empty, this field will be used to determine whether Argo CD should
 	// attempt to manage cluster-scoped resources.
-	// - If .spec.namespaces field is empty, this field is not used.
+	// - If .spec.namespaces field is empty, this field is ignored.
 	// - If you are familiar with Argo CD: this field is equivalent to the field of the same name in the Argo CD Cluster Secret.
 	//
 	// Optional, default to false.

--- a/backend-shared/config/crd/bases/managed-gitops.redhat.com_gitopsdeploymentmanagedenvironments.yaml
+++ b/backend-shared/config/crd/bases/managed-gitops.redhat.com_gitopsdeploymentmanagedenvironments.yaml
@@ -35,20 +35,62 @@ spec:
           metadata:
             type: object
           spec:
-            description: GitOpsDeploymentManagedEnvironmentSpec defines the desired
-              state of GitOpsDeploymentManagedEnvironment
+            description: The GitOpsDeploymentManagedEnvironment CR describes a remote
+              cluster which the GitOps Service will deploy to, via Argo CD. This resource
+              references a Secret resource, of type managed-gitops.redhat.com/managed-environment,
+              that contains the cluster credentials. The Secret should contain credentials
+              to a ServiceAccount/User account on the target cluster. This is referred
+              to as the Argo CD 'ServiceAccount' below.
             properties:
               allowInsecureSkipTLSVerify:
+                description: 'AllowInsecureSkipTLSVerify controls whether Argo CD
+                  will accept a Kubernetes API URL with untrusted-TLS certificate.
+                  Optional: If true, the GitOps Service will allow Argo CD to connect
+                  to the specified cluster even if it is using an invalid or self-signed
+                  TLS certificate. Defaults to false.'
                 type: boolean
               apiURL:
+                description: APIURL is the URL of the cluster to connect to
                 type: string
               clusterResources:
+                description: "ClusterResources is used in conjuction with the Namespace
+                  field. If the .spec.namespaces field is non-empty, this field will
+                  be used to determine whether Argo CD should attempt to manage cluster-scoped
+                  resources. - If .spec.namespaces field is empty, this field is ignored.
+                  - If you are familiar with Argo CD: this field is equivalent to
+                  the field of the same name in the Argo CD Cluster Secret. \n Optional,
+                  default to false."
                 type: boolean
               createNewServiceAccount:
+                description: "CreateNewServiceAccount controls whether Argo CD will
+                  use the ServiceAccount provided by the user in the Secret, or if
+                  a new ServiceAccount should be created. \n Optional, default to
+                  false. \n - If true, the GitOps Service will automatically create
+                  a ServiceAccount/ClusterRole/ClusterRoleBinding on the target cluster,
+                  \  using the credentials provided by the user in the secret.   -
+                  Argo CD will then be configured to deploy with that new ServiceAccount.
+                  \n - Default: If false, it is assumed that the credentials provided
+                  by the user in the Secret are for a ServiceAccount on the cluster,
+                  and   Argo CD will be configred to use the ServiceAccount referenced
+                  by the Secret of the user. No new ServiceAccount will be created.
+                  \  - This should be used, for example, when the ServiceAccount Argo
+                  CD does not have full cluster access (*/*/* at cluster scope)"
                 type: boolean
               credentialsSecret:
+                description: ClusterCredentialsSecret is a reference to a Secret that
+                  contains cluster connection details. The cluster details should
+                  be in the form of a kubeconfig file.
                 type: string
               namespaces:
+                description: "Namespaces allows one to indicate which Namespaces the
+                  Secret's ServiceAccount has access to. \n Optional, defaults to
+                  empty. If empty, it is assumed that the ServiceAccount has access
+                  to all Namespaces. \n The ServiceAccount that GitOps Service/Argo
+                  CD uses to deploy may not have access to all of the Namespaces on
+                  a cluster. If not specified, it is assumed that the Argo CD ServiceAccount
+                  has read/write at cluster-scope. - If you are familiar with Argo
+                  CD: this field is equivalent to the field of the same name in the
+                  Argo CD Cluster Secret."
                 items:
                   type: string
                 type: array

--- a/backend/eventloop/workspace_resource_event_loop.go
+++ b/backend/eventloop/workspace_resource_event_loop.go
@@ -196,7 +196,7 @@ func internalProcessWorkspaceResourceMessage(ctx context.Context, msg workspaceR
 		}
 
 		// Request that the shared resource loop handle the GitOpsDeploymentRepositoryCredential resource:
-		// - If the GitOpsDeploymentRepositoryCredential doesn't exist, delete the corsponding database table
+		// - If the GitOpsDeploymentRepositoryCredential doesn't exist, delete the corresponding database table
 		// - If the GitOpsDeploymentRepositoryCredential does exist, but not in the DB, then create a RepositoryCredential DB entry
 		// - If the GitOpsDeploymentRepositoryCredential does exist, and also in the DB, then compare and change a RepositoryCredential DB entry
 		// Then, in all 3 cases, create an Operation to update the cluster-agent

--- a/docs/api.md
+++ b/docs/api.md
@@ -189,7 +189,7 @@ spec:
   # Optional: the ServiceAccount that GitOps Service/Argo CD uses to deploy may not have access to all of the Namespaces on a cluster
   # If not specified, it is assumed that the Argo CD ServiceAccount has read/write at cluster-scope.
   # - If you are familiar with Argo CD: this field is equivalent to the field of the same name in the Argo CD Cluster Secret.
-	namespaces:
+  namespaces:
     - bank-loan-app
     - bank-account-app
 
@@ -197,7 +197,7 @@ spec:
   # attempt to manage cluster-scoped resources.
   # - If .spec.namespaces field is empty, this field is not used.
   # - If you are familiar with Argo CD: this field is equivalent to the field of the same name in the Argo CD Cluster Secret.
-	clusterResources: false
+  clusterResources: false
 
 ---
 # The GitOpsDeploymentManagedEnvironment references a Secret, containing the connection information

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,12 +5,12 @@ This document describes the APIs supported by the GitOps Service. The examples p
 
 The K8s resource *Go structs* defined in the `managed-gitops` repository, the `application-api` repository, and the corresponding CustomResourceDefinitions (CRDs), are the canonical representations of the current state of this API. This document flows downstream from those.
 
-## Core vs Stonesoup Environment APIs
+## Core vs App Studio Environment APIs
 
-The Stonesoup Environment APIs implement (opinionated) concepts and APIs that are specific to Stonesoup, including `Environment`s, `Application`s, and `Component`s.
-- Applications and Components are examples of Stonesoup-specific concepts that relate to how an application is composed, and are primarily reconciled by the [application-service](https://github.com/redhat-appstudio/application-service) component.
-- Stonesoup Environment APIs implement promotion of application versions between environments, via APIs such as `Environment`, `Snapshot`, and `SnapshotEnvironmentBinding`.
-- Stonesoup API resources are translated by the Stonesoup GitOps Service controllers into one or more Core GitOps Service API resources. For example:
+The App Studio Environment APIs implement (opinionated) concepts and APIs that are specific to App Studio, including `Environment`s, `Application`s, and `Component`s.
+- Applications and Components are examples of App-Studio-specific concepts that relate to how an application is composed, and are primarily reconciled by the [application-service](https://github.com/redhat-appstudio/application-service) component.
+- App Studio Environment APIs implement promotion of application versions between environments, via APIs such as `Environment`, `Snapshot`, and `SnapshotEnvironmentBinding`.
+- App Studio API resources are translated by the AppStudio GitOps Service controllers into one or more Core GitOps Service API resources. For example:
     - A `SnapshotEnvironmentBinding` is reconciled into one or more `GitOpsDeployments`.
     - A `Environment` is usually reconciled into a `GitOpsDeploymentManagedEnvironment` 
 
@@ -171,7 +171,34 @@ spec:
 
   # Optional: If true, the GitOps Service will allow Argo CD to connect to the specified cluster
   # even if it is using an invalid or self-signed TLS certificate.
+  # Defaults to false.
   allowInsecureSkipTLSVerify: false
+
+  # Optional: Controls whether Argo CD will use the ServiceAccount provided by the user in the Secret, or if a new ServiceAccount
+  # should be created.
+  # 
+  # - If true, the GitOps Service will automatically create a ServiceAccount/ClusterRole/ClusterRoleBinding on the target cluster,
+  #   using the credentials provided by the user in the secret. 
+  #   - Argo CD will then be configured to deploy with that new ServiceAccount.
+  #
+  # - Default: If false, it is assumed that the credentials provided by the user in the Secret are for a ServiceAccount on the cluster, and
+  #   Argo CD will be configred to use the ServiceAccount referenced by the Secret of the user. No new ServiceAccount will be created.
+  #   - This should be used, for example, when the ServiceAccount Argo CD is using will not full cluster access (*/*/* at cluster scope)
+  createNewServiceAccount: false
+
+  # Optional: the ServiceAccount that GitOps Service/Argo CD uses to deploy may not have access to all of the Namespaces on a cluster
+  # If not specified, it is assumed that the Argo CD ServiceAccount has read/write at cluster-scope.
+  # - If you are familiar with Argo CD: this field is equivalent to the field of the same name in the Argo CD Cluster Secret.
+	namespaces:
+    - bank-loan-app
+    - bank-account-app
+
+  # Optional: If the .spec.namespaces field is non-empty, this field will be used to determine whether Argo CD should 
+  # attempt to manage cluster-scoped resources.
+  # - If .spec.namespaces field is empty, this field is not used.
+  # - If you are familiar with Argo CD: this field is equivalent to the field of the same name in the Argo CD Cluster Secret.
+	clusterResources: false
+
 ---
 # The GitOpsDeploymentManagedEnvironment references a Secret, containing the connection information
 # - Kubeconfig credentials for the target cluster (as a Secret)
@@ -285,18 +312,18 @@ This resource has no corresponding Argo CD CR equivalent: with Argo CD, a manual
 
 See the [GitOpsDeploymentSyncRun API reference](https://redhat-appstudio.github.io/book/ref/gitops.html#gitopsdeploymentsyncrun) for details of other fields.
 
-## GitOps Service: Stonesoup Environment APIs
+## GitOps Service: App Studio Environment APIs
 
-The Stonesoup Environment API is based on the [Application](https://redhat-appstudio.github.io/book/ref/application-environment-api.html#application), and [Component](https://redhat-appstudio.github.io/book/ref/application-environment-api.html#component) APIs, which are primarily handled by the [application-service](https://github.com/redhat-appstudio/application-service) component. 
+The App Studio Environment API is based on the [Application](https://redhat-appstudio.github.io/book/ref/application-environment-api.html#application), and [Component](https://redhat-appstudio.github.io/book/ref/application-environment-api.html#component) APIs, which are primarily handled by the [application-service](https://github.com/redhat-appstudio/application-service) component. 
 - These APIs are opinionated representations of the constituent parts of a user's application: a application (e.g. a loan application of a bank) contains multiple components (e.g. Node frontend, Java backend, Postgresql database).
 
-The Stonesoup Environment APIs -- which are simultaneously reconciled by multiple Stonesoup components -- are all related to provisioning or deploying K8s resources to external environments, such as external K8s clusters/namespaces or local namespaces.
+The App Studio Environment APIs -- which are simultaneously reconciled by multiple App Studio components -- are all related to provisioning or deploying K8s resources to external environments, such as external K8s clusters/namespaces or local namespaces.
 
 ### Environment
 
 Environment describes a target deployment location for deployments of Kubernetes resources, with the source for those Kubernetes resources coming from a GitOps repository.
 
-An Environment could be namespace on a Stonesoup cluster, an Environment could be a full remote cluster, or an Environment could be another type of environment that is not yet implemented as of this writing.
+An Environment could be namespace on an App Studio cluster, an Environment could be a full remote cluster, or an Environment could be another type of environment that is not yet implemented as of this writing.
 
 
 ```yaml
@@ -387,7 +414,7 @@ spec:
   artifacts:
     # (...) - 
 status:
-  # Conditions field is not currently used by GitOps Service, but is used by other Stonesoup components.
+  # Conditions field is not currently used by GitOps Service, but is used by other App Studio components.
   conditions:
     - # (...)
 ```
@@ -486,7 +513,7 @@ See the [SnapshotEnvironmentBinding API reference](https://redhat-appstudio.gith
 
 PromotionRun currently only supports manual promotion, but was originally conceived to handle both automated and manual promotion. 
 
-Promotion via PromotionRun CR was part of the original Environment API design, but this CR may no longer be required in a Stonesoup, post-Appstudio world, where promotion is primarily handled by HACBS components.
+Promotion via PromotionRun CR was part of the original Environment API design, but this CR may no longer be required, as promotion is primarily handled by HACBS components.
 
 ```yaml
 apiVersion: appstudio.redhat.com/v1alpha1

--- a/docs/api.md
+++ b/docs/api.md
@@ -183,7 +183,7 @@ spec:
   #
   # - Default: If false, it is assumed that the credentials provided by the user in the Secret are for a ServiceAccount on the cluster, and
   #   Argo CD will be configred to use the ServiceAccount referenced by the Secret of the user. No new ServiceAccount will be created.
-  #   - This should be used, for example, when the ServiceAccount Argo CD is using will not full cluster access (*/*/* at cluster scope)
+  #   - This should be used, for example, when the ServiceAccount Argo CD does not have full cluster access (*/*/* at cluster scope)
   createNewServiceAccount: false
 
   # Optional: the ServiceAccount that GitOps Service/Argo CD uses to deploy may not have access to all of the Namespaces on a cluster
@@ -195,7 +195,7 @@ spec:
 
   # Optional: If the .spec.namespaces field is non-empty, this field will be used to determine whether Argo CD should 
   # attempt to manage cluster-scoped resources.
-  # - If .spec.namespaces field is empty, this field is not used.
+  # - If .spec.namespaces field is empty, this field is ignored.
   # - If you are familiar with Argo CD: this field is equivalent to the field of the same name in the Argo CD Cluster Secret.
   clusterResources: false
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -4,11 +4,11 @@ There are 4 separated, tightly-coupled components:
 
 - [Backend]: responsible for watching and determining the user's intent via the `GitOpsDeployent*` API resources, next the backend component updates the database with the users intent, and finally it informs the [Cluster-Agent] which will act on the user's intent.
 - [Cluster-Agent]: responsible ensuring that Argo CD state is up-to-date with the user intent (as defined in the database). Or, said another way, the cluster-agent component ensures that Argo CD resources ([ArgoCD Application CR]), and Cluster/Repository `Secret`s, are configured to be consistent with user intent.
-- [App Studio Controller]: Responsible for implementing the Stonesoup Environment API (see [API doc for details](api.md)).
+- [App Studio Controller]: Responsible for implementing the App Studio Environment API (see [API doc for details](api.md)).
 - [Backend Shared]: Contains code that is shared among the rest of the components. This is where shared utility code lives, such as GitOpsDeployment resource Go types, database Go types, and database access functionality. Including code within this component ensures it is not duplicated within the other components.
 
 There is also a fifth component, which lives in a separate GitHub repository:
-- [application-api]: defines the public API of GitOps Service 'appstudio-controller' component (e.g the Environment API), and the Stonesoup 'application-service' component.
+- [application-api]: defines the public API of GitOps Service 'appstudio-controller' component (e.g the Environment API), and the App Studio 'application-service' component.
 
 For detailed step-by-step guide on how each component works, check the `README` file of each individual component.
 


### PR DESCRIPTION
#### Description:
- No functional code changes, just comments and doc.
- Tweaks to the `GitOpsDeploymentManagedEnvironment` API documentation and the corresponding comments in the Go structs.
- I also renamed Stonesoup -> App Studio, since App Studio is the official name for open source upstream project (with RHTAP being the downstream product)

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
