### PR TITLE
Added timeout for github url fetch and added retries for kustomize build

### DIFF
--- a/utilities/upgrade-service/install-upgrade.sh
+++ b/utilities/upgrade-service/install-upgrade.sh
@@ -3,8 +3,6 @@
 KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-"v4.5.7"}
 KUBECTL_VERSION=${KUBECTL_VERSION:-"v1.26.0"}
 
-
-
 # deletes the temp directory
 function cleanup() {
   rm -rf "${TEMP_DIR}"
@@ -34,6 +32,9 @@ function install_kubectl() {
 
 # Check if a pod is ready, if it fails to get ready, rollback to PREV_IMAGE
 check_pod_status_ready() {
+  # Wait for the deployment rollout to complete before trying to list the pods
+  # to ensure that only pods corresponding to the new version is considered.
+  ${KUBECTL} rollout status deploy -n gitops --timeout=5m
   for binary in "$@"; do
     echo "Binary $binary";
     pod_name=$(kubectl get pods --no-headers -o custom-columns=":metadata.name" -n gitops | grep "$binary");
@@ -65,13 +66,13 @@ function create_kustomization_init_file() {
   echo "apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/managed-gitops/manifests/base/crd/overlays/local-dev?ref=${GIT_REVISION}
-  - https://github.com/redhat-appstudio/managed-gitops/manifests/base/gitops-namespace?ref=${GIT_REVISION}
-  - https://github.com/redhat-appstudio/managed-gitops/manifests/base/gitops-service-argocd/base?ref=${GIT_REVISION}
-  - https://github.com/redhat-appstudio/managed-gitops/manifests/base/postgresql-staging?ref=${GIT_REVISION}
-  - https://github.com/redhat-appstudio/managed-gitops/appstudio-controller/config/default?ref=${GIT_REVISION}
-  - https://github.com/redhat-appstudio/managed-gitops/backend/config/default?ref=${GIT_REVISION}
-  - https://github.com/redhat-appstudio/managed-gitops/cluster-agent/config/default?ref=${GIT_REVISION}" > ${TEMP_DIR}/kustomization.yaml
+  - https://github.com/redhat-appstudio/managed-gitops/manifests/base/crd/overlays/local-dev?ref=${GIT_REVISION}&timeout=90s
+  - https://github.com/redhat-appstudio/managed-gitops/manifests/base/gitops-namespace?ref=${GIT_REVISION}&timeout=90s
+  - https://github.com/redhat-appstudio/managed-gitops/manifests/base/gitops-service-argocd/base?ref=${GIT_REVISION}&timeout=90s
+  - https://github.com/redhat-appstudio/managed-gitops/manifests/base/postgresql-staging?ref=${GIT_REVISION}&timeout=90s
+  - https://github.com/redhat-appstudio/managed-gitops/appstudio-controller/config/default?ref=${GIT_REVISION}&timeout=90s
+  - https://github.com/redhat-appstudio/managed-gitops/backend/config/default?ref=${GIT_REVISION}&timeout=90s
+  - https://github.com/redhat-appstudio/managed-gitops/cluster-agent/config/default?ref=${GIT_REVISION}&timeout=90s" > ${TEMP_DIR}/kustomization.yaml
   cat ${TEMP_DIR}/kustomization.yaml
 }
 
@@ -83,6 +84,34 @@ function generate_postgresql_secret {
     --namespace=gitops \
     --from-literal=postgresql-password=$(openssl rand -base64 20)
   fi
+}
+
+# Checks if the gitops-appstudio-service-controller-manager is already installed in the system.
+# if so, stores the previous version which would be used for rollback in case of
+# a failure during installation.
+function get_prev_image() {
+  for image in $(${KUBECTL} get deploy/gitops-appstudio-service-controller-manager -n gitops -o jsonpath='{..image}' 2>/dev/null)
+  do
+    if [[ "${image}" == *"controller-manager"* ]]; then
+      PREV_IMG="${image}"
+      break
+    fi
+  done
+}
+
+# Build and apply the kustomize manifests with retries
+function apply_kustomize_manifests() {
+  MAX_RETRIES=3
+  retry_count=1
+  until [ "${retry_count}" -gt ${MAX_RETRIES} ]
+  do
+    attempt=${retry_count}
+    retry_count=$((retry_count+1))
+    echo "[INFO] (Attempt ${attempt}) Executing kustomize build command"
+    ${KUSTOMIZE} build ${TEMP_DIR} > ${TEMP_DIR}/kustomize-build-output.yaml || continue
+    echo "[INFO] (Attempt ${attempt}) Creating k8s resources from kustomize manifests"
+    ${KUBECTL} apply -f ${TEMP_DIR}/kustomize-build-output.yaml && break
+  done
 }
 
 # Code execution starts here
@@ -120,7 +149,7 @@ fi
 
 echo "IMAGE $IMG";
 
-PREV_IMAGE=$(${KUBECTL} get deploy/gitops-appstudio-service-controller-manager -n gitops -o jsonpath='{..image}');
+get_prev_image
 echo "PREV IMAGE : $PREV_IMAGE";
 
 if [ "$PREV_IMAGE" = "$IMG" ]; then
@@ -134,8 +163,7 @@ echo "Upgrading from $PREV_IMAGE to $IMG";
 create_kustomization_init_file
 
 # Set the right container image and apply the manifests
-echo "[INFO] Applying the manifests generated using kustomize"
-${KUSTOMIZE} build ${TEMP_DIR} |  COMMON_IMAGE=${IMG} envsubst | ${KUBECTL} apply -f -
+apply_kustomize_manifests
 
 # Create Postgresql DB password secret
 generate_postgresql_secret


### PR DESCRIPTION
#### Description:
Rollback error:
During the upgrade, if there is an error, then the deployment is rolled back to its previous image. There is an issue when finding out the previous image when a side car container is running. Due to which during rollback, the image set is wrong causing the rollback to fail.

Timeout Issue:
For git fetch URLs, add a `timeout` value to `90s` and add retries with maximum of 3 retries so that random network failures can be handled gracefully.

#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-570
https://issues.redhat.com/browse/GITOPSRVCE-571
