### PR TITLE
Delete GitOpsDeploymentManagedEnvironment when the corresponding Environment resource is deleted

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
@@ -24,6 +24,11 @@ import (
 )
 
 var _ = Describe("Environment controller tests", func() {
+	ctx := context.Background()
+
+	var k8sClient client.Client
+	var reconciler EnvironmentReconciler
+	var apiNamespace corev1.Namespace
 
 	ctx := context.Background()
 
@@ -819,12 +824,7 @@ var _ = Describe("Environment controller tests", func() {
 
 			By("verify if the ManagedEnvironment is using the incoming secret")
 
-			managedEnvCR := managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "managed-environment-" + env.Name,
-					Namespace: req.Namespace,
-				},
-			}
+			managedEnvCR := generateEmptyManagedEnvironment(env.Name, req.Namespace)
 			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&managedEnvCR), &managedEnvCR)
 			Expect(err).To(BeNil())
 

--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
@@ -30,12 +30,6 @@ var _ = Describe("Environment controller tests", func() {
 	var reconciler EnvironmentReconciler
 	var apiNamespace corev1.Namespace
 
-	ctx := context.Background()
-
-	var k8sClient client.Client
-	var reconciler EnvironmentReconciler
-	var apiNamespace corev1.Namespace
-
 	Context("Reconcile function call tests", func() {
 
 		BeforeEach(func() {

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -29,7 +29,6 @@ import (
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -711,7 +710,7 @@ var _ = Describe("Environment E2E tests", func() {
 			apiServerURL       string
 			secret             *corev1.Secret
 		)
-		ctx := context.Background()
+
 		BeforeEach(func() {
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())
 
@@ -1259,11 +1258,7 @@ var _ = Describe("Environment E2E tests", func() {
 			err = k8s.Create(&managedEnv, k8sClient)
 			Expect(err).To(BeNil())
 
-			Eventually(func() bool {
-				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&managedEnv), &managedEnv)
-				Expect(apierr.IsNotFound(err)).To(BeTrue())
-				return Expect(err).ToNot(BeNil())
-			}, 1*time.Minute)
+			Eventually(managedEnv, "60s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
 
 		})
 	})

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -1239,6 +1239,7 @@ var _ = Describe("Environment E2E tests", func() {
 
 		It("should verify Deletion of GitOpsDeploymentManagedEnvironment on Non-existent Environment", func() {
 			By("creates a GitOpsDeploymentManagedEnvironment with an ownerref to an Environment that doesn't exist")
+
 			kubeConfigContents, apiServerURL, err := fixture.ExtractKubeConfigValues()
 			Expect(err).To(BeNil())
 
@@ -1258,7 +1259,7 @@ var _ = Describe("Environment E2E tests", func() {
 			err = k8s.Create(&managedEnv, k8sClient)
 			Expect(err).To(BeNil())
 
-			Eventually(managedEnv, "60s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
+			Eventually(&managedEnv, "60s", "1s").Should(k8s.ExistByName(k8sClient))
 
 		})
 	})

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -1244,11 +1244,15 @@ var _ = Describe("Environment E2E tests", func() {
 			Expect(err).To(BeNil())
 
 			managedEnv, _ := buildManagedEnvironment(apiServerURL, kubeConfigContents, true)
+
+			fakeEnvName := "name"
+
+			managedEnv.Name = "managed-environment-" + fakeEnvName
 			managedEnv.OwnerReferences = []metav1.OwnerReference{
 				{
 					Kind:       "Environment",
-					Name:       "name",
-					APIVersion: "SomeOtherAPIVersion",
+					Name:       fakeEnvName,
+					APIVersion: managedgitopsv1alpha1.GroupVersion.Group + "/" + managedgitopsv1alpha1.GroupVersion.Version,
 					UID:        "123",
 				},
 			}
@@ -1259,7 +1263,7 @@ var _ = Describe("Environment E2E tests", func() {
 			err = k8s.Create(&managedEnv, k8sClient)
 			Expect(err).To(BeNil())
 
-			Eventually(&managedEnv, "60s", "1s").Should(k8s.ExistByName(k8sClient))
+			Eventually(&managedEnv, "60s", "1s").ShouldNot(k8s.ExistByName(k8sClient))
 
 		})
 	})


### PR DESCRIPTION
#### Description:
- Deleting GitOpsDeploymentManagedEnvironment in environment_controller.go when Environment Resource doesn't exists
- Updated unit test as above

#### Link to JIRA Story (if applicable):
https://issues.redhat.com/browse/GITOPSRVCE-562
