### PR TITLE
Set Argo CD reconciliation timeout env variable

### DIFF
--- a/cluster-agent/utils/argocd_create.go
+++ b/cluster-agent/utils/argocd_create.go
@@ -37,6 +37,9 @@ const (
 	DefaultAppProject = "default"
 
 	ArgoCDFinalizerName = "argoproj.io/finalizer"
+
+	argoCDReconciliationTimeoutEnvName  = "ARGOCD_RECONCILIATION_TIMEOUT"
+	argoCDReconciliationTimeoutEnvValue = "60s"
 )
 
 // ReconcileNamespaceScopedArgoCD will create/update an ArgoCD operand within the specified namespace.
@@ -90,6 +93,12 @@ func ReconcileNamespaceScopedArgoCD(ctx context.Context, argocdCRName string, na
 					},
 				},
 				Sharding: argocdoperator.ArgoCDApplicationControllerShardSpec{},
+				Env: []corev1.EnvVar{
+					{
+						Name:  argoCDReconciliationTimeoutEnvName,
+						Value: argoCDReconciliationTimeoutEnvValue,
+					},
+				},
 			},
 			Grafana: argocdoperator.ArgoCDGrafanaSpec{
 				Enabled: false,
@@ -158,6 +167,12 @@ func ReconcileNamespaceScopedArgoCD(ctx context.Context, argocdCRName string, na
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("250m"),
 						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name:  argoCDReconciliationTimeoutEnvName,
+						Value: argoCDReconciliationTimeoutEnvValue,
 					},
 				},
 			},

--- a/manifests/base/gitops-service-argocd/base/argo-cd.yaml
+++ b/manifests/base/gitops-service-argocd/base/argo-cd.yaml
@@ -87,10 +87,10 @@ spec:
       requests:
         cpu: 250m
         memory: 256Mi
+    env:
+    - name: ARGOCD_RECONCILIATION_TIMEOUT
+      value: 60s
     sharding: {}
-
-    # May 2022: Argo CD to check for new Git revisions every 1 minute, rather than every 3 minutes. (jonwest@redhat.com)
-    appSync: 60s
 
 #  dex:
 #    enabled: false
@@ -151,6 +151,9 @@ spec:
       requests:
         cpu: 250m
         memory: 256Mi
+    env:
+    - name: ARGOCD_RECONCILIATION_TIMEOUT
+      value: "60s"
   server:
     logLevel: "debug"
     autoscale:


### PR DESCRIPTION
#### Description:
- Set the refresh rate by configuring the `ARGOCD_RECONCILIATION_TIMEOUT` environment variable in the application controller and repo server

#### How to test?

1. Create a sample GitOpsDeployment and check if the corresponding Argo CD app is synced.
2. Check the log timestamp of the application controller pod in the `gitops-service-argocd` namespace and verify if Argo CD refreshes the app every 60s.

#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-425