### PR TITLE
Run PromotionRun E2E test apps in separate namespaces

### DIFF
--- a/tests-e2e/core/promotionrun_controller_test.go
+++ b/tests-e2e/core/promotionrun_controller_test.go
@@ -28,13 +28,13 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 		BeforeEach(func() {
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
-			const serviceAccountName = "gitops-promotion-run-test-service-account"
-			const secondNamespace = "new-e2e-test-namespace2"
-
 			// Staging environment must be in a different namespace from the production environment, else we get a
 			// problem with the same resource being owned by two different applications.
 			// See Jira issue https://issues.redhat.com/browse/GITOPSRVCE-544
 			// To do this, we need to create the namespace and also a managed environment secret
+
+			const serviceAccountName = "gitops-promotion-run-test-service-account"
+			const secondNamespace = "new-e2e-test-namespace2"
 
 			By("creating another namespace for one of the environments")
 			clientconfig, err := fixture.GetSystemKubeConfig()
@@ -67,9 +67,8 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 			_, apiServerURL, err := fixture.ExtractKubeConfigValues()
 			Expect(err).To(BeNil())
 
-			kubeConfigContents := generateKubeConfig(apiServerURL, fixture.GitOpsServiceE2ENamespace, tokenSecret)
-
 			// We actually need a managed environment secret containing a kubeconfig that has the bearer token
+			kubeConfigContents := generateKubeConfig(apiServerURL, fixture.GitOpsServiceE2ENamespace, tokenSecret)
 			secret := corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-managed-env-secret",

--- a/tests-e2e/core/promotionrun_controller_test.go
+++ b/tests-e2e/core/promotionrun_controller_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 			promotionRun = buildPromotionRunResource("new-demo-app-manual-promotion", "new-demo-app", "my-snapshot", "prod")
 		})
 
-		FIt("Should create GitOpsDeployments and it should be Synced/Healthy.", func() {
+		It("Should create GitOpsDeployments and it should be Synced/Healthy.", func() {
 			// ToDo: https://issues.redhat.com/browse/GITOPSRVCE-234
 			if fixture.IsRunningAgainstKCP() {
 				Skip("Skipping this test in KCP until we fix the race condition")

--- a/tests-e2e/fixture/fixture.go
+++ b/tests-e2e/fixture/fixture.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 
 	argocdoperator "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	appv1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -85,7 +86,7 @@ func EnsureCleanSlateNonKCPVirtualWorkspace() error {
 		return err
 	}
 
-	if err := ensureDestinationNamespaceExists(GitOpsServiceE2ENamespace, dbutil.GetGitOpsEngineSingleInstanceNamespace(), clientconfig); err != nil {
+	if err := EnsureDestinationNamespaceExists(GitOpsServiceE2ENamespace, dbutil.GetGitOpsEngineSingleInstanceNamespace(), clientconfig); err != nil {
 		return err
 	}
 
@@ -396,7 +397,7 @@ func removeAllFinalizers(k8sClient client.Client, obj client.Object) error {
 	return nil
 }
 
-func ensureDestinationNamespaceExists(namespaceParam string, argoCDNamespaceParam string, clientConfig *rest.Config) error {
+func EnsureDestinationNamespaceExists(namespaceParam string, argoCDNamespaceParam string, clientConfig *rest.Config) error {
 
 	kubeClientSet, err := kubernetes.NewForConfig(clientConfig)
 	if err != nil {
@@ -1065,7 +1066,7 @@ func EnsureCleanSlateKCPVirtualWorkspace() error {
 		return err
 	}
 
-	if err := ensureDestinationNamespaceExists(GitOpsServiceE2ENamespace, dbutil.GetGitOpsEngineSingleInstanceNamespace(), userConfig); err != nil {
+	if err := EnsureDestinationNamespaceExists(GitOpsServiceE2ENamespace, dbutil.GetGitOpsEngineSingleInstanceNamespace(), userConfig); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### Description:
- Run PromotionRun E2E test apps in separate namespaces so that the two apps don't share resources, which leads to syncing issues with Argo CD.
- This requires a new version of the e2e apps, since otherwise the two instances of the application will try to create a route with the same name, which is not allowed by OpenShift. The route-less version of the apps was committed via https://github.com/redhat-appstudio/managed-gitops/pull/435

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-544

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
