### PR TITLE
Remove references to KUBECONFIG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ ensure-gitops-ns-exists:
 	kubectl create namespace gitops 2> /dev/null || true
 
 ensure-workload-gitops-ns-exists:
-	KUBECONFIG=${WORKLOAD_KUBECONFIG} kubectl create namespace gitops 2> /dev/null || true
+	kubectl create namespace gitops 2> /dev/null || true
 
 
 

--- a/cluster-agent/Makefile
+++ b/cluster-agent/Makefile
@@ -116,7 +116,7 @@ build: generate fmt vet ## Build manager binary.
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	KUBECONFIG=${WORKLOAD_KUBECONFIG} go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
+	go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
 # more on controller log level configuration: https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/
 
 runexec: ## Run a controller from your host using exe in current folder
@@ -124,11 +124,11 @@ ifeq (,$(wildcard ./main))
 runexec: manifests generate fmt vet
 	@echo Building and running cluster-agent
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build ./main.go
-	KUBECONFIG=${WORKLOAD_KUBECONFIG} main --zap-log-level info --zap-time-encoding=rfc3339nano
+	main --zap-log-level info --zap-time-encoding=rfc3339nano
 else
 runexec:
 	@echo Running cluster-agent using existing main executable.
-	KUBECONFIG=${WORKLOAD_KUBECONFIG} main --zap-log-level info --zap-time-encoding=rfc3339nano
+	 main --zap-log-level info --zap-time-encoding=rfc3339nano
 endif
 
 chaos-run: manifests generate fmt vet ## Chaos Engineering: Simulate a controller that restarts every ~33 seconds.


### PR DESCRIPTION
#### Description:
Remove references to Kubeconfig in makefiles as it is no longer required (was previously used for KCP support) and is causing an error (cluster agent) in CI. 

#### Link to JIRA Story (if applicable):
https://issues.redhat.com/browse/GITOPSRVCE-453 
