### PR TITLE
Remove time.Sleep() and replace it with mocked time

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetreclaimer_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetreclaimer_controller_test.go
@@ -8,10 +8,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/tests"
 	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -113,8 +115,8 @@ var _ = Describe("Test DeploymentTargetReclaimController", func() {
 				err = k8sClient.Delete(ctx, &sr)
 				Expect(err).To(BeNil())
 
-				// TODO: GITOPSRVCE-576 - Replace this with mocked time
-				time.Sleep(2 * time.Minute)
+				// Use a mock clock and forward the time by two minutes.
+				reconciler.Clock = sharedutil.NewMockClock(time.Now().Add(2 * time.Minute))
 
 				res, err = reconciler.Reconcile(ctx, request)
 				Expect(err).To(BeNil())

--- a/appstudio-controller/main.go
+++ b/appstudio-controller/main.go
@@ -184,6 +184,7 @@ func main() {
 	if err = (&appstudioredhatcomcontrollers.DeploymentTargetReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
+		Clock:  sharedutil.NewClock(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DeploymentTarget")
 		os.Exit(1)

--- a/backend-shared/util/time.go
+++ b/backend-shared/util/time.go
@@ -1,0 +1,33 @@
+package util
+
+import "time"
+
+// Clock interface is used to mock the functions provided by the time package.
+type Clock interface {
+	Now() time.Time
+}
+
+type clock struct{}
+
+func (d *clock) Now() time.Time {
+	return time.Now()
+}
+
+func NewClock() Clock {
+	return &clock{}
+}
+
+// MockClock implements the Clock interface with a custom current time.
+type MockClock struct {
+	now time.Time
+}
+
+func NewMockClock(cur time.Time) *MockClock {
+	return &MockClock{
+		now: cur,
+	}
+}
+
+func (m *MockClock) Now() time.Time {
+	return m.now
+}


### PR DESCRIPTION
#### Description:
- Remove the `time.Sleep()` used in the deploymenttargetreclaimer_controller.go and replace it with mocked time. 
#### Link to JIRA Story (if applicable):

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->

https://issues.redhat.com/browse/GITOPSRVCE-576