### PR TITLE
Add webhook validation to avoid creation of GitopsDeployment for empty Environment field and non-empty namespace 

### DIFF
--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_webhook.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_webhook.go
@@ -26,6 +26,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+const (
+	error_nonempty_namespace_empty_environment = "the environment field should not be empty when the namespace is non-empty"
+	error_invalid_sync_option                  = "the specified sync option in .spec.syncPolicy.syncOptions is either mispelled or is not supported by GitOpsDeployment"
+	error_invalid_spec_type                    = "spec type must be manual or automated"
+)
+
 // log is for logging in this package.
 var gitopsdeploymentlog = logf.Log.WithName(logutil.LogLogger_managed_gitops)
 
@@ -82,7 +88,7 @@ func (r *GitOpsDeployment) ValidateGitOpsDeployment() error {
 
 	// Check whether Type is manual or automated
 	if !(r.Spec.Type == GitOpsDeploymentSpecType_Automated || r.Spec.Type == GitOpsDeploymentSpecType_Manual) {
-		return fmt.Errorf("spec type must be manual or automated")
+		return fmt.Errorf(error_invalid_spec_type)
 	}
 
 	// Check whether sync options are valid
@@ -91,14 +97,14 @@ func (r *GitOpsDeployment) ValidateGitOpsDeployment() error {
 
 			if !(syncOptionString == SyncOptions_CreateNamespace_true ||
 				syncOptionString == SyncOptions_CreateNamespace_false) {
-				return fmt.Errorf("the specified sync option in .spec.syncPolicy.syncOptions is either mispelled or is not supported by GitOpsDeployment")
+				return fmt.Errorf(error_invalid_sync_option)
 			}
 
 		}
 	}
 
 	if r.Spec.Destination.Environment == "" && r.Spec.Destination.Namespace != "" {
-		return fmt.Errorf("the environment field should not be empty when the namespace is non-empty")
+		return fmt.Errorf(error_nonempty_namespace_empty_environment)
 	}
 
 	return nil

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_webhook.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_webhook.go
@@ -97,5 +97,9 @@ func (r *GitOpsDeployment) ValidateGitOpsDeployment() error {
 		}
 	}
 
+	if r.Spec.Destination.Environment == "" && r.Spec.Destination.Namespace != "" {
+		return fmt.Errorf("the environment field should not be empty when the namespace is non-empty")
+	}
+
 	return nil
 }

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_webhook_test.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_webhook_test.go
@@ -48,7 +48,7 @@ var _ = Describe("GitOpsDeployment validation webhook", func() {
 
 			err = k8sClient.Create(ctx, gitopsDepl)
 			Expect(err).Should(Not(Succeed()))
-			Expect(err.Error()).Should(ContainSubstring("spec type must be manual or automated"))
+			Expect(err.Error()).Should(ContainSubstring(error_invalid_spec_type))
 
 		})
 
@@ -64,21 +64,7 @@ var _ = Describe("GitOpsDeployment validation webhook", func() {
 
 			err := k8sClient.Create(ctx, gitopsDepl)
 			Expect(err).Should(Not(Succeed()))
-			Expect(err.Error()).Should(ContainSubstring("the specified sync option in .spec.syncPolicy.syncOptions is either mispelled or is not supported by GitOpsDeployment"))
-
-		})
-
-	})
-
-	Context("Create GitOpsDeployment CR with empty Environment field and non-empty namespace", func() {
-		It("Should fail with error saying the environment field should not be empty when the namespace is non-empty", func() {
-			gitopsDepl.Spec.Type = GitOpsDeploymentSpecType_Automated
-			gitopsDepl.Spec.Destination.Environment = ""
-			gitopsDepl.Spec.Destination.Namespace = "test-namespace"
-
-			err := k8sClient.Create(ctx, gitopsDepl)
-			Expect(err).Should(Not(Succeed()))
-			Expect(err.Error()).Should(ContainSubstring("the environment field should not be empty when the namespace is non-empty"))
+			Expect(err.Error()).Should(ContainSubstring(error_invalid_sync_option))
 
 		})
 
@@ -96,7 +82,7 @@ var _ = Describe("GitOpsDeployment validation webhook", func() {
 			gitopsDepl.Spec.Type = "invalid-type"
 			err = k8sClient.Update(ctx, gitopsDepl)
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("spec type must be manual or automated"))
+			Expect(err.Error()).Should(ContainSubstring(error_invalid_spec_type))
 
 			err = k8sClient.Delete(context.Background(), gitopsDepl)
 			Expect(err).To(BeNil())
@@ -122,12 +108,26 @@ var _ = Describe("GitOpsDeployment validation webhook", func() {
 			}
 			err = k8sClient.Update(ctx, gitopsDepl)
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("the specified sync option in .spec.syncPolicy.syncOptions is either mispelled or is not supported by GitOpsDeployment"))
+			Expect(err.Error()).Should(ContainSubstring(error_invalid_sync_option))
 
 			err = k8sClient.Delete(context.Background(), gitopsDepl)
 			Expect(err).To(BeNil())
 
 		})
+	})
+
+	Context("Create GitOpsDeployment CR with empty Environment field and non-empty namespace", func() {
+		It("Should fail with error saying the environment field should not be empty when the namespace is non-empty", func() {
+			gitopsDepl.Spec.Type = GitOpsDeploymentSpecType_Automated
+			gitopsDepl.Spec.Destination.Environment = ""
+			gitopsDepl.Spec.Destination.Namespace = "test-namespace"
+
+			err := k8sClient.Create(ctx, gitopsDepl)
+			Expect(err).Should(Not(Succeed()))
+			Expect(err.Error()).Should(ContainSubstring(error_nonempty_namespace_empty_environment))
+
+		})
+
 	})
 
 	Context("Update GitOpsDeployment CR with empty Environment field and non-empty namespace", func() {
@@ -143,7 +143,7 @@ var _ = Describe("GitOpsDeployment validation webhook", func() {
 			gitopsDepl.Spec.Destination.Namespace = "test-namespace"
 			err = k8sClient.Update(ctx, gitopsDepl)
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("the environment field should not be empty when the namespace is non-empty"))
+			Expect(err.Error()).Should(ContainSubstring(error_nonempty_namespace_empty_environment))
 
 			err = k8sClient.Delete(context.Background(), gitopsDepl)
 			Expect(err).To(BeNil())

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_webhook.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_webhook.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+const error_invalid_cluster_api_url = "cluster api url must start with https://"
+
 // log is for logging in this package.
 var gitopsdeploymentmanagedenvironmentlog = logf.Log.WithName(logutil.LogLogger_managed_gitops)
 
@@ -87,7 +89,7 @@ func (r *GitOpsDeploymentManagedEnvironment) ValidateGitOpsDeploymentManagedEnv(
 		}
 
 		if apiURL.Scheme != "https" {
-			return fmt.Errorf("cluster api url must start with https://")
+			return fmt.Errorf(error_invalid_cluster_api_url)
 		}
 	}
 

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_webhook_test.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_webhook_test.go
@@ -52,7 +52,7 @@ var _ = Describe("GitOpsDeploymentManagedEnvironment validation webhook", func()
 			err = k8sClient.Create(ctx, managedEnv)
 
 			Expect(err).Should(Not(Succeed()))
-			Expect(err.Error()).Should(ContainSubstring("cluster api url must start with https://"))
+			Expect(err.Error()).Should(ContainSubstring(error_invalid_cluster_api_url))
 		})
 	})
 
@@ -70,7 +70,7 @@ var _ = Describe("GitOpsDeploymentManagedEnvironment validation webhook", func()
 			managedEnv.Spec.APIURL = "smtp://api-url"
 			err = k8sClient.Update(ctx, managedEnv)
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("cluster api url must start with https://"))
+			Expect(err.Error()).Should(ContainSubstring(error_invalid_cluster_api_url))
 
 			err = k8sClient.Delete(context.Background(), managedEnv)
 			Expect(err).To(BeNil())

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentrepositorycredential_webhook.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentrepositorycredential_webhook.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+const error_invalid_repository = "repository must begin with ssh:// or https://"
+
 // log is for logging in this package.
 var gitopsdeploymentrepositorycredentiallog = logf.Log.WithName(logutil.LogLogger_managed_gitops)
 
@@ -87,7 +89,7 @@ func (r *GitOpsDeploymentRepositoryCredential) ValidateGitOpsDeploymentRepoCred(
 		}
 
 		if !(apiURL.Scheme == "https" || apiURL.Scheme == "ssh") {
-			return fmt.Errorf("repository must begin with ssh:// or https://")
+			return fmt.Errorf(error_invalid_repository)
 		}
 	}
 

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentrepositorycredential_webhook_test.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentrepositorycredential_webhook_test.go
@@ -52,7 +52,7 @@ var _ = Describe("GitOpsDeploymentRepositoryCredential validation webhook", func
 			err = k8sClient.Create(ctx, repoCredentialCr)
 
 			Expect(err).Should(Not(Succeed()))
-			Expect(err.Error()).Should(ContainSubstring("repository must begin with ssh:// or https://"))
+			Expect(err.Error()).Should(ContainSubstring(error_invalid_repository))
 
 		})
 	})
@@ -71,7 +71,7 @@ var _ = Describe("GitOpsDeploymentRepositoryCredential validation webhook", func
 			repoCredentialCr.Spec.Repository = "smtp://repo-url"
 			err = k8sClient.Update(ctx, repoCredentialCr)
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("repository must begin with ssh:// or https://"))
+			Expect(err.Error()).Should(ContainSubstring(error_invalid_repository))
 
 			err = k8sClient.Delete(context.Background(), repoCredentialCr)
 			Expect(err).To(BeNil())

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentsyncrun_webhook.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentsyncrun_webhook.go
@@ -26,6 +26,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+const (
+	error_invalid_name = "name should not be zyxwvutsrqponmlkjihgfedcba-abcdefghijklmnoqrstuvwxyz"
+	invalid_name       = "zyxwvutsrqponmlkjihgfedcba-abcdefghijklmnoqrstuvwxyz"
+)
+
 // log is for logging in this package.
 var gitopsdeploymentsyncrunlog = logf.Log.WithName(logutil.LogLogger_managed_gitops)
 
@@ -53,8 +58,8 @@ var _ webhook.Validator = &GitOpsDeploymentSyncRun{}
 func (r *GitOpsDeploymentSyncRun) ValidateCreate() error {
 	gitopsdeploymentsyncrunlog.Info("validate create", "name", r.Name)
 
-	if r.Name == "zyxwvutsrqponmlkjihgfedcba-abcdefghijklmnoqrstuvwxyz" {
-		return fmt.Errorf("name should not be zyxwvutsrqponmlkjihgfedcba-abcdefghijklmnoqrstuvwxyz")
+	if r.Name == invalid_name {
+		return fmt.Errorf(error_invalid_name)
 	}
 
 	return nil

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentsyncrun_webhook_test.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentsyncrun_webhook_test.go
@@ -46,11 +46,11 @@ var _ = Describe("GitOpsDeploymentSyncRun validation webhook", func() {
 			err := k8sClient.Create(ctx, namespace)
 			Expect(err).To(BeNil())
 
-			gitopsDeplSyncRunCr.Name = "zyxwvutsrqponmlkjihgfedcba-abcdefghijklmnoqrstuvwxyz"
+			gitopsDeplSyncRunCr.Name = invalid_name
 			err = k8sClient.Create(ctx, gitopsDeplSyncRunCr)
 
 			Expect(err).Should(Not(Succeed()))
-			Expect(err.Error()).Should(ContainSubstring("name should not be zyxwvutsrqponmlkjihgfedcba-abcdefghijklmnoqrstuvwxyz"))
+			Expect(err.Error()).Should(ContainSubstring(error_invalid_name))
 
 		})
 	})

--- a/tests-e2e/appstudio/webhook_test.go
+++ b/tests-e2e/appstudio/webhook_test.go
@@ -310,7 +310,6 @@ var _ = Describe("Webhook E2E tests", func() {
 					managedgitopsv1alpha1.SyncOptions_CreateNamespace_true,
 				},
 			}
-			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
@@ -536,8 +535,6 @@ var _ = Describe("Webhook E2E tests", func() {
 			gitOpsDeploymentResource := gitopsDeplFixture.BuildGitOpsDeploymentResource(name,
 				repoURL, "resources/test-data/sample-gitops-repository/environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Manual)
-			gitOpsDeploymentResource.Spec.Destination.Environment = ""
-			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
 
 			err = k8sClient.Create(ctx, &gitOpsDeploymentResource)
 			Expect(err).To(BeNil())

--- a/tests-e2e/core/environment_test.go
+++ b/tests-e2e/core/environment_test.go
@@ -17,7 +17,6 @@ import (
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	dtfixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/deploymenttarget"
 	dtcfixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/deploymenttargetclaim"
-	envFixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/environment"
 	environmentFixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/environment"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,7 +80,7 @@ var _ = Describe("Environment Status.Conditions tests", func() {
 			Expect(err).To(Succeed())
 
 			By("checking the status component environment condition is true")
-			Eventually(env, "2m", "1s").Should(envFixture.HaveEnvironmentCondition(
+			Eventually(env, "2m", "1s").Should(environmentFixture.HaveEnvironmentCondition(
 				metav1.Condition{
 					Type:    app.EnvironmentConditionErrorOccurred,
 					Status:  metav1.ConditionTrue,
@@ -125,7 +124,7 @@ var _ = Describe("Environment Status.Conditions tests", func() {
 			Expect(err).To(Succeed())
 
 			By("checking the status component environment condition is true")
-			Eventually(environment, "2m", "1s").Should(envFixture.HaveEnvironmentCondition(
+			Eventually(environment, "2m", "1s").Should(environmentFixture.HaveEnvironmentCondition(
 				metav1.Condition{
 					Type:    app.EnvironmentConditionErrorOccurred,
 					Status:  metav1.ConditionTrue,

--- a/tests-e2e/core/gitopsdeployment_syncrun_test.go
+++ b/tests-e2e/core/gitopsdeployment_syncrun_test.go
@@ -57,8 +57,6 @@ var _ = Describe("GitOpsDeploymentSyncRun E2E tests", func() {
 			gitOpsDeploymentResource = gitopsDeplFixture.BuildGitOpsDeploymentResource(name,
 				repoURL, "resources/test-data/sample-gitops-repository/environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Manual)
-			gitOpsDeploymentResource.Spec.Destination.Environment = ""
-			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
 
 			err = k8sClient.Create(ctx, &gitOpsDeploymentResource)
 			Expect(err).To(BeNil())
@@ -208,8 +206,6 @@ var _ = Describe("GitOpsDeploymentSyncRun E2E tests", func() {
 			gitOpsDeploymentResource = gitopsDeplFixture.BuildGitOpsDeploymentResource("test-deply-with-presync",
 				"https://github.com/managed-gitops-test-data/deployment-presync-hook", "guestbook",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Manual)
-			gitOpsDeploymentResource.Spec.Destination.Environment = ""
-			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
 
 			err := k8sClient.Create(ctx, &gitOpsDeploymentResource)
 			Expect(err).To(BeNil())
@@ -327,8 +323,6 @@ var _ = Describe("GitOpsDeploymentSyncRun E2E tests", func() {
 			gitOpsDeploymentResource = gitopsDeplFixture.BuildGitOpsDeploymentResource("test-deply-with-presync",
 				"https://github.com/managed-gitops-test-data/deployment-presync-hook", "guestbook",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Manual)
-			gitOpsDeploymentResource.Spec.Destination.Environment = ""
-			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
 
 			err := k8sClient.Create(ctx, &gitOpsDeploymentResource)
 			Expect(err).To(BeNil())
@@ -405,8 +399,6 @@ var _ = Describe("GitOpsDeploymentSyncRun E2E tests", func() {
 			gitOpsDeploymentResource = gitopsDeplFixture.BuildGitOpsDeploymentResource("test-deply",
 				"https://github.com/managed-gitops-test-data/deployment-presync-hook", "guestbook-without-hook",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Manual)
-			gitOpsDeploymentResource.Spec.Destination.Environment = ""
-			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
 
 			err := k8sClient.Create(ctx, &gitOpsDeploymentResource)
 			Expect(err).To(BeNil())

--- a/tests-e2e/core/gitopsdeployment_test.go
+++ b/tests-e2e/core/gitopsdeployment_test.go
@@ -142,8 +142,6 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 			gitOpsDeploymentResource := gitopsDeplFixture.BuildGitOpsDeploymentResource(name,
 				repoURL, "resources/test-data/sample-gitops-repository/environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
-			gitOpsDeploymentResource.Spec.Destination.Environment = ""
-			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
 
 			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
 			Expect(err).To(Succeed())
@@ -178,7 +176,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				},
 				Destination: managedgitopsv1alpha1.GitOpsDeploymentDestination{
 					Name:      gitOpsDeploymentResource.Spec.Destination.Environment,
-					Namespace: gitOpsDeploymentResource.Spec.Destination.Namespace,
+					Namespace: fixture.GitOpsServiceE2ENamespace,
 				},
 			}
 
@@ -265,8 +263,6 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 			gitOpsDeploymentResource := gitopsDeplFixture.BuildGitOpsDeploymentResource(name,
 				repoURL, "resources/test-data/sample-gitops-repository/environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
-			gitOpsDeploymentResource.Spec.Destination.Environment = ""
-			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
 
 			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
 			Expect(err).To(Succeed())
@@ -300,7 +296,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				},
 				Destination: managedgitopsv1alpha1.GitOpsDeploymentDestination{
 					Name:      gitOpsDeploymentResource.Spec.Destination.Environment,
-					Namespace: gitOpsDeploymentResource.Spec.Destination.Namespace,
+					Namespace: fixture.GitOpsServiceE2ENamespace,
 				},
 			}
 
@@ -440,8 +436,6 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 			gitOpsDeploymentResource := gitopsDeplFixture.BuildTargetRevisionGitOpsDeploymentResource("gitops-depl-test",
 				"https://github.com/managed-gitops-test-data/deployment-permutations-a", "pathB", "branchA",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
-			gitOpsDeploymentResource.Spec.Destination.Environment = ""
-			gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
 
 			err = k8s.Create(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(Succeed())
@@ -460,7 +454,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				},
 				Destination: managedgitopsv1alpha1.GitOpsDeploymentDestination{
 					Name:      gitOpsDeploymentResource.Spec.Destination.Environment,
-					Namespace: gitOpsDeploymentResource.Spec.Destination.Namespace,
+					Namespace: fixture.GitOpsServiceE2ENamespace,
 				},
 			}
 
@@ -496,7 +490,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				},
 				Destination: managedgitopsv1alpha1.GitOpsDeploymentDestination{
 					Name:      gitOpsDeploymentResource.Spec.Destination.Environment,
-					Namespace: gitOpsDeploymentResource.Spec.Destination.Namespace,
+					Namespace: fixture.GitOpsServiceE2ENamespace,
 				},
 			}
 
@@ -812,8 +806,6 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 				gitOpsDeploymentResource := gitopsDeplFixture.BuildGitOpsDeploymentResource(name,
 					repoURL, "resources/test-data/sample-gitops-repository/environments/overlays/dev",
 					managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
-				gitOpsDeploymentResource.Spec.Destination.Environment = ""
-				gitOpsDeploymentResource.Spec.Destination.Namespace = fixture.GitOpsServiceE2ENamespace
 
 				k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
 				Expect(err).To(Succeed())

--- a/tests-e2e/core/managed_environment_test.go
+++ b/tests-e2e/core/managed_environment_test.go
@@ -809,6 +809,7 @@ var _ = Describe("GitOpsDeployment Managed Environment E2E tests", func() {
 
 			By("Removing reference to the managed environment from the GitOpsDeployment resource")
 			gitOpsDeploymentResource.Spec.Destination.Environment = ""
+			gitOpsDeploymentResource.Spec.Destination.Namespace = ""
 
 			err = k8s.Update(&gitOpsDeploymentResource, k8sClient)
 			Expect(err).To(BeNil())


### PR DESCRIPTION
#### Description:
- Added validation for empty Environment and non-empty Namespace
- Unit/e2e tests
- Moved error strings to constants

#### Link to JIRA Story (if applicable):
https://issues.redhat.com/browse/GITOPSRVCE-642
