### PR TITLE
fix: remove finalizer for a deleted GitOpsDepl when the controllers are restarted

### DIFF
--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -162,7 +162,7 @@ func (a *applicationEventLoopRunner_Action) applicationEventRunner_handleDeploym
 
 	// 4) Clean up any old GitOpsDeployments that have the same name/namespace as this resource, but that no longer exist
 	successfulCleanup := signalledShutdown_true
-	if len(oldDeplToAppMappings) > 0 {
+	if len(oldDeplToAppMappings) > 0 || isGitOpsDeploymentDeleted(gitopsDeployment) {
 
 		// We should signal shutdown if both conditions are satisfied:
 		// - we have successfully cleaned up old resources


### PR DESCRIPTION
#### Description:
- The backend controller should not forget to remove the finalizer from a deleted GitOpsDepl when the controllers are restarted. Currently, we skip handling the deletion if the DB resources are already removed even though the GitOpsDeployment with a finalizer could still exist.

#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-455