### PR TITLE
Delete GitOpsDeployment when Component removed from SEB

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
@@ -302,7 +302,8 @@ func deleteUnmatchedDeployments(ctx context.Context, c client.Client, binding *a
 	}
 
 	// Delete all the deployments which aren't in the expectedDeployments map
-	for _, deployment := range deployments.Items {
+	for i := range deployments.Items {
+		deployment := deployments.Items[i]
 		component := deployment.Labels[componentLabelKey]
 		_, exists := expectedDeployments[component]
 		if !exists {

--- a/tests-e2e/fixture/gitopsdeployment/fixture.go
+++ b/tests-e2e/fixture/gitopsdeployment/fixture.go
@@ -319,6 +319,27 @@ func HasNonNilDeletionTimestamp() matcher.GomegaMatcher {
 	}, BeTrue())
 }
 
+func Exist() matcher.GomegaMatcher {
+	return WithTransform(func(gitopsDepl managedgitopsv1alpha1.GitOpsDeployment) bool {
+
+		config, err := fixture.GetE2ETestUserWorkspaceKubeConfig()
+		Expect(err).To(BeNil())
+
+		k8sClient, err := fixture.GetKubeClient(config)
+		if err != nil {
+			fmt.Println(k8sFixture.K8sClientError, err)
+			return false
+		}
+
+		err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&gitopsDepl), &gitopsDepl)
+		if err != nil {
+			fmt.Println(k8sFixture.K8sClientError, err)
+			return false
+		}
+		return true
+	}, BeTrue())
+}
+
 // UpdateDeploymentWithFunction will update the GitOpsDeployment by:
 // - retrieving the latest version of the GitOpsDeployment from the cluster
 // - applying the mutation function


### PR DESCRIPTION
#### Description:
- Updated the SnapshotEnvironmentBinding reconciler to delete any GitOpsDeployments that are not associated with a Component.
- Added unit and e2e tests for the deletion of deployments in response to removal of components
- Added constant strings for the keys used for the labels applied to the deployment to identify the associated application, component and environment

The most efficient way to find the deployments to delete uses the `component` label on the deployment as the key to a map of expected deployments.  Label values are limited in length to 63 characters (in the production, the names of components, applications and environments will be limited to 63 characters by a webhook.) The existing code that sets the labels on the deployment truncates the value if the limit is exceeded.  There are some unit and e2e tests that set component/application names to longer than 63 characters in order to test the algorithm that produces the name for a GitOpsDeployment.  For the the e2e tests, if the component name is truncated, the new deletion code causes the associated deployment to continually be deleted then recreated.

The right solution is for the reconciler to error out if any of the application, component or environment names are greater than 63 characters. This requires the following additional changes:

- Changed the reconciler so that instead of truncating label values that are too long, it will error out instead.
- Changed the test cases that test the logic for generating shortened names for deployments to keep the names of the application, component and environment to at most 63 characters.

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-564

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
