### PR TITLE
Update code to remove a single 'gitops-service-argocd' Argo CD namespace

### DIFF
--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -681,7 +681,6 @@ func (a applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplEvent(ctx cont
 	}
 
 	waitForOperation := !a.testOnlySkipCreateOperation // if it's for a unit test, we don't wait for the operation
-
 	if engineInstance.Namespace_name == "" {
 		err = fmt.Errorf("gitopsengineinstance namespace is nil, expected non-nil:  %s", engineInstance.Gitopsengineinstance_id)
 		return nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewDevOnlyError(err)

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -681,11 +681,7 @@ func (a applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplEvent(ctx cont
 	}
 
 	waitForOperation := !a.testOnlySkipCreateOperation // if it's for a unit test, we don't wait for the operation
-	if engineInstance == nil {
-		err = fmt.Errorf("gitopsengineinstance is nil, expected non-nil:  %v", engineInstance)
-		log.Error(err, "unexpected nil value of required objects")
-		return nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewDevOnlyError(err)
-	}
+
 	if engineInstance.Namespace_name == "" {
 		err = fmt.Errorf("gitopsengineinstance namespace is nil, expected non-nil:  %s", engineInstance.Gitopsengineinstance_id)
 		return nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewDevOnlyError(err)

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -366,7 +366,15 @@ func (a applicationEventLoopRunner_Action) handleNewGitOpsDeplEvent(ctx context.
 	}
 
 	waitForOperation := !a.testOnlySkipCreateOperation // if it's for a unit test, we don't wait for the operation
-
+	if engineInstance == nil {
+		err = fmt.Errorf("gitopsengineinstance is nil, expected non-nil:  %v", engineInstance)
+		a.log.Error(err, "unexpected nil value of required objects")
+		return nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewDevOnlyError(err)
+	}
+	if engineInstance.Namespace_name == "" {
+		err = fmt.Errorf("gitopsengineinstance namespace is nil, expected non-nil:  %s", engineInstance.Gitopsengineinstance_id)
+		return nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewDevOnlyError(err)
+	}
 	k8sOperation, dbOperation, err := operations.CreateOperation(ctx, waitForOperation, dbOperationInput,
 		clusterUser.Clusteruser_id, engineInstance.Namespace_name, dbQueries, gitopsEngineClient, a.log)
 	if err != nil {
@@ -692,7 +700,15 @@ func (a applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplEvent(ctx cont
 	}
 
 	waitForOperation := !a.testOnlySkipCreateOperation // if it's for a unit test, we don't wait for the operation
-
+	if engineInstance == nil {
+		err = fmt.Errorf("gitopsengineinstance is nil, expected non-nil:  %v", engineInstance)
+		log.Error(err, "unexpected nil value of required objects")
+		return nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewDevOnlyError(err)
+	}
+	if engineInstance.Namespace_name == "" {
+		err = fmt.Errorf("gitopsengineinstance namespace is nil, expected non-nil:  %s", engineInstance.Gitopsengineinstance_id)
+		return nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewDevOnlyError(err)
+	}
 	k8sOperation, dbOperation, err := operations.CreateOperation(ctx, waitForOperation, dbOperationInput, clusterUser.Clusteruser_id,
 		engineInstance.Namespace_name, dbQueries, gitopsEngineClient, log)
 	if err != nil {
@@ -818,6 +834,16 @@ func (a applicationEventLoopRunner_Action) cleanOldGitOpsDeploymentEntry(ctx con
 	}
 
 	waitForOperation := !a.testOnlySkipCreateOperation // if it's for a unit test, we don't wait for the operation
+	if gitopsEngineInstance == nil {
+		err = fmt.Errorf("gitopsengineinstance is nil, expected non-nil:  %v", gitopsEngineInstance)
+		log.Error(err, "unexpected nil value of required objects")
+		return false, err
+	}
+
+	if gitopsEngineInstance.Namespace_name == "" {
+		err = fmt.Errorf("gitopsengineinstance namespace is nil, expected non-nil:  %s", gitopsEngineInstance.Gitopsengineinstance_id)
+		return false, err
+	}
 	k8sOperation, dbOperation, err := operations.CreateOperation(ctx, waitForOperation, dbOperationInput,
 		clusterUser.Clusteruser_id, gitopsEngineInstance.Namespace_name, dbQueries, gitopsEngineClient, log)
 	if err != nil {

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -164,25 +164,6 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleDeploym
 	successfulCleanup := signalledShutdown_true
 	if len(oldDeplToAppMappings) > 0 || isGitOpsDeploymentDeleted(gitopsDeployment) {
 
-		// We should signal shutdown if both conditions are satisfied:
-		// - we have successfully cleaned up old resources
-		// - AND, the CR no longer exists
-		// for idx := range oldDeplToAppMappings {
-		// 	applicationDB := db.Application{
-		// 		Application_id: oldDeplToAppMappings[idx].Application_id,
-		// 	}
-		// 	if err := dbQueries.GetApplicationById(ctx, &applicationDB); err != nil {
-		// 		userError := "Error occured in retrieveing Application row from the database"
-		// 		return signalledShutdown_false, nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewUserDevError(userError, err)
-		// 	}
-		// 	engineInstanceDB := db.GitopsEngineInstance{
-		// 		Gitopsengineinstance_id: applicationDB.Engine_instance_inst_id,
-		// 	}
-		// 	if err := dbQueries.GetGitopsEngineInstanceById(ctx, &engineInstanceDB); err != nil {
-		// 		userError := "Error occured in retrieveing GitopsEngineInstance row from the database"
-		// 		return signalledShutdown_false, nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewUserDevError(userError, err)
-		// 	}
-
 		var deleteErr gitopserrors.UserError
 		successfulCleanup, deleteErr = a.handleDeleteGitOpsDeplEvent(ctx, gitopsDeployment, clusterUser, &oldDeplToAppMappings, dbQueries)
 		if deleteErr != nil {

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
@@ -378,6 +378,16 @@ func (a *applicationEventLoopRunner_Action) handleDeletedGitOpsDeplSyncRunEvent(
 		log.Error(err, "unable to retrieve gitopsengineinstance, on sync run modified", "instanceId", string(application.Engine_instance_inst_id))
 		return gitopserrors.NewDevOnlyError(err)
 	}
+	if gitopsEngineInstance == nil {
+		err = fmt.Errorf("gitopsengineinstance is nil, expected non-nil:  %v", gitopsEngineInstance)
+		log.Error(err, "unexpected nil value of required objects")
+		return gitopserrors.NewDevOnlyError(err)
+	}
+
+	if gitopsEngineInstance.Namespace_name == "" {
+		err = fmt.Errorf("gitopsengineinstance namespace is empty")
+		return gitopserrors.NewDevOnlyError(err)
+	}
 
 	dbOperationInput := db.Operation{
 		Instance_id:   gitopsEngineInstance.Gitopsengineinstance_id,
@@ -447,6 +457,10 @@ func (a *applicationEventLoopRunner_Action) handleNewGitOpsDeplSyncRunEvent(ctx 
 	if application == nil || gitopsEngineInstance == nil {
 		err := fmt.Errorf("app or engine instance were nil in handleSyncRunModified app: %v, instance: %v", application, gitopsEngineInstance)
 		log.Error(err, "unexpected nil value of required objects")
+		return gitopserrors.NewDevOnlyError(err)
+	}
+	if gitopsEngineInstance.Namespace_name == "" {
+		err := fmt.Errorf("gitopsengineinstance namespace is empty")
 		return gitopserrors.NewDevOnlyError(err)
 	}
 

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
@@ -394,15 +394,15 @@ func (a *applicationEventLoopRunner_Action) handleDeletedGitOpsDeplSyncRunEvent(
 
 	waitForOperation := !a.testOnlySkipCreateOperation // if it's for a unit test, we don't wait for the operation
 	k8sOperation, dbOperation, err := operations.CreateOperation(ctx, waitForOperation, dbOperationInput, clusterUser.Clusteruser_id,
-		dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, operationClient, log)
+		gitopsEngineInstance.Namespace_name, dbQueries, operationClient, log)
 	if err != nil {
-		log.Error(err, "could not create operation, when resource was deleted", "namespace", dbutil.GetGitOpsEngineSingleInstanceNamespace())
+		log.Error(err, "could not create operation, when resource was deleted", "namespace", gitopsEngineInstance.Namespace_name)
 
 		return gitopserrors.NewDevOnlyError(err)
 	}
 
 	// 3) Clean up the operation and database table entries
-	if err := operations.CleanupOperation(ctx, *dbOperation, *k8sOperation, dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, operationClient, !a.testOnlySkipCreateOperation, log); err != nil {
+	if err := operations.CleanupOperation(ctx, *dbOperation, *k8sOperation, gitopsEngineInstance.Namespace_name, dbQueries, operationClient, !a.testOnlySkipCreateOperation, log); err != nil {
 		return gitopserrors.NewDevOnlyError(err)
 	}
 
@@ -508,9 +508,9 @@ func (a *applicationEventLoopRunner_Action) handleNewGitOpsDeplSyncRunEvent(ctx 
 	}
 
 	k8sOperation, dbOperation, err := operations.CreateOperation(ctx, false, dbOperationInput, clusterUser.Clusteruser_id,
-		dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, operationClient, log)
+		gitopsEngineInstance.Namespace_name, dbQueries, operationClient, log)
 	if err != nil {
-		log.Error(err, "could not create operation", "namespace", dbutil.GetGitOpsEngineSingleInstanceNamespace())
+		log.Error(err, "could not create operation", "namespace", gitopsEngineInstance.Namespace_name)
 
 		// If we were unable to create the operation, delete the resources we created in the previous steps
 		dbutil.DisposeApplicationScopedResources(ctx, createdResources, dbQueries, log)
@@ -564,7 +564,7 @@ outer_for:
 
 	}
 
-	if err := operations.CleanupOperation(ctx, *dbOperation, *k8sOperation, dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, operationClient, !a.testOnlySkipCreateOperation, log); err != nil {
+	if err := operations.CleanupOperation(ctx, *dbOperation, *k8sOperation, gitopsEngineInstance.Namespace_name, dbQueries, operationClient, !a.testOnlySkipCreateOperation, log); err != nil {
 		return gitopserrors.NewDevOnlyError(err)
 	}
 

--- a/backend/eventloop/eventlooptypes/types.go
+++ b/backend/eventloop/eventlooptypes/types.go
@@ -137,6 +137,7 @@ func GetWorkspaceIDFromNamespaceID(namespace corev1.Namespace) string {
 func GetK8sClientForGitOpsEngineInstance(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
 
 	// TODO: GITOPSRVCE-66: Update this once we support using Argo CD instances that are running on a separate cluster	serviceClient, err := GetK8sClientForServiceWorkspace()
+	serviceClient, err := GetK8sClientForServiceWorkspace()
 	if err != nil {
 		return nil, err
 	}

--- a/backend/eventloop/eventlooptypes/types.go
+++ b/backend/eventloop/eventlooptypes/types.go
@@ -136,8 +136,7 @@ func GetWorkspaceIDFromNamespaceID(namespace corev1.Namespace) string {
 // Returns a normal client that targets the same cluster as backend.
 func GetK8sClientForGitOpsEngineInstance(ctx context.Context, gitopsEngineInstance *db.GitopsEngineInstance) (client.Client, error) {
 
-	// TODO: GITOPSRVCE-73: When we support multiple Argo CD instances (and multiple instances on separate clusters), this logic should be updated.
-	serviceClient, err := GetK8sClientForServiceWorkspace()
+	// TODO: GITOPSRVCE-66: Update this once we support using Argo CD instances that are running on a separate cluster	serviceClient, err := GetK8sClientForServiceWorkspace()
 	if err != nil {
 		return nil, err
 	}

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -613,7 +613,7 @@ func internalProcessMessage_GetOrCreateSharedResources(ctx context.Context, gito
 //
 // This logic would be improved by https://issues.redhat.com/browse/GITOPSRVCE-73 (and others)
 func internalDetermineGitOpsEngineInstance(ctx context.Context, user db.ClusterUser, k8sClient client.Client, dbq db.DatabaseQueries, l logr.Logger) (*db.GitopsEngineInstance, bool, *db.GitopsEngineCluster, gitopserrors.ConditionError) {
-
+	// TODO: GITOPSRVCE-73 - Once we have a way to distribute work between Argo CD instances, update this function.
 	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: dbutil.GetGitOpsEngineSingleInstanceNamespace()}}
 	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
 		devError := fmt.Errorf("unable to retrieve gitopsengine namespace in determineGitOpsEngineInstanceForNewApplication: %w", err)

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
@@ -11,7 +11,6 @@ import (
 
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	db "github.com/redhat-appstudio/managed-gitops/backend-shared/db"
-	dbutil "github.com/redhat-appstudio/managed-gitops/backend-shared/db/util"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/gitopserrors"
 	logutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util/log"
@@ -620,7 +619,7 @@ func DeleteManagedEnvironmentResources(ctx context.Context, managedEnvID string,
 
 		// Don't wait for the Operation to complete, just create it and continue with the next.
 		_, _, err = operations.CreateOperation(ctx, false, operation, user.Clusteruser_id,
-			dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, client, log)
+			gitopsEngineInstance.Namespace_name, dbQueries, client, log)
 		// TODO: GITOPSRVCE-174 - Add garbage collection of this operation once 174 is finished.
 		if err != nil {
 			return fmt.Errorf("unable to create operation for applicaton '%s': %v", app.Application_id, err)
@@ -694,7 +693,7 @@ func DeleteManagedEnvironmentResources(ctx context.Context, managedEnvID string,
 
 		// TODO: GITOPSRVCE-174 - Add garbage collection of this operation once 174 is finished.
 		_, _, err = operations.CreateOperation(ctx, false, operation, user.Clusteruser_id,
-			dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, client, log)
+			gitopsEngineInstance.Namespace_name, dbQueries, client, log)
 		if err != nil {
 			return fmt.Errorf("unable to create operation for deleted managed environment: %v", err)
 		}

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv_test.go
@@ -14,7 +14,6 @@ import (
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1/mocks"
 	db "github.com/redhat-appstudio/managed-gitops/backend-shared/db"
-	dbutil "github.com/redhat-appstudio/managed-gitops/backend-shared/db/util"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/tests"
 	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/eventloop_test_util"
@@ -1057,7 +1056,7 @@ func buildManagedEnvironmentForSRLWithOptionalSA(createNewServiceAccount bool) (
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-my-managed-env-secret",
-			Namespace: dbutil.DefaultGitOpsEngineSingleInstanceNamespace,
+			Namespace: "test-k8s-namespace",
 		},
 		Type: sharedutil.ManagedEnvironmentSecretType,
 		Data: map[string][]byte{
@@ -1068,7 +1067,7 @@ func buildManagedEnvironmentForSRLWithOptionalSA(createNewServiceAccount bool) (
 	managedEnv := &managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-my-managed-env",
-			Namespace: dbutil.DefaultGitOpsEngineSingleInstanceNamespace,
+			Namespace: "test-k8s-namespace",
 		},
 		Spec: managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironmentSpec{
 			APIURL:                   "https://api.fake-unit-test-data.origin-ci-int-gce.dev.rhcloud.com:6443",

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv_test.go
@@ -14,6 +14,7 @@ import (
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1/mocks"
 	db "github.com/redhat-appstudio/managed-gitops/backend-shared/db"
+	dbutil "github.com/redhat-appstudio/managed-gitops/backend-shared/db/util"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/tests"
 	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/eventloop_test_util"

--- a/cluster-agent/controllers/argoproj.io/namespace_reconciler.go
+++ b/cluster-agent/controllers/argoproj.io/namespace_reconciler.go
@@ -153,6 +153,7 @@ func runNamespaceReconcile(ctx context.Context, dbQueries db.DatabaseQueries, cl
 					}
 					if err = dbQueries.GetGitopsEngineInstanceById(ctx, &engineInstanceDB); err != nil {
 						log.Error(err, "Unable to fetch GitopsEngineInstance")
+						continue
 					}
 					_, _, err = operations.CreateOperation(ctx, false, dbOperationInput,
 						specialClusterUser.Clusteruser_id, engineInstanceDB.Namespace_name, dbQueries, client, log)
@@ -200,6 +201,7 @@ func runNamespaceReconcile(ctx context.Context, dbQueries db.DatabaseQueries, cl
 			}
 			if err := dbQueries.GetGitopsEngineInstanceById(ctx, &engineInstanceDB); err != nil {
 				log.Error(err, "Unable to fetch GitopsEngineInstance")
+				continue
 			}
 			if _, _, err := operations.CreateOperation(ctx, false, dbOperationInput,
 				specialClusterUser.Clusteruser_id, engineInstanceDB.Namespace_name, dbQueries, client, log); err != nil {

--- a/cluster-agent/controllers/argoproj.io/namespace_reconciler.go
+++ b/cluster-agent/controllers/argoproj.io/namespace_reconciler.go
@@ -371,6 +371,7 @@ func cleanK8sOperations(ctx context.Context, dbq db.DatabaseQueries, client clie
 		}
 		if err = dbq.GetGitopsEngineInstanceById(ctx, &engineInstanceDB); err != nil {
 			log.Error(err, "Unable to fetch GitopsEngineInstance")
+			continue
 		}
 		// Delete the k8s operation now.
 		if err := operations.CleanupOperation(ctx, dbOperation, k8sOperation, engineInstanceDB.Namespace_name,

--- a/cluster-agent/controllers/argoproj.io/namespace_reconciler.go
+++ b/cluster-agent/controllers/argoproj.io/namespace_reconciler.go
@@ -148,9 +148,14 @@ func runNamespaceReconcile(ctx context.Context, dbQueries db.DatabaseQueries, cl
 						Resource_id:   applicationRowFromDB.Application_id,
 						Resource_type: db.OperationResourceType_Application,
 					}
-
+					engineInstanceDB := db.GitopsEngineInstance{
+						Gitopsengineinstance_id: dbOperationInput.Instance_id,
+					}
+					if err = dbQueries.GetGitopsEngineInstanceById(ctx, &engineInstanceDB); err != nil {
+						log.Error(err, "Unable to fetch GitopsEngineInstance")
+					}
 					_, _, err = operations.CreateOperation(ctx, false, dbOperationInput,
-						specialClusterUser.Clusteruser_id, dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, client, log)
+						specialClusterUser.Clusteruser_id, engineInstanceDB.Namespace_name, dbQueries, client, log)
 					if err != nil {
 						log.Error(err, "Namespace Reconciler is unable to create operation: "+dbOperationInput.ShortString())
 					}
@@ -190,9 +195,14 @@ func runNamespaceReconcile(ctx context.Context, dbQueries db.DatabaseQueries, cl
 				Resource_id:   applicationRowFromDB.Application_id,
 				Resource_type: db.OperationResourceType_Application,
 			}
-
+			engineInstanceDB := db.GitopsEngineInstance{
+				Gitopsengineinstance_id: dbOperationInput.Instance_id,
+			}
+			if err := dbQueries.GetGitopsEngineInstanceById(ctx, &engineInstanceDB); err != nil {
+				log.Error(err, "Unable to fetch GitopsEngineInstance")
+			}
 			if _, _, err := operations.CreateOperation(ctx, false, dbOperationInput,
-				specialClusterUser.Clusteruser_id, dbutil.GetGitOpsEngineSingleInstanceNamespace(), dbQueries, client, log); err != nil {
+				specialClusterUser.Clusteruser_id, engineInstanceDB.Namespace_name, dbQueries, client, log); err != nil {
 				log.Error(err, "Namespace Reconciler is unable to create operation: "+dbOperationInput.ShortString())
 				continue
 			}
@@ -354,9 +364,14 @@ func cleanK8sOperations(ctx context.Context, dbq db.DatabaseQueries, client clie
 		}
 
 		log.Info("Deleting Operation created by Namespace Reconciler." + string(k8sOperation.UID))
-
+		engineInstanceDB := db.GitopsEngineInstance{
+			Gitopsengineinstance_id: dbOperation.Instance_id,
+		}
+		if err = dbq.GetGitopsEngineInstanceById(ctx, &engineInstanceDB); err != nil {
+			log.Error(err, "Unable to fetch GitopsEngineInstance")
+		}
 		// Delete the k8s operation now.
-		if err := operations.CleanupOperation(ctx, dbOperation, k8sOperation, dbutil.GetGitOpsEngineSingleInstanceNamespace(),
+		if err := operations.CleanupOperation(ctx, dbOperation, k8sOperation, engineInstanceDB.Namespace_name,
 			dbq, client, false, log); err != nil {
 
 			log.Error(err, "Unable to Delete k8s Operation"+string(k8sOperation.UID)+" for DbOperation: "+string(k8sOperation.Spec.OperationID))

--- a/cluster-agent/controllers/managed-gitops/operation_controller.go
+++ b/cluster-agent/controllers/managed-gitops/operation_controller.go
@@ -137,6 +137,7 @@ func (g *garbageCollector) garbageCollectOperations(ctx context.Context, operati
 			}
 			if err = g.db.GetGitopsEngineInstanceById(ctx, &engineInstanceDB); err != nil {
 				log.Error(err, "Unable to fetch GitopsEngineInstance")
+				continue
 			}
 			// remove the Operation resource from the cluster
 			operationCR := &managedgitopsv1alpha1.Operation{

--- a/cluster-agent/metrics/argocd/argocd_metrics.go
+++ b/cluster-agent/metrics/argocd/argocd_metrics.go
@@ -99,6 +99,7 @@ func (m *reconciliationMetricsUpdater) gitopsNamespaces() []string {
 		return m.testNamespaceNames
 	}
 	return []string{
+		// TODO: GITOPSRVCE-73 - Once we have a way to distribute work between Argo CD instances, update this function.
 		dbutil.GetGitOpsEngineSingleInstanceNamespace(),
 	}
 }


### PR DESCRIPTION
#### Description:
This PR deals with all the places in the code where it was assumed that only a single Argo CD instance (a single GitOpsEngineInstance) exists. Changing that to fetch the ArgoCD namespace from GitopsEngineInstance database row's value i.e. `Namespace_name`. The unit tests and e2e-tests aren't updated if it is not a reference but instead a hardcoded value.

#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-421