### PR TITLE
Remove DTClass from appstudio-e2e tests overlay

### DIFF
--- a/manifests/overlays/appstudio-staging-cluster/kustomization.yaml
+++ b/manifests/overlays/appstudio-staging-cluster/kustomization.yaml
@@ -4,7 +4,9 @@ kind: Kustomization
 resources:
 - ../../base/crd/overlays/stonesoup
 - ../../base/gitops-namespace
-- ../../base/cluster-scoped
+# This is not needed: these kustomize overlay is used to run appstudio-e2e tests in infra-deployments, 
+# and these tests assume that there is no DeploymentTargetClass defined.
+#       - ../../base/cluster-scoped
 - ../../../appstudio-controller/config/default-no-prometheus
 - ../../../backend/config/default-no-prometheus
 - ../../../cluster-agent/config/default-no-prometheus


### PR DESCRIPTION
#### Description:
- The `DeploymentTargetClass` is not needed to be defined when running the appstudio-e2e tests, as part of the infra-deployments repository.

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
