### PR TITLE
fix(STONEINTG-261): missing permission to update finalizers

### DIFF
--- a/appstudio-controller/config/rbac/role.yaml
+++ b/appstudio-controller/config/rbac/role.yaml
@@ -282,6 +282,12 @@ rules:
 - apiGroups:
   - toolchain.dev.openshift.com
   resources:
+  - spacerequests/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
   - spacerequests/status
   verbs:
   - get

--- a/appstudio-controller/controllers/appstudio.redhat.com/predicate_provision.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/predicate_provision.go
@@ -29,7 +29,7 @@ func SpaceRequestReadyPredicate() predicate.Predicate {
 	}
 }
 
-//IsSpaceRequestReady checks if SpaceRequest condition is in Ready status.
+// IsSpaceRequestReady checks if SpaceRequest condition is in Ready status.
 func IsSpaceRequestReady(spacerequest *codereadytoolchainv1alpha1.SpaceRequest) bool {
 	return condition.IsTrue(spacerequest.Status.Conditions, codereadytoolchainv1alpha1.ConditionReady)
 }

--- a/appstudio-controller/controllers/appstudio.redhat.com/sandboxprovisioner_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/sandboxprovisioner_controller.go
@@ -19,6 +19,7 @@ package appstudioredhatcom
 import (
 	"context"
 	"fmt"
+
 	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	applicationv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 
@@ -48,6 +49,7 @@ type SandboxProvisionerReconciler struct {
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=deploymenttargetclasses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spacerequests,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spacerequests/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spacerequests/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
#### Description:
Fix for `SpaceRequests` related E2E test failure due to missing RBAC policy.

```
Summarizing 1 Failure:
  [FAIL] Devsandbox deployment controller tests Testing Devsandbox deployment controller [It] should create a DeploymentTarget for a SpaceRequest with dtc Label
  /workspace/git/managed-gitops-git/tests-e2e/core/devsandboxdeployment_test.go:129
```
Error in appstudio-controller logs:

```
2023-04-22T16:55:29.721603669Z	ERROR	failed to create the DeploymentTarget for a SpaceRequest	
{
"controller": "spacerequest", 
"controllerGroup": "toolchain.dev.openshift.com", 
"controllerKind": "SpaceRequest", 
"spaceRequest": {
"name":"test-spacerequest","namespace":"gitops-service-e2e"
}, 
"namespace": "gitops-service-e2e", "name": "test-spacerequest",
 "reconcileID": "d266de4d-aa3a-48ef-83e0-c1f757c323e7", 
"name": "test-spacerequest", 
"namespace": "gitops-service-e2e", 
"component": "devsandboxDeployment", 
"error": "deploymenttargets.appstudio.redhat.com \"test-dtc-dt-977zs\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"
}
```

How to fix: https://sdk.operatorframework.io/docs/faqs/#after-deploying-my-operator-why-do-i-see-errors-like-is-forbidden-cannot-set-blockownerdeletion-if-an-ownerreference-refers-to-a-resource-you-cant-set-finalizers-on-

#### Link to JIRA Story (if applicable):

N/A
