### PR TITLE
Add ability to control the frequency of self-healing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,10 @@ deploy-k8s-env: pre-deploy-crds postgresql-secret-on-k8s ## Deploy all controlle
 undeploy-k8s-env: pre-undeploy-crds ## Remove all controller/DB workloads from K8s.
 	$(KUSTOMIZE) build $(MAKEFILE_ROOT)/manifests/overlays/k8s-env | kubectl delete -f - 
 
-deploy-k8s-env-e2e: kustomize postgresql-secret-on-k8s ## Deploy all controller/DB workloads to K8s for e2e tests, use e.g. IMG=quay.io/pgeorgia/gitops-service:latest to specify a specific image
+deploy-k8s-env-e2e: pre-deploy-crds postgresql-secret-on-k8s ## Deploy all controller/DB workloads to K8s for e2e tests, use e.g. IMG=quay.io/pgeorgia/gitops-service:latest to specify a specific image
 	$(KUSTOMIZE) build $(MAKEFILE_ROOT)/manifests/overlays/k8s-env-e2e | COMMON_IMAGE=${IMG} envsubst | kubectl apply -f -
 
-undeploy-k8s-env-e2e: kustomize ## Remove all controller/DB e2e test workloads from K8s.
+undeploy-k8s-env-e2e: pre-undeploy-crds ## Remove all controller/DB e2e test workloads from K8s.
 	$(KUSTOMIZE) build $(MAKEFILE_ROOT)/manifests/overlays/k8s-env-e2e | kubectl delete -f -
 
 

--- a/Procfile.no-self-heal
+++ b/Procfile.no-self-heal
@@ -1,0 +1,3 @@
+backend: cd backend && make run-no-self-heal
+cluster-agent: cd cluster-agent && make run-no-self-heal
+appstudio-controller: cd appstudio-controller && make run

--- a/backend-shared/util/util_test.go
+++ b/backend-shared/util/util_test.go
@@ -1,0 +1,53 @@
+package util
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var _ = Describe("General Util Unit Tests", func() {
+
+	Context("Testing the SelfHealInterval() function", func() {
+		const defaultValue = time.Duration(10) * time.Minute
+		var logger logr.Logger
+
+		BeforeEach(func() {
+			logger = log.FromContext(context.Background())
+		})
+
+		When("Environment variable SELF_HEAL_INTERVAL is set to a number", func() {
+			It("Should return a time.Duration of the equivalent number of minutes", func() {
+				defer os.Unsetenv(SelfHealIntervalEnVar)
+
+				os.Setenv(SelfHealIntervalEnVar, "5")
+				actual := SelfHealInterval(defaultValue, logger)
+				Expect(actual).To(Equal(time.Duration(5) * time.Minute))
+			})
+		})
+
+		When("Environment variable SELF_HEAL_INTERVAL is set to something non-numeric", func() {
+			It("Should return the default time.Duration", func() {
+				defer os.Unsetenv(SelfHealIntervalEnVar)
+
+				os.Setenv(SelfHealIntervalEnVar, "five")
+				actual := SelfHealInterval(defaultValue, logger)
+				Expect(actual).To(Equal(defaultValue))
+			})
+		})
+
+		When("Environment variable SELF_HEAL_INTERVAL is not set", func() {
+			It("Should return the default time.Duration", func() {
+				_, isSet := os.LookupEnv(SelfHealIntervalEnVar)
+				Expect(isSet).To(BeFalse())
+				actual := SelfHealInterval(defaultValue, logger)
+				Expect(actual).To(Equal(defaultValue))
+			})
+		})
+	})
+})

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -61,6 +61,9 @@ build: generate fmt vet ## Build manager binary.
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
+	DISABLE_APPSTUDIO_WEBHOOK=true go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
+
+run-no-self-heal: manifests generate fmt vet ## Run a controller from your host.
 	SELF_HEAL_INTERVAL=0 DISABLE_APPSTUDIO_WEBHOOK=true go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
 
 runexec: ## Run a controller from your host using exe in current folder
@@ -79,7 +82,7 @@ endif
 
 chaos-run: manifests generate fmt vet ## Chaos Engineering: Simulate a controller that restarts every ~33 seconds.
 	go build -o /tmp/backend-manager-chaos  main.go
-	SELF_HEAL_INTERVAL=0 DISABLE_APPSTUDIO_WEBHOOK=true KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/backend-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
+	DISABLE_APPSTUDIO_WEBHOOK=true KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/backend-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
 	rm /tmp/backend-manager-chaos
 
 ##@ Deployment

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -61,7 +61,7 @@ build: generate fmt vet ## Build manager binary.
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	DISABLE_APPSTUDIO_WEBHOOK=true go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
+	SELF_HEAL_INTERVAL=0 DISABLE_APPSTUDIO_WEBHOOK=true go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
 
 runexec: ## Run a controller from your host using exe in current folder
 ifeq (,$(wildcard ./main))
@@ -79,7 +79,7 @@ endif
 
 chaos-run: manifests generate fmt vet ## Chaos Engineering: Simulate a controller that restarts every ~33 seconds.
 	go build -o /tmp/backend-manager-chaos  main.go
-	DISABLE_APPSTUDIO_WEBHOOK=true KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/backend-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
+	SELF_HEAL_INTERVAL=0 DISABLE_APPSTUDIO_WEBHOOK=true KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/backend-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
 	rm /tmp/backend-manager-chaos
 
 ##@ Deployment

--- a/cluster-agent/Makefile
+++ b/cluster-agent/Makefile
@@ -116,7 +116,7 @@ build: generate fmt vet ## Build manager binary.
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
+	SELF_HEAL_INTERVAL=0 go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
 # more on controller log level configuration: https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/
 
 runexec: ## Run a controller from your host using exe in current folder
@@ -133,7 +133,7 @@ endif
 
 chaos-run: manifests generate fmt vet ## Chaos Engineering: Simulate a controller that restarts every ~33 seconds.
 	go build -o /tmp/cluster-agent-manager-chaos main.go
-	KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/cluster-agent-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
+	SELF_HEAL_INTERVAL=0 KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/cluster-agent-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
 	rm /tmp/cluster-agent-manager-chaos
 
 # docker-build: test ## Build docker image with the manager.

--- a/cluster-agent/Makefile
+++ b/cluster-agent/Makefile
@@ -116,7 +116,7 @@ build: generate fmt vet ## Build manager binary.
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	SELF_HEAL_INTERVAL=0 go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
+	go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
 # more on controller log level configuration: https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/
 
 run-no-self-heal: manifests generate fmt vet ## Run a controller from your host.

--- a/cluster-agent/Makefile
+++ b/cluster-agent/Makefile
@@ -119,6 +119,9 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	SELF_HEAL_INTERVAL=0 go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
 # more on controller log level configuration: https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/
 
+run-no-self-heal: manifests generate fmt vet ## Run a controller from your host.
+	SELF_HEAL_INTERVAL=0 KUBECONFIG=${WORKLOAD_KUBECONFIG} go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
+
 runexec: ## Run a controller from your host using exe in current folder
 ifeq (,$(wildcard ./main))
 runexec: manifests generate fmt vet
@@ -133,7 +136,7 @@ endif
 
 chaos-run: manifests generate fmt vet ## Chaos Engineering: Simulate a controller that restarts every ~33 seconds.
 	go build -o /tmp/cluster-agent-manager-chaos main.go
-	SELF_HEAL_INTERVAL=0 KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/cluster-agent-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
+	KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/cluster-agent-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
 	rm /tmp/cluster-agent-manager-chaos
 
 # docker-build: test ## Build docker image with the manager.

--- a/manifests/overlays/k8s-env-e2e/backend-deployment-patch.yaml
+++ b/manifests/overlays/k8s-env-e2e/backend-deployment-patch.yaml
@@ -9,5 +9,5 @@ spec:
       containers:
       - env:
         - name: SELF_HEAL_INTERVAL
-          value: "0" 
+          value: "0"
         name: manager

--- a/manifests/overlays/k8s-env-e2e/backend-deployment-patch.yaml
+++ b/manifests/overlays/k8s-env-e2e/backend-deployment-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gitops-core-service-controller-manager
+  namespace: gitops
+spec:
+  template:
+    spec:
+      containers:
+      - env:
+        - name: SELF_HEAL_INTERVAL
+          value: "0" 
+        name: manager

--- a/manifests/overlays/k8s-env-e2e/cluster-agent-deployment-patch.yaml
+++ b/manifests/overlays/k8s-env-e2e/cluster-agent-deployment-patch.yaml
@@ -9,5 +9,5 @@ spec:
       containers:
       - env:
         - name: SELF_HEAL_INTERVAL
-          value: "0" 
+          value: "0"
         name: manager

--- a/manifests/overlays/k8s-env-e2e/cluster-agent-deployment-patch.yaml
+++ b/manifests/overlays/k8s-env-e2e/cluster-agent-deployment-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gitops-service-agent-controller-manager
+  namespace: gitops
+spec:
+  template:
+    spec:
+      containers:
+      - env:
+        - name: SELF_HEAL_INTERVAL
+          value: "0" 
+        name: manager

--- a/manifests/overlays/k8s-env-e2e/kustomization.yaml
+++ b/manifests/overlays/k8s-env-e2e/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base/crd/overlays/local-dev
+- ../../base/gitops-namespace
+- ../../../appstudio-controller/config/default
+- ../../../backend/config/default
+- ../../../cluster-agent/config/default
+- ../../base/postgresql-staging
+# - ../../base/gitops-service-argocd
+
+patchesStrategicMerge:
+- backend-deployment-patch.yaml
+- cluster-agent-deployment-patch.yaml
+
+# Uncomment to use a custom image:
+
+# images:
+#   - name: \${COMMON_IMAGE}
+#     newName: quay.io/(your user name)/gitops-service
+#     newTag: latest

--- a/manifests/overlays/k8s-env-e2e/kustomization.yaml
+++ b/manifests/overlays/k8s-env-e2e/kustomization.yaml
@@ -2,13 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../base/crd/overlays/local-dev
-- ../../base/gitops-namespace
-- ../../../appstudio-controller/config/default
-- ../../../backend/config/default
-- ../../../cluster-agent/config/default
-- ../../base/postgresql-staging
-# - ../../base/gitops-service-argocd
+- ../k8s-env
 
 patchesStrategicMerge:
 - backend-deployment-patch.yaml

--- a/scripts/openshiftci-presubmit-e2e-tests.sh
+++ b/scripts/openshiftci-presubmit-e2e-tests.sh
@@ -27,7 +27,7 @@ make install-argocd-openshift
 # Deploy GitOps Service components
 # Use Image built by CI, image name is provided as env variable 'CI_IMAGE' by CI
 echo "Using Image $CI_IMAGE"
-make install-all-k8s IMG=$CI_IMAGE
+make install-all-k8s-e2e IMG=$CI_IMAGE
 
 # Port forwarding is needed by E2E to connect with DB
 echo "Starting Port-Forward loop"


### PR DESCRIPTION
#### Description:
- Added ability to use an environment variable to set the the interval in minutes for both database and namespace reconciliation.  If the variable is set to `0`, reconciliation will be disabled.  If the variable is not set, the current value of `30` minutes will be used
- Updated the Makefiles for the backend and the cluster-agent to set the variable to `0` to disable reconciliation when running the e2e and chaos tests.

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-565

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
