### PR TITLE
fix typo reference to '/tests-e2e && make test-backward-compatibility'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,7 @@ test-e2e-kcp-virtual-workspace: ## Test E2E against KCP virtual workspaces
 ### --- CI Tests ---
 
 check-backward-compatibility: ##  test executed from OpenShift CI
-	cd $(MAKEFILE_ROOT)/tests-e2e && make test-backward-compatability
+	cd $(MAKEFILE_ROOT)/tests-e2e && make test-backward-compatibility
 
 
 ### --- Utilities for other makefile targets ---


### PR DESCRIPTION
#### Description:
Correct typo 'compatibility'

#### Link to JIRA Story (if applicable):

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
https://issues.redhat.com/browse/GITOPSRVCE-456
