### PR TITLE
Temporarily disable infra-deployments repo update

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -15,11 +15,11 @@ spec:
       value: "{{ revision }}"
     - name: output-image
       value: 'quay.io/redhat-appstudio/gitops-service:{{ revision }}'
-    - name: infra-deployment-update-script
-      value: |
-        sed -i -E 's/[0-9a-f]{40}/$(params.revision)/g' components/gitops/staging/base/kustomization.yaml
-        sed -i -E 's/[0-9a-f]{40}/$(params.revision)/g' components/gitops/production/base/kustomization.yaml
-        sed -i -E 's/[0-9a-f]{40}/$(params.revision)/g' components/gitops/development/kustomization.yaml
+    # - name: infra-deployment-update-script
+    #   value: |
+    #     sed -i -E 's/[0-9a-f]{40}/$(params.revision)/g' components/gitops/staging/base/kustomization.yaml
+    #     sed -i -E 's/[0-9a-f]{40}/$(params.revision)/g' components/gitops/production/base/kustomization.yaml
+    #     sed -i -E 's/[0-9a-f]{40}/$(params.revision)/g' components/gitops/development/kustomization.yaml
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest


### PR DESCRIPTION
#### Description:
- Pushes to the `main` branch should not update the infra-deployments repo: instead we should only rely on pushes to the `release-summit-2023` branch to update the infra-deployments repo
- This will be re-enabled once summit is over (and the summit PipelineRun and branch will be removed).


#### Link to JIRA Story (if applicable): N/A
