### PR TITLE
Unset DT claimRef when the reclaim policy is Retain

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetbinder_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetbinder_controller.go
@@ -135,6 +135,10 @@ func (r *DeploymentTargetClaimReconciler) Reconcile(ctx context.Context, req ctr
 						return ctrl.Result{}, fmt.Errorf("failed to update the claimRef: %v", err)
 					}
 
+					log.Info("ClaimRef of DeploymentTarget is unset since its corresponding DeploymentTargetClaim is already deleted", "DeploymentTarget", dt.Name)
+
+					logutil.LogAPIResourceChangeEvent(dt.Namespace, dt.Name, dt, logutil.ResourceModified, log)
+
 					err := updateDTStatusPhase(ctx, r.Client, dt, applicationv1alpha1.DeploymentTargetPhase_Released, log)
 					if err != nil {
 						return ctrl.Result{}, fmt.Errorf("failed to update DeploymentTarget %s in namespace %s to Released status", dt.Name, dt.Namespace)

--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetbinder_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetbinder_controller_test.go
@@ -120,6 +120,9 @@ var _ = Describe("Test DeploymentTargetClaimBinderController", func() {
 				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&dt), &dt)
 				Expect(err).To(BeNil())
 				Expect(dt.Status.Phase).To(Equal(appstudiosharedv1.DeploymentTargetPhase_Released))
+
+				By("verify if the claimRef of the DT is unset")
+				Expect(dt.Spec.ClaimRef).Should(BeEmpty())
 			})
 
 			It("should handle the deletion of a bounded DeploymentTargetClaim with class of Delete", func() {

--- a/tests-e2e/appstudio/dt_dtc_dtclass_test.go
+++ b/tests-e2e/appstudio/dt_dtc_dtclass_test.go
@@ -323,6 +323,10 @@ var _ = Describe("DeploymentTarget DeploymentTargetClaim and Class tests", func(
 
 			Eventually(matchingDT, "30s", "1s").Should(dtfixture.HasStatusPhase(appstudiosharedv1.DeploymentTargetPhase_Released))
 
+			By("Ensure the claimRef is unset from the DT")
+			err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&matchingDT), &matchingDT)
+			Expect(err).To(BeNil())
+			Expect(matchingDT.Spec.ClaimRef).Should(BeEmpty())
 		})
 
 		It("should ensure that if the SpaceRequest fails to delete, DT is set to failed, and that if the SpaceRequest is eventually deleted, so will the DT and DTC", func() {


### PR DESCRIPTION
#### Description:
- When the DTC is deleted with a reclaim policy of Retain, we don't remove the matching DT. So the DT might end up pointing to a DTC that doesn't exist. This PR unsets the DT claimRef whenever a DTC is deleted with Retain policy.

Ref: https://redhat-internal.slack.com/archives/C02C3SE8QS2/p1686889611653789?thread_ts=1686730438.404799&cid=C02C3SE8QS2

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-647

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
