### PR TITLE
Change argocd e2e tests to call EnsureCleanSlate() before running

### DIFF
--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/tests"
 	"github.com/redhat-appstudio/managed-gitops/backend/eventloop/eventloop_test_util"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -488,7 +488,7 @@ var _ = Describe("SharedResourceEventLoop ManagedEnvironment-related Test", func
 			defer mockCtrl.Finish()
 			mockClient := mocks.NewMockClient(mockCtrl)
 
-			forbidden := errors.NewForbidden(schema.GroupResource{Group: "", Resource: "namespaces"}, "", fmt.Errorf("user can't access namespaces"))
+			forbidden := k8serrors.NewForbidden(schema.GroupResource{Group: "", Resource: "namespaces"}, "", fmt.Errorf("user can't access namespaces"))
 			mockClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(forbidden)
 			mockClient.EXPECT().List(gomock.Any(), gomock.Any()).Return(forbidden)
 
@@ -537,7 +537,7 @@ var _ = Describe("SharedResourceEventLoop ManagedEnvironment-related Test", func
 			defer mockCtrl.Finish()
 			mockClient := mocks.NewMockClient(mockCtrl)
 
-			forbidden := errors.NewForbidden(schema.GroupResource{Group: "", Resource: "namespace"}, "", fmt.Errorf("user can't access namespace"))
+			forbidden := k8serrors.NewForbidden(schema.GroupResource{Group: "", Resource: "namespace"}, "", fmt.Errorf("user can't access namespace"))
 			mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(forbidden)
 			mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(forbidden)
 

--- a/tests-e2e/argocd/argocd_application_test.go
+++ b/tests-e2e/argocd/argocd_application_test.go
@@ -18,6 +18,11 @@ import (
 
 var _ = Describe("Argo CD Application", func() {
 	Context("Creating GitOpsDeployment should result in an Argo CD Application", func() {
+		BeforeEach(func() {
+			By("Delete old namespaces, and kube-system resources")
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+		})
+
 		It("Argo CD Application should have has prune, allowEmpty and selfHeal enabled", func() {
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 

--- a/tests-e2e/argocd/argocd_application_test.go
+++ b/tests-e2e/argocd/argocd_application_test.go
@@ -24,7 +24,6 @@ var _ = Describe("Argo CD Application", func() {
 		})
 
 		It("Argo CD Application should have has prune, allowEmpty and selfHeal enabled", func() {
-			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
 			By("create a new GitOpsDeployment CR")
 			gitOpsDeployment := gitopsDeplFixture.BuildGitOpsDeploymentResource("my-gitops-depl-automated",

--- a/tests-e2e/argocd/queryscoped_cluster_secrets_test.go
+++ b/tests-e2e/argocd/queryscoped_cluster_secrets_test.go
@@ -73,6 +73,8 @@ var _ = Describe("Argo CD Application tests", func() {
 					Expect(err).To(BeNil())
 				}
 			}
+
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 		}
 
 		// For each user, create: Namespace, ServiceAccounts, Roles/RoleBindings, and optionally, ClusterRole/ClusterRoleBindings.


### PR DESCRIPTION
#### Description:
- Two of the e2e tests in the argocd package don't call EnsureCleanSlate() before running, which makes them sucseptable to failing if a prior test leave some conflicting artifacts around.

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
