### PR TITLE
Fix comparison race condition in SnapshotEnvironmentBinding E2E tests

### DIFF
--- a/tests-e2e/core/snapshotenvironmentbinding_test.go
+++ b/tests-e2e/core/snapshotenvironmentbinding_test.go
@@ -367,7 +367,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 				ComponentName: binding.Spec.Components[0].Name, GitOpsDeployment: gitOpsDeploymentName,
 			}}
 
-			Eventually(binding, "2m", "1s").Should(bindingFixture.HaveStatusGitOpsDeployments(expectedGitOpsDeployments))
+			Eventually(binding, "2m", "1s").Should(bindingFixture.HaveStatusGitOpsDeployments(expectedGitOpsDeployments, true))
 
 			//====================================================
 			By("Verify that GitOpsDeployment CR created, is having Spec.Source as given in Binding.")
@@ -388,7 +388,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 			//====================================================
 			By("Verify that GitOpsDeployment CR is recreated by GitOps-Service.")
 
-			Eventually(binding, "2m", "1s").Should(bindingFixture.HaveStatusGitOpsDeployments(expectedGitOpsDeployments))
+			Eventually(binding, "2m", "1s").Should(bindingFixture.HaveStatusGitOpsDeployments(expectedGitOpsDeployments, true))
 
 			gitOpsDeploymentAfter := buildGitOpsDeploymentObjectMeta(gitOpsDeploymentName, binding.Namespace)
 


### PR DESCRIPTION
#### Description:
- This PR fixes this race condition in SEB tests:
```
Summarizing 1 Failure:
  [FAIL] SnapshotEnvironmentBinding Reconciler E2E tests Testing SnapshotEnvironmentBinding Reconciler. [It] Should recreate GitOpsDeployment, if Binding still exists but GitOpsDeployment is deleted.
  /home/jgw/managed-gitops/managed-gitops/tests-e2e/core/snapshotenvironmentbinding_test.go:370
```

The race condition was due to the fixture function comparing the sync status/health/commit id, which the test was not designed to expect.

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
