### PR TITLE
Fixed manifests to use hardcoded DB name instead of postgres database name from env

### DIFF
--- a/manifests-v1/database-init/job.yaml
+++ b/manifests-v1/database-init/job.yaml
@@ -27,7 +27,7 @@ spec:
 
         env:
           - name: POSTGRES_DB
-            value: postgresql://gitops-postgresql-staging:5432/{{ env "POSTGRESQL_DATABASE" }}
+            value: postgresql://gitops-postgresql-staging:5432/postgres
           - name: POSTGRESQL_PORT_NUMBER
             value: "5432"
           - name: POSTGRESQL_VOLUME_DIR

--- a/manifests-v1/postgresql-staging/old-bitnami-yaml/values.yaml
+++ b/manifests-v1/postgresql-staging/old-bitnami-yaml/values.yaml
@@ -1,5 +1,5 @@
 values.yaml:
-  postgresqlDatabase: ${POSTGRESQL_DATABASE}
+  postgresqlDatabase: postgres
   postgresqlUsername: postgres
   postgresqlPassword: gitops
 

--- a/manifests-v1/postgresql-staging/postgresql-staging.yaml
+++ b/manifests-v1/postgresql-staging/postgresql-staging.yaml
@@ -107,7 +107,7 @@ spec:
               memory: 256Mi
           env:
             - name: POSTGRESQL_DATABASE
-              value: ${POSTGRESQL_DATABASE}
+              value: postgres
             - name: POSTGRESQL_USER
               value: postgres
             - name: POSTGRESQL_PASSWORD

--- a/manifests/base/postgresql-staging/postgresql-staging.yaml
+++ b/manifests/base/postgresql-staging/postgresql-staging.yaml
@@ -107,7 +107,7 @@ spec:
               memory: 256Mi
           env:
             - name: POSTGRESQL_DATABASE
-              value: ${POSTGRESQL_DATABASE}
+              value: postgres
             - name: POSTGRESQL_USER
               value: postgres
             - name: POSTGRESQL_PASSWORD


### PR DESCRIPTION
#### Description:
Revert the changes done to postgres related manifest as part of the PR https://github.com/redhat-appstudio/managed-gitops/pull/418. These changes broke the existing installation in staging environment as the postgresql pods never reached the ready state.

The readiness probe was failing with the following error
```
sh-4.4$ /usr/libexec/check-container      
pg_isready: error: too many command-line arguments (first is "0")
Try "pg_isready --help" for more information.
sh-4.4$ echo $?
3
```

![image](https://user-images.githubusercontent.com/6103351/233617447-5c8902a8-7cf9-45f2-a451-7ba39c4ee8f1.png)
![image](https://user-images.githubusercontent.com/6103351/233617486-261d033b-3179-4037-aa26-9a6aa8d9e42a.png)

#### Link to JIRA Story (if applicable):

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
