### PR TITLE
Ensure DeploymentTarget/SpaceRequest Namespaces are used in GitOpsDeployments destination field

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetbinder_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetbinder_controller.go
@@ -402,6 +402,7 @@ func handleDynamicDTCProvisioning(ctx context.Context, k8sClient client.Client, 
 }
 
 // findMatchingDTForDTC tries to find a DT that matches the given DTC in a namespace.
+// NOTE: this function returns nil if no matching DT was found.
 func findMatchingDTForDTC(ctx context.Context, k8sClient client.Client, dtc applicationv1alpha1.DeploymentTargetClaim) (*applicationv1alpha1.DeploymentTarget, error) {
 	dtList := applicationv1alpha1.DeploymentTargetList{}
 	if err := k8sClient.List(ctx, &dtList, &client.ListOptions{Namespace: dtc.Namespace}); err != nil {

--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetbinder_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetbinder_controller_test.go
@@ -788,7 +788,7 @@ var _ = Describe("Test DeploymentTargetClaimBinderController", func() {
 				err = k8sClient.Create(ctx, &dtc)
 				Expect(err).To(BeNil())
 
-				boundedDT, err := getDTBoundByDTC(ctx, k8sClient, &dtc)
+				boundedDT, err := getDTBoundByDTC(ctx, k8sClient, dtc)
 				Expect(err).To(BeNil())
 				Expect(boundedDT).ToNot(BeNil())
 				Expect(client.ObjectKeyFromObject(boundedDT)).To(Equal(client.ObjectKeyFromObject(&dt)))
@@ -801,7 +801,7 @@ var _ = Describe("Test DeploymentTargetClaimBinderController", func() {
 				err := k8sClient.Create(ctx, &dtc)
 				Expect(err).To(BeNil())
 
-				boundedDT, err := getDTBoundByDTC(ctx, k8sClient, &dtc)
+				boundedDT, err := getDTBoundByDTC(ctx, k8sClient, dtc)
 				Expect(apierr.IsNotFound(err)).To(BeTrue())
 				Expect(boundedDT).To(BeNil())
 			})
@@ -824,7 +824,7 @@ var _ = Describe("Test DeploymentTargetClaimBinderController", func() {
 				err = k8sClient.Create(ctx, &fakedt)
 				Expect(err).To(BeNil())
 
-				boundedDT, err := getDTBoundByDTC(ctx, k8sClient, &dtc)
+				boundedDT, err := getDTBoundByDTC(ctx, k8sClient, dtc)
 				Expect(err).To(BeNil())
 				Expect(boundedDT).ToNot(BeNil())
 				Expect(client.ObjectKeyFromObject(boundedDT)).To(Equal(client.ObjectKeyFromObject(&dt)))
@@ -851,7 +851,7 @@ var _ = Describe("Test DeploymentTargetClaimBinderController", func() {
 				Expect(err).To(BeNil())
 
 				By("check if an error is a second DT is detected and an error is returned")
-				dt, err := getDTBoundByDTC(ctx, k8sClient, &dtc)
+				dt, err := getDTBoundByDTC(ctx, k8sClient, dtc)
 				Expect(dt).To(BeNil())
 				Expect(err).ToNot(BeNil())
 				expectedErr := fmt.Errorf("multiple DeploymentTargets found for a bounded DeploymentTargetClaim %s", dtc.Name)

--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
@@ -388,7 +388,7 @@ func generateDesiredResource(ctx context.Context, env appstudioshared.Environmen
 		}
 
 		// If the DeploymentTargetClaim is bounded, find the corresponding DeploymentTarget.
-		dt, err := getDTBoundByDTC(ctx, k8sClient, dtc)
+		dt, err := getDTBoundByDTC(ctx, k8sClient, *dtc)
 		if err != nil {
 			if apierr.IsNotFound(err) {
 				log.Error(err, "DeploymentTargetClaim references a DeploymentTarget that does not exist", "DeploymentTargetClaim", dtc.Name)
@@ -601,7 +601,7 @@ func (r *EnvironmentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&source.Kind{Type: &corev1.Secret{}},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForSecret),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}), // secret doesn't have a generation, so we use RV
 		).
 		Watches(
 			&source.Kind{Type: &appstudioshared.DeploymentTargetClaim{}},

--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
@@ -340,7 +340,7 @@ var _ = Describe("Environment controller tests", func() {
 
 			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&env), &env)
 			Expect(err).To(BeNil())
-			ExpectEnvironmentConditionErrorOccured("the secret secret-that-doesnt-exist referenced by the Environment resource was not found", env)
+			expectEnvironmentConditionErrorOccured("the secret secret-that-doesnt-exist referenced by the Environment resource was not found", env)
 
 		})
 
@@ -411,7 +411,7 @@ var _ = Describe("Environment controller tests", func() {
 			env = appstudioshared.Environment{}
 			err = reconciler.Get(ctx, req.NamespacedName, &env)
 			Expect(err).To(BeNil())
-			ExpectEnvironmentConditionErrorOccured("Environment is invalid since it cannot have both DeploymentTargetClaim and credentials configuration set", env)
+			expectEnvironmentConditionErrorOccured("Environment is invalid since it cannot have both DeploymentTargetClaim and credentials configuration set", env)
 
 		})
 
@@ -552,7 +552,7 @@ var _ = Describe("Environment controller tests", func() {
 			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&env), &env); err != nil {
 				Expect(err).To(BeNil())
 			}
-			ExpectEnvironmentConditionErrorOccured("the secret test-secret referenced by the Environment resource was not found", env)
+			expectEnvironmentConditionErrorOccured("the secret test-secret referenced by the Environment resource was not found", env)
 			Expect(res).To(Equal(reconcile.Result{}))
 			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&managedEnvSecret), &managedEnvSecret)
 			Expect(err).ToNot(BeNil())
@@ -698,7 +698,7 @@ var _ = Describe("Environment controller tests", func() {
 			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&env), &env); err != nil {
 				Expect(err).To(BeNil())
 			}
-			ExpectEnvironmentConditionErrorOccured("the secret test-secret referenced by the Environment resource was not found", env)
+			expectEnvironmentConditionErrorOccured("the secret test-secret referenced by the Environment resource was not found", env)
 			Expect(res).To(Equal(reconcile.Result{}))
 
 			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&managedEnvSecret), &managedEnvSecret)
@@ -793,7 +793,7 @@ var _ = Describe("Environment controller tests", func() {
 			err = reconciler.Get(ctx, req.NamespacedName, &env)
 			Expect(err).To(BeNil())
 
-			ExpectEnvironmentConditionErrorOccured("DeploymentTargetClaim not found while generating the desired Environment resource", env)
+			expectEnvironmentConditionErrorOccured("DeploymentTargetClaim not found while generating the desired Environment resource", env)
 
 		})
 
@@ -853,7 +853,7 @@ var _ = Describe("Environment controller tests", func() {
 			err = reconciler.Get(ctx, req.NamespacedName, &env)
 			Expect(err).To(BeNil())
 
-			ExpectEnvironmentConditionErrorOccured("DeploymentTarget not found for DeploymentTargetClaim", env)
+			expectEnvironmentConditionErrorOccured("DeploymentTarget not found for DeploymentTargetClaim", env)
 		})
 
 		It("should set an error condition, but not return a Reconcile error, if Environment's DTC references a DeploymentTarget that doesn't exist", func() {
@@ -903,7 +903,7 @@ var _ = Describe("Environment controller tests", func() {
 			env = appstudioshared.Environment{}
 			err = reconciler.Get(ctx, req.NamespacedName, &env)
 			Expect(err).To(BeNil())
-			ExpectEnvironmentConditionErrorOccured("DeploymentTargetClaim references a DeploymentTarget that does not exist", env)
+			expectEnvironmentConditionErrorOccured("DeploymentTargetClaim references a DeploymentTarget that does not exist", env)
 		})
 
 		It("shouldn't process the Environment if neither credentials nor DTC is provided", func() {
@@ -1624,7 +1624,8 @@ var _ = Describe("Environment controller tests", func() {
 	})
 })
 
-func ExpectEnvironmentConditionErrorOccured(envMessage string, env appstudioshared.Environment) {
+// expectEnvironmentConditionErrorOccured verifies that an EnvironmentConditionErrorOccurred is set, with the appropriate message
+func expectEnvironmentConditionErrorOccured(envMessage string, env appstudioshared.Environment) {
 
 	// WithOffset tells Gingko to ignore this function when reporting the failing line in the test
 

--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
@@ -302,7 +302,7 @@ var _ = Describe("Environment controller tests", func() {
 
 		})
 
-		It("should return an error if the Environment references a Secret that doesn't exist", func() {
+		It("should update the Environment status condition if the Environment references a Secret that doesn't exist, but should not return an error", func() {
 
 			By("creating an Environment resource pointing to a Secret that doesn't exist")
 			env := appstudioshared.Environment{
@@ -328,7 +328,7 @@ var _ = Describe("Environment controller tests", func() {
 			err := k8sClient.Create(ctx, &env)
 			Expect(err).To(BeNil())
 
-			By("reconciling the ManagedEnvironment")
+			By("reconciling the Environment")
 			req := ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      env.Name,

--- a/appstudio-controller/controllers/appstudio.redhat.com/predicates.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/predicates.go
@@ -8,10 +8,10 @@ import (
 	applicationv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 )
 
-// DTCPendingDynamicProvisioningBySandbox returns a predicate which filters out
+// dtcPendingDynamicProvisioningBySandbox returns a predicate which filters out
 // only DeploymentTargetClaims which have been marked for dynamic provisioning by a sandbox-provisioner
 // and are in Pending phase
-func DTCPendingDynamicProvisioningBySandbox() predicate.Predicate {
+func dtcPendingDynamicProvisioningBySandbox() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(createEvent event.CreateEvent) bool {
 			return false
@@ -23,23 +23,23 @@ func DTCPendingDynamicProvisioningBySandbox() predicate.Predicate {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return IsDeploymentClaimStatusPending(e.ObjectNew) && IsDeploymentTargetClaimMarkedForDynamicProvisioning(e.ObjectNew)
+			return isDeploymentClaimStatusPending(e.ObjectNew) && isDeploymentTargetClaimMarkedForDynamicProvisioning(e.ObjectNew)
 		},
 	}
 }
 
-// IsDeploymentClaimStatusPending returns a boolean indicating whether the DeploymentTargetClaim status is pending.
+// isDeploymentClaimStatusPending returns a boolean indicating whether the DeploymentTargetClaim status is pending.
 // If the objects passed to this function are not DeploymentTargetClaim, the function will return false.
-func IsDeploymentClaimStatusPending(objectNew client.Object) bool {
+func isDeploymentClaimStatusPending(objectNew client.Object) bool {
 	if dtc, ok := objectNew.(*applicationv1alpha1.DeploymentTargetClaim); ok {
 		return dtc.Status.Phase == applicationv1alpha1.DeploymentTargetClaimPhase_Pending
 	}
 	return false
 }
 
-// IsDeploymentTargetClaimMarkedForDynamicProvisioning returns a boolean indicating whether the DeploymentTargetClaim
+// isDeploymentTargetClaimMarkedForDynamicProvisioning returns a boolean indicating whether the DeploymentTargetClaim
 // is marked for dynamic provisioning. If the objects passed to this function are not DeploymentTargetClaim, the function will return false.
-func IsDeploymentTargetClaimMarkedForDynamicProvisioning(objectNew client.Object) bool {
+func isDeploymentTargetClaimMarkedForDynamicProvisioning(objectNew client.Object) bool {
 	if dtc, ok := objectNew.(*applicationv1alpha1.DeploymentTargetClaim); ok {
 		return isMarkedForDynamicProvisioning(*dtc)
 	}

--- a/appstudio-controller/controllers/appstudio.redhat.com/predicates_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/predicates_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Test Predicates", func() {
 
 		})
 		Context("Test DTCPendingDynamicProvisioningBySandbox predicate", func() {
-			instance := DTCPendingDynamicProvisioningBySandbox()
+			instance := dtcPendingDynamicProvisioningBySandbox()
 
 			It("should ignore creating events", func() {
 				contextEvent := event.CreateEvent{

--- a/appstudio-controller/controllers/appstudio.redhat.com/sandboxprovisioner_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/sandboxprovisioner_controller.go
@@ -210,6 +210,6 @@ func createSpaceRequestForDTC(ctx context.Context, k8sClient client.Client, dtc 
 func (r *SandboxProvisionerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&applicationv1alpha1.DeploymentTargetClaim{}).
-		WithEventFilter(DTCPendingDynamicProvisioningBySandbox()).
+		WithEventFilter(dtcPendingDynamicProvisioningBySandbox()).
 		Complete(r)
 }

--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
@@ -618,7 +618,8 @@ func (r *SnapshotEnvironmentBindingReconciler) SetupWithManager(mgr ctrl.Manager
 		Watches(
 			&source.Kind{Type: &appstudioshared.DeploymentTarget{}},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForDeploymentTarget),
-			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+			// When/if we start using DT's .status field, switch this ResourceVersionChangedPredicate:
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		Watches(
 			&source.Kind{Type: &appstudioshared.DeploymentTargetClaim{}},

--- a/backend-shared/util/log/log.go
+++ b/backend-shared/util/log/log.go
@@ -53,4 +53,5 @@ func LogAPIResourceChangeEvent(resourceNamespace string, resourceName string, re
 
 	log.Info(fmt.Sprintf("API Resource changed: %s", string(resourceChangeType)), "namespace",
 		resourceNamespace, "name", resourceName, "object", string(jsonRepresentation))
+
 }

--- a/tests-e2e/appstudio/devsandboxdeployment_test.go
+++ b/tests-e2e/appstudio/devsandboxdeployment_test.go
@@ -1,14 +1,15 @@
-package core
+package appstudio
 
 import (
 	"context"
+
 	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
-	//dtcfixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/deploymenttargetclaim"
+
 	spfixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/spacerequest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/tests-e2e/appstudio/dt_dtc_dtclass_test.go
+++ b/tests-e2e/appstudio/dt_dtc_dtclass_test.go
@@ -1,4 +1,4 @@
-package core
+package appstudio
 
 import (
 	"context"
@@ -61,7 +61,7 @@ var _ = Describe("DeploymentTarget DeploymentTargetClaim and Class tests", func(
 			err := k8s.Create(dtclass, k8sClient)
 			Expect(err).To(BeNil())
 
-			By("Step 1 - Create a DeploymentTargetClaim that references the class ")
+			By("Step 1 - Create a DeploymentTargetClaim that references the class")
 			dtc := appstudiosharedv1.DeploymentTargetClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "staging-dtc",
@@ -147,7 +147,7 @@ var _ = Describe("DeploymentTarget DeploymentTargetClaim and Class tests", func(
 					Namespace: dtc.Namespace,
 				},
 				StringData: map[string]string{
-					"some-data": generateFakeKubeConfig(),
+					"some-data": k8s.GenerateFakeKubeConfig(),
 				},
 			}
 			err = k8s.Create(&secret, k8sClient)

--- a/tests-e2e/appstudio/sandboxprovisioner_test.go
+++ b/tests-e2e/appstudio/sandboxprovisioner_test.go
@@ -1,7 +1,8 @@
-package core
+package appstudio
 
 import (
 	"context"
+
 	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -39,7 +40,7 @@ var _ = Describe("Sandbox Provisioner controller tests", func() {
 					Annotations: map[string]string{},
 				},
 				Spec: appstudiosharedv1.DeploymentTargetClassSpec{
-					Provisioner: appstudiosharedv1.Provisioner_Devsandbox,
+					Provisioner:   appstudiosharedv1.Provisioner_Devsandbox,
 					ReclaimPolicy: "Retain",
 				},
 			}

--- a/tests-e2e/core/managed_environment_status_test.go
+++ b/tests-e2e/core/managed_environment_status_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 			By("creating the GitOpsDeploymentManagedEnvironment with a target cluster that does not exist")
 
 			apiServerURL := "https://api2.fake-e2e-test-data.origin-ci-int-gce.dev.rhcloud.com:6443"
-			managedEnv, secret := buildManagedEnvironment(apiServerURL, generateFakeKubeConfig(), true)
+			managedEnv, secret := buildManagedEnvironment(apiServerURL, k8s.GenerateFakeKubeConfig(), true)
 
 			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
 			Expect(err).To(Succeed())
@@ -163,40 +163,3 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 		})
 	})
 })
-
-func generateFakeKubeConfig() string {
-	// This config has been sanitized of any real credentials.
-	return `
-apiVersion: v1
-kind: Config
-clusters:
-  - cluster:
-      insecure-skip-tls-verify: true
-      server: https://api.fake-e2e-test-data.origin-ci-int-gce.dev.rhcloud.com:6443
-    name: api-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
-  - cluster:
-      insecure-skip-tls-verify: true
-      server: https://api2.fake-e2e-test-data.origin-ci-int-gce.dev.rhcloud.com:6443
-    name: api2-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
-contexts:
-  - context:
-      cluster: api-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
-      namespace: jgw
-      user: kube:admin/api-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
-    name: default/api-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443/kube:admin
-  - context:
-      cluster: api2-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
-      namespace: jgw
-      user: kube:admin/api2-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
-    name: default/api2-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443/kube:admin
-current-context: default/api-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443/kube:admin
-preferences: {}
-users:
-  - name: kube:admin/api-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
-    user:
-      token: sha256~ABCdEF1gHiJKlMnoP-Q19qrTuv1_W9X2YZABCDefGH4
-  - name: kube:admin/api2-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
-    user:
-      token: sha256~abcDef1gHIjkLmNOp-q19QRtUV1_w9x2yzabcdEFgh4
-`
-}

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -1243,6 +1243,7 @@ var _ = Describe("Environment E2E tests", func() {
 			expectedEnvSpec := managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironmentSpec{
 				APIURL:                   dt.Spec.KubernetesClusterCredentials.APIURL,
 				ClusterCredentialsSecret: dt.Spec.KubernetesClusterCredentials.ClusterCredentialsSecret,
+				Namespaces:               []string{dt.Spec.KubernetesClusterCredentials.DefaultNamespace},
 			}
 			Eventually(*managedEnvCR, "2m", "1s").Should(managedenvironment.HaveCredentials(expectedEnvSpec))
 		})

--- a/tests-e2e/fixture/gitopsdeployment/fixture.go
+++ b/tests-e2e/fixture/gitopsdeployment/fixture.go
@@ -326,6 +326,7 @@ func HaveReconciledState(reconciledState managedgitopsv1alpha1.ReconciledState) 
 func HaveTargetNamespace(targetNamespace string) matcher.GomegaMatcher {
 
 	return expectedCondition(func(gitopsDepl managedgitopsv1alpha1.GitOpsDeployment) bool {
+		fmt.Println("Waiting for gitopsDepl.Spec.Destination.Namespace. expected:", targetNamespace, ", actual:", gitopsDepl.Spec.Destination.Namespace)
 		return gitopsDepl.Spec.Destination.Namespace == targetNamespace
 	})
 

--- a/tests-e2e/fixture/k8s/fixture.go
+++ b/tests-e2e/fixture/k8s/fixture.go
@@ -291,6 +291,44 @@ func CreateOrUpdateClusterRoleAndRoleBinding(ctx context.Context, uuid string, k
 	return nil
 }
 
+// Generate generic fake kube config
+func GenerateFakeKubeConfig() string {
+	// This config has been sanitized of any real credentials.
+	return `
+apiVersion: v1
+kind: Config
+clusters:
+  - cluster:
+      insecure-skip-tls-verify: true
+      server: https://api.fake-e2e-test-data.origin-ci-int-gce.dev.rhcloud.com:6443
+    name: api-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
+  - cluster:
+      insecure-skip-tls-verify: true
+      server: https://api2.fake-e2e-test-data.origin-ci-int-gce.dev.rhcloud.com:6443
+    name: api2-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
+contexts:
+  - context:
+      cluster: api-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
+      namespace: jgw
+      user: kube:admin/api-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
+    name: default/api-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443/kube:admin
+  - context:
+      cluster: api2-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
+      namespace: jgw
+      user: kube:admin/api2-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
+    name: default/api2-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443/kube:admin
+current-context: default/api-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443/kube:admin
+preferences: {}
+users:
+  - name: kube:admin/api-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
+    user:
+      token: sha256~ABCdEF1gHiJKlMnoP-Q19qrTuv1_W9X2YZABCDefGH4
+  - name: kube:admin/api2-fake-e2e-test-data-origin-ci-int-gce-dev-rhcloud-com:6443
+    user:
+      token: sha256~abcDef1gHIjkLmNOp-q19QRtUV1_w9x2yzabcdEFgh4
+`
+}
+
 func GenerateKubeConfig(serverURL string, currentNamespace string, token string) string {
 
 	return `


### PR DESCRIPTION
#### Description:
- This PR fixes issues reported on [RHTAP-411](https://issues.redhat.com//browse/RHTAP-411):
- 1) The `GitOpsDeploymentManagedEnvironment` was missing a namespace, when it was based on a DTC that had a namespace value
- 2) The `GitOpsDeployment` was missing a namespace, when it came from a `SnapshotEnvironmentBinding` that referenced an `Environment` that referenced a DTC that had a target namespace :grin: (that's a long sentence)
- Plus a bunch of unit and E2E tests, because we should have caught the above previously (we, including myself, just never thought of it at the time)
- And some minor typos/refactoring (I've marked these with GitHub comments).

#### Link to JIRA Story (if applicable): [RHTAPBUGS-411](https://issues.redhat.com/browse/RHTAPBUGS-411)

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
