### PR TITLE
Add namespaces and clusterResources fields to the app studio Environment API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TAG ?= latest
 BASE_IMAGE ?= gitops-service
 USERNAME ?= redhat-appstudio
 IMG ?= quay.io/${USERNAME}/${BASE_IMAGE}:${TAG}
-APPLICATION_API_COMMIT ?= 394e8c127f031990838397fcb2d1e10110b2e7ae
+APPLICATION_API_COMMIT ?= f25d47ce749967013a7f13dcb9e65ede36b96f18
 
 # Default values match the their respective deployments in staging/production environment for GitOps Service, otherwise the E2E will fail.
 ARGO_CD_NAMESPACE ?= gitops-service-argocd

--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
@@ -427,6 +427,14 @@ func generateDesiredResource(ctx context.Context, env appstudioshared.Environmen
 		return nil, nil
 	}
 
+	if env.Spec.UnstableConfigurationFields != nil {
+		manageEnvDetails.ClusterResources = env.Spec.UnstableConfigurationFields.ClusterResources
+
+		// Make a copy of the Environment's namespaces field
+		size := len(env.Spec.UnstableConfigurationFields.Namespaces)
+		manageEnvDetails.Namespaces = append(make([]string, 0, size), env.Spec.UnstableConfigurationFields.Namespaces...)
+	}
+
 	// 1) Retrieve the secret that the Environment is pointing to
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/appstudio-controller/go.mod
+++ b/appstudio-controller/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20230417235430-8258a3281250
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.20.1
-	github.com/redhat-appstudio/application-api v0.0.0-20230418144704-93276b7c779d
+	github.com/redhat-appstudio/application-api v0.0.0-20230421113855-f25d47ce7499
 	github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0
 	k8s.io/apimachinery v0.25.0
 	k8s.io/client-go v0.25.0

--- a/appstudio-controller/go.sum
+++ b/appstudio-controller/go.sum
@@ -354,10 +354,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/redhat-appstudio/application-api v0.0.0-20230421113855-f25d47ce7499 h1:cOr4QX/0d+QZ80ef7wjXRsGm7Bnr5RCapTqTPKqgRao=
 github.com/redhat-appstudio/application-api v0.0.0-20230421113855-f25d47ce7499/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
-github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=

--- a/appstudio-controller/go.sum
+++ b/appstudio-controller/go.sum
@@ -354,8 +354,10 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/redhat-appstudio/application-api v0.0.0-20230418144704-93276b7c779d h1:PExij4tPAspKUU1hlV64swFgZBqsnVL2EG43rIpdT8o=
-github.com/redhat-appstudio/application-api v0.0.0-20230418144704-93276b7c779d/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
+github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/redhat-appstudio/application-api v0.0.0-20230421113855-f25d47ce7499 h1:cOr4QX/0d+QZ80ef7wjXRsGm7Bnr5RCapTqTPKqgRao=
+github.com/redhat-appstudio/application-api v0.0.0-20230421113855-f25d47ce7499/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
+github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=

--- a/manifests/base/crd/overlays/local-dev/kustomization.yaml
+++ b/manifests/base/crd/overlays/local-dev/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/redhat-appstudio/application-api/config/crd?ref=7a48b1d4c860ab4670e14e2f5e7a6f7ffa92043e
+- https://github.com/redhat-appstudio/application-api/config/crd?ref=f25d47ce749967013a7f13dcb9e65ede36b96f18
 - https://github.com/codeready-toolchain/host-operator/config/crd?ref=826d3d5928fefa0105852bda895d326abefe992d
 - ../../base

--- a/tests-e2e/fixture/managedenvironment/fixture.go
+++ b/tests-e2e/fixture/managedenvironment/fixture.go
@@ -91,3 +91,57 @@ func HaveCredentials(expectedEnvSpec managedgitopsv1alpha1.GitOpsDeploymentManag
 		return res
 	}, BeTrue())
 }
+
+// HaveClusterResources checks if the ClusterResources field of Environment is equal to clusterResouces.
+func HaveClusterResources(clusterResouces bool) matcher.GomegaMatcher {
+	return WithTransform(func(menv managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment) bool {
+		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+		Expect(err).To(BeNil())
+
+		k8sClient, err := fixture.GetKubeClient(config)
+		if err != nil {
+			fmt.Println(k8s.K8sClientError, err)
+			return false
+		}
+
+		err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&menv), &menv)
+		if err != nil {
+			fmt.Println(k8s.K8sClientError, err)
+			return false
+		}
+
+		res := clusterResouces == menv.Spec.ClusterResources
+
+		fmt.Println("HaveClusterResources:", res, "/ Expected:", clusterResouces, "/ Actual:", menv.Spec.ClusterResources)
+
+		return res
+
+	}, BeTrue())
+}
+
+// HaveNamespaces checks if the HaveNamespaces field of Environment is equal to namespaces.
+func HaveNamespaces(namespaces []string) matcher.GomegaMatcher {
+	return WithTransform(func(menv managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment) bool {
+		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+		Expect(err).To(BeNil())
+
+		k8sClient, err := fixture.GetKubeClient(config)
+		if err != nil {
+			fmt.Println(k8s.K8sClientError, err)
+			return false
+		}
+
+		err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&menv), &menv)
+		if err != nil {
+			fmt.Println(k8s.K8sClientError, err)
+			return false
+		}
+
+		res := reflect.DeepEqual(namespaces, menv.Spec.Namespaces)
+
+		fmt.Println("HaveNamespaces:", res, "/ Expected:", namespaces, "/ Actual:", menv.Spec.Namespaces)
+
+		return res
+
+	}, BeTrue())
+}

--- a/tests-e2e/fixture/managedenvironment/fixture.go
+++ b/tests-e2e/fixture/managedenvironment/fixture.go
@@ -92,8 +92,8 @@ func HaveCredentials(expectedEnvSpec managedgitopsv1alpha1.GitOpsDeploymentManag
 	}, BeTrue())
 }
 
-// HaveClusterResources checks if the ClusterResources field of Environment is equal to clusterResouces.
-func HaveClusterResources(clusterResouces bool) matcher.GomegaMatcher {
+// HaveClusterResources checks if the ClusterResources field of GitOpsDeploymentManagedEnvironment is equal to clusterResouces.
+func HaveClusterResources(clusterResources bool) matcher.GomegaMatcher {
 	return WithTransform(func(menv managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment) bool {
 		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
 		Expect(err).To(BeNil())
@@ -110,16 +110,16 @@ func HaveClusterResources(clusterResouces bool) matcher.GomegaMatcher {
 			return false
 		}
 
-		res := clusterResouces == menv.Spec.ClusterResources
+		res := clusterResources == menv.Spec.ClusterResources
 
-		fmt.Println("HaveClusterResources:", res, "/ Expected:", clusterResouces, "/ Actual:", menv.Spec.ClusterResources)
+		fmt.Println("HaveClusterResources:", res, "/ Expected:", clusterResources, "/ Actual:", menv.Spec.ClusterResources)
 
 		return res
 
 	}, BeTrue())
 }
 
-// HaveNamespaces checks if the HaveNamespaces field of Environment is equal to namespaces.
+// HaveNamespaces checks if the HaveNamespaces field of GitOpsDeploymentManagedEnvironment is equal to namespaces.
 func HaveNamespaces(namespaces []string) matcher.GomegaMatcher {
 	return WithTransform(func(menv managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment) bool {
 		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()

--- a/tests-e2e/go.mod
+++ b/tests-e2e/go.mod
@@ -137,7 +137,6 @@ require (
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.4.1 // indirect
-	github.com/go-git/go-git/v5 v5.4.2 // indirect
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect

--- a/tests-e2e/go.mod
+++ b/tests-e2e/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/codeready-toolchain/api v0.0.0-20230417183849-f62ccbf3bd40
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20230417235430-8258a3281250
 	github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible
-	github.com/redhat-appstudio/application-api v0.0.0-20230418144704-93276b7c779d
+	github.com/redhat-appstudio/application-api v0.0.0-20230421113855-f25d47ce7499
 	github.com/redhat-appstudio/managed-gitops/appstudio-controller v0.0.0
 	github.com/redhat-appstudio/managed-gitops/backend v0.0.0
 	github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0
@@ -137,6 +137,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.4.1 // indirect
+	github.com/go-git/go-git/v5 v5.4.2 // indirect
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect

--- a/tests-e2e/go.sum
+++ b/tests-e2e/go.sum
@@ -810,8 +810,8 @@ github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H
 github.com/r3labs/diff v1.1.0 h1:V53xhrbTHrWFWq3gI4b94AjgEJOerO1+1l0xyHOBi8M=
 github.com/r3labs/diff v1.1.0/go.mod h1:7WjXasNzi0vJetRcB/RqNl5dlIsmXcTTLmF5IoH6Xig=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/redhat-appstudio/application-api v0.0.0-20230418144704-93276b7c779d h1:PExij4tPAspKUU1hlV64swFgZBqsnVL2EG43rIpdT8o=
-github.com/redhat-appstudio/application-api v0.0.0-20230418144704-93276b7c779d/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
+github.com/redhat-appstudio/application-api v0.0.0-20230421113855-f25d47ce7499 h1:cOr4QX/0d+QZ80ef7wjXRsGm7Bnr5RCapTqTPKqgRao=
+github.com/redhat-appstudio/application-api v0.0.0-20230421113855-f25d47ce7499/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=

--- a/tests-e2e/main.go
+++ b/tests-e2e/main.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"flag"
-	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"os"
+
+	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.


### PR DESCRIPTION
#### Description:
- Added namespaces and clusterResources fields to the app studio Environment API
- Updated the appstudio controller to copy these fields from the app studio Environment when a GitOpsDeploymentManagedEnvironment is created

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-538

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
