### PR TITLE
Log and return if the ApplicationID of the SyncOperation is not found

### DIFF
--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
@@ -359,7 +359,7 @@ func (a *applicationEventLoopRunner_Action) handleDeletedGitOpsDeplSyncRunEvent(
 	log.Info("Received GitOpsDeploymentSyncRun event for a GitOpsDeploymentSyncRun resource that no longer exists")
 
 	if syncOperation.Application_id == "" {
-		log.Info("Application row not found for SyncOperation", "syncOperationID", syncOperation.SyncOperation_id, "applicationID", syncOperation.Application_id)
+		log.Info("Application row not found for SyncOperation. This is normally because the Application has already been deleted.", "syncOperationID", syncOperation.SyncOperation_id, "applicationID", syncOperation.Application_id)
 		return nil
 	}
 

--- a/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_syncruns.go
@@ -358,6 +358,11 @@ func (a *applicationEventLoopRunner_Action) handleDeletedGitOpsDeplSyncRunEvent(
 	log := a.log
 	log.Info("Received GitOpsDeploymentSyncRun event for a GitOpsDeploymentSyncRun resource that no longer exists")
 
+	if syncOperation.Application_id == "" {
+		log.Info("Application row not found for SyncOperation", "syncOperationID", syncOperation.SyncOperation_id, "applicationID", syncOperation.Application_id)
+		return nil
+	}
+
 	// 1) Update the state of the SyncOperation DB table to say that we want to terminate it, if it is runing
 	syncOperation.DesiredState = db.SyncOperation_DesiredState_Terminated
 	if err := dbQueries.UpdateSyncOperation(ctx, &syncOperation); err != nil {

--- a/backend/eventloop/db_reconciler.go
+++ b/backend/eventloop/db_reconciler.go
@@ -393,6 +393,11 @@ func cleanOrphanedEntriesfromTable_ACTDM_GitOpsDeploymentSyncRun(ctx context.Con
 		return
 	}
 
+	if syncOperationDb.Application_id == "" {
+		log.Info("Application row not found for SyncOperation", "syncOperationID", syncOperationDb.SyncOperation_id, "applicationID", syncOperationDb.Application_id)
+		return
+	}
+
 	applicationDb = db.Application{Application_id: syncOperationDb.Application_id}
 	if err := dbQueries.GetApplicationById(ctx, &applicationDb); err != nil {
 		log.Error(err, "Error occurred in cleanOrphanedEntriesfromTable_ACTDM_GitOpsDeploymentSyncRun while fetching Application by Id : "+syncOperationDb.Application_id+" from DB.")


### PR DESCRIPTION
#### Description:
- The Application row could have been deleted while processing SyncRun so log and return if the ApplicationID of SyncOperation is empty.

#### Link to JIRA Story (if applicable):
https://issues.redhat.com/browse/GITOPSRVCE-543