### PR TITLE
Ignore mocks and generated files in codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,21 @@
 ignore:
-- "**/*_test.go"
-- "vendor/.*"
+  - "**/*_test.go"
+  - "vendor/.*"
+  - "backend-shared/main.go" # placeholder: not executed
+  - "backend-shared/apis/managed-gitops/v1alpha1/zz_generated.deepcopy.go" # generated file, does not need to be included in the coverage
+
+  # mock file for testing: these are not included/executed as part of the product code.
+  - "backend/condition/mocks/conditions.go"
+  - "backend-shared/apis/managed-gitops/v1alpha1/mocks/cr-client.go"
+  - "backend-shared/apis/managed-gitops/v1alpha1/mocks/generate.go"
+  - "backend-shared/apis/managed-gitops/v1alpha1/mocks/status-writer.go"
+  - "backend-shared/apis/managed-gitops/v1alpha1/mocks/structs/builders.go"
+  - "backend-shared/apis/managed-gitops/v1alpha1/mocks/structs/gitopsdeployment.go"
+  - "cluster-agent/utils/mocks/ApplicationServiceClient.go"
+  - "cluster-agent/utils/mocks/SessionServiceClient.go"
+  - "cluster-agent/utils/mocks/SettingsServiceClient.go"
+  - "cluster-agent/utils/mocks/VersionServiceClient.go"
+
 
 github_checks:
   annotations: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,6 +12,7 @@ ignore:
   - "backend-shared/apis/managed-gitops/v1alpha1/mocks/structs/builders.go"
   - "backend-shared/apis/managed-gitops/v1alpha1/mocks/structs/gitopsdeployment.go"
   - "cluster-agent/utils/mocks/ApplicationServiceClient.go"
+  - "cluster-agent/utils/mocks/Client.go"
   - "cluster-agent/utils/mocks/SessionServiceClient.go"
   - "cluster-agent/utils/mocks/SettingsServiceClient.go"
   - "cluster-agent/utils/mocks/VersionServiceClient.go"


### PR DESCRIPTION
#### Description:
- I happened to be looking at the [application-service](https://github.com/redhat-appstudio/application-service) repo, and notice they were using a [codecov.yaml file](https://github.com/redhat-appstudio/application-service/blob/main/codecov.yml) to exclude certain classes of files from code coverage.
- They are excluding mocks and generated code, so we can/should do the same.

#### Link to JIRA Story (if applicable): N/A

