### PR TITLE
Improve error message when ServiceAccount doesn't have needed roles

### DIFF
--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
@@ -880,11 +880,15 @@ func createNewClusterCredentials(ctx context.Context, managedEnvironment managed
 
 			log.Error(err, "Unable to verify ClusterCredentials using provided token", clusterCredentials.GetAsLogKeyValues()...)
 
+			message := "Unable to validate the credentials provided in the ManagedEnvironment Secret. Verify the API URL, and service account token are correct."
+			if apierr.IsForbidden(err) {
+				message = "Provided service account does not have permission to access resources in the cluster. Verify that the service account has the correct Role and RoleBinding."
+			}
 			return db.ClusterCredentials{}, connectionInitializedCondition{
 				managedEnvCR: managedEnvironment,
 				status:       metav1.ConditionUnknown,
 				reason:       managedgitopsv1alpha1.ConditionReasonUnableToValidateClusterCredentials,
-				message:      "Unable to validate the credentials provided in the ManagedEnvironment Secret. Verify the API URL, and service account token are correct.",
+				message:      message,
 			}, fmt.Errorf("unable to create cluster credentials for host '%s': %w", clusterCredentials.Host, err)
 
 		}
@@ -1099,7 +1103,7 @@ func verifyClusterCredentialsWithNamespaceList(ctx context.Context, clusterCreds
 			},
 		}
 		if err := clientObj.Get(ctx, client.ObjectKeyFromObject(&firstNamespaceName), &firstNamespaceName); err != nil {
-			return false, fmt.Errorf("unable to verify cluster credentials by retrieve a namespace in the namespace list '%s': %w",
+			return false, fmt.Errorf("unable to verify cluster credentials by retrieving a namespace in the namespace list '%s': %w",
 				firstNamespaceName.Name, err)
 		}
 


### PR DESCRIPTION
#### Description:
- Added new message for when the check for cluster access returns status of `forbidden`.
- Added new unit tests for this situation.

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-574

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
