### PR TITLE
Remove generatorOptions as it prevents dashboard refresh in RHTAP

### DIFF
--- a/manifests/base/monitoring/grafana-dashboards-new/kustomization.yaml
+++ b/manifests/base/monitoring/grafana-dashboards-new/kustomization.yaml
@@ -3,9 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 
 namespace: grafana-operator-system
 
-generatorOptions:
-  disableNameSuffixHash: true
-
 configMapGenerator:
   - name: grafana-dashboard-gitops-service
     files:


### PR DESCRIPTION
#### Description:
- Remove `disableNameSuffixHash`, as recommended as a solution to the lack of dashboard refresh that was mentioned on https://github.com/redhat-appstudio/application-service/pull/318/files

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-563

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
