### PR TITLE
Fix gradual memory leak in the backend controller

### DIFF
--- a/backend/eventloop/application_event_loop/application_event_runner.go
+++ b/backend/eventloop/application_event_loop/application_event_runner.go
@@ -89,15 +89,14 @@ func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent
 
 	signalledShutdown := false
 
+	ctx, cancel := context.WithCancel(outerContext)
+	defer cancel()
+
 	for {
 		// Read from input channel: wait for an event on this application
 		newEvent := <-inputChannel
 
-		ctx, cancel := context.WithCancel(outerContext)
-
 		ctx = sharedutil.AddKCPClusterToContext(ctx, newEvent.Request.ClusterName)
-
-		defer cancel()
 
 		// Process the event
 
@@ -107,7 +106,7 @@ func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent
 
 		// Keep attempting the process the event until no error is returned, or the request is cancelled.
 		attempts := 1
-		backoff := sharedutil.ExponentialBackoff{Min: time.Duration(100 * time.Millisecond), Max: time.Duration(15 * time.Second), Factor: 2, Jitter: true}
+		backoff := sharedutil.ExponentialBackoff{Min: time.Duration(100 * time.Millisecond), Max: time.Duration(60 * time.Second), Factor: 2, Jitter: true}
 	inner_for:
 		for {
 


### PR DESCRIPTION
#### Description:
* Use a common context for all events in the application event runner. Creating a new context for every event will cause it to stay on the heap until it is canceled.
* Increase maximum backoff retry duration so the controller doesn't reconcile too much on CRs with errors.

##### Before:

The memory increased by almost 200MiB in the course of  2 hours.

![Screenshot from 2023-04-24 13-58-36](https://user-images.githubusercontent.com/21128732/234468400-97929745-5bf2-46b5-b343-18debdd16ed4.png)


##### After:

We can observe that memory has been almost the same in the 2 hours window with the same load.

![Screenshot from 2023-04-25 12-26-37](https://user-images.githubusercontent.com/21128732/234468454-8747b8ce-5932-4473-8637-14f3feb35420.png)


#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-557