### PR TITLE
Refactor applicationEventQueueLoop so it can be unit tested, and write new unit tests for it

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetbinder_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetbinder_controller.go
@@ -100,11 +100,6 @@ func (r *DeploymentTargetClaimReconciler) Reconcile(ctx context.Context, req ctr
 					return ctrl.Result{}, err
 				}
 
-				if dtcls.Name == "" {
-					log.Error(nil, "unable to locate DeploymentTargetClass matching deploymentTargetClassName", "className", dt.Spec.DeploymentTargetClassName)
-					return ctrl.Result{}, nil
-				}
-
 				// Add the deletion finalizer to the DT if it is absent.
 				if addFinalizer(dt, FinalizerDT) {
 					if err = r.Client.Update(ctx, dt); err != nil {
@@ -227,8 +222,7 @@ func (r *DeploymentTargetClaimReconciler) Reconcile(ctx context.Context, req ctr
 	if dt.Spec.ClaimRef != "" {
 		if dt.Spec.ClaimRef == dtc.Name {
 			// Both DT and DTC refer each other. So bind them together.
-			err := bindDeploymentTargetClaimToTarget(ctx, r.Client, &dtc, &dt, false, log)
-			if err != nil {
+			if err := bindDeploymentTargetClaimToTarget(ctx, r.Client, &dtc, &dt, false, log); err != nil {
 				log.Error(err, "failed to bind DeploymentTargetClaim to the DeploymentTarget", "DeploymentTargetName", dt.Name, "Namespace", dt.Name)
 				return ctrl.Result{}, err
 			}
@@ -292,13 +286,11 @@ func bindDeploymentTargetClaimToTarget(ctx context.Context, k8sClient client.Cli
 	}
 
 	// Set the status of DT and DTC to Bound
-	err := updateDTCStatusPhase(ctx, k8sClient, dtc, applicationv1alpha1.DeploymentTargetClaimPhase_Bound, log)
-	if err != nil {
+	if err := updateDTCStatusPhase(ctx, k8sClient, dtc, applicationv1alpha1.DeploymentTargetClaimPhase_Bound, log); err != nil {
 		return err
 	}
 
-	err = updateDTStatusPhase(ctx, k8sClient, dt, applicationv1alpha1.DeploymentTargetPhase_Bound, log)
-	if err != nil {
+	if err := updateDTStatusPhase(ctx, k8sClient, dt, applicationv1alpha1.DeploymentTargetPhase_Bound, log); err != nil {
 		return err
 	}
 
@@ -316,7 +308,6 @@ func bindDeploymentTargetClaimToTarget(ctx context.Context, k8sClient client.Cli
 		}
 
 		log.Info("Added bind-complete annotation since the DeploymentTargetClaim is bounded", "annotation", applicationv1alpha1.AnnBindCompleted)
-		return nil
 	}
 
 	return nil
@@ -646,8 +637,7 @@ func (r *DeploymentTargetClaimReconciler) findObjectsForDeploymentTarget(dt clie
 	}
 
 	dtcList := applicationv1alpha1.DeploymentTargetClaimList{}
-	err := r.List(ctx, &dtcList, &client.ListOptions{Namespace: dt.GetNamespace()})
-	if err != nil {
+	if err := r.List(ctx, &dtcList, &client.ListOptions{Namespace: dt.GetNamespace()}); err != nil {
 		handlerLog.Error(err, "failed to list DeploymentTargetClaims in the mapping function")
 		return []reconcile.Request{}
 	}

--- a/backend/eventloop/application_event_loop/application_event_loop.go
+++ b/backend/eventloop/application_event_loop/application_event_loop.go
@@ -114,8 +114,28 @@ func startApplicationEventQueueLoopWithFactory(ctx context.Context, aeqlParam Ap
 
 }
 
+type applicationEventQueueLoopState struct {
+
+	// Only one deployment event is processed at a time
+	// These are events that are waiting to be sent to application_event_runner_deployments runner
+	activeDeploymentEvent   *RequestMessage
+	waitingDeploymentEvents []*RequestMessage
+
+	// Only one sync operation event is processed at a time
+	// For example: if the user created multiple GitOpsDeploymentSyncRun CRs, they will be processed to completion, one at a time.
+	// These are events that are waiting to be sent to application_event_runner_syncruns runner
+	activeSyncOperationEvent   *RequestMessage
+	waitingSyncOperationEvents []*RequestMessage
+
+	deploymentEventRunner         chan *eventlooptypes.EventLoopEvent
+	deploymentEventRunnerShutdown bool
+
+	syncOperationEventRunner         chan *eventlooptypes.EventLoopEvent
+	syncOperationEventRunnerShutdown bool
+}
+
 // applicationEventQueueLoop is the main function of the application event loop: it accepts messages from the
-// workspace event loop, creates runners, and passes them to runners.
+// workspace event loop, creates runners, and passes messages to runners.
 func applicationEventQueueLoop(ctx context.Context, k8sClient client.Client,
 	input chan RequestMessage,
 	gitopsDeploymentName string, gitopsDeploymentNamespace string,
@@ -131,24 +151,20 @@ func applicationEventQueueLoop(ctx context.Context, k8sClient client.Client,
 	log.Info("applicationEventQueueLoop started.")
 	defer log.Info("applicationEventQueueLoop ended.")
 
-	// Only one deployment event is processed at a time
-	// These are events that are waiting to be sent to application_event_runner_deployments runner
-	var activeDeploymentEvent *RequestMessage
-	waitingDeploymentEvents := []*RequestMessage{}
+	state := applicationEventQueueLoopState{
+		activeDeploymentEvent:      nil,
+		waitingDeploymentEvents:    []*RequestMessage{},
+		activeSyncOperationEvent:   nil,
+		waitingSyncOperationEvents: []*RequestMessage{},
 
-	// Only one sync operation event is processed at a time
-	// For example: if the user created multiple GitOpsDeploymentSyncRun CRs, they will be processed to completion, one at a time.
-	// These are events that are waiting to be sent to application_event_runner_syncruns runner
-	var activeSyncOperationEvent *RequestMessage
-	waitingSyncOperationEvents := []*RequestMessage{}
+		deploymentEventRunner: aerFactory.createNewApplicationEventLoopRunner(input, sharedResourceEventLoop, gitopsDeploymentName,
+			gitopsDeploymentNamespace, workspaceID, "deployment"),
+		deploymentEventRunnerShutdown: false,
 
-	deploymentEventRunner := aerFactory.createNewApplicationEventLoopRunner(input, sharedResourceEventLoop, gitopsDeploymentName,
-		gitopsDeploymentNamespace, workspaceID, "deployment")
-	deploymentEventRunnerShutdown := false
-
-	syncOperationEventRunner := aerFactory.createNewApplicationEventLoopRunner(input, sharedResourceEventLoop, gitopsDeploymentName,
-		gitopsDeploymentNamespace, workspaceID, "sync-operation")
-	syncOperationEventRunnerShutdown := false
+		syncOperationEventRunner: aerFactory.createNewApplicationEventLoopRunner(input, sharedResourceEventLoop, gitopsDeploymentName,
+			gitopsDeploymentNamespace, workspaceID, "sync-operation"),
+		syncOperationEventRunnerShutdown: false,
+	}
 
 	// Start the ticker, which will -- every X seconds -- instruct the GitOpsDeployment CR fields to update
 	startNewStatusUpdateTimer(ctx, k8sClient, input, log)
@@ -158,213 +174,230 @@ out:
 		// Block on waiting for more events for this application
 		newEvent := <-input
 
-		eventLoopMessage := newEvent.Message.Event
+		breakOut := processApplicationEventQueueLoopMessage(ctx, newEvent, &state, input, k8sClient, log)
+		if breakOut {
+			break out
+		}
+	}
+}
 
-		if eventLoopMessage != nil {
-			if !(eventLoopMessage.EventType == eventlooptypes.UpdateDeploymentStatusTick && disableDeploymentStatusTickLogging) {
-				log.V(logutil.LogLevel_Debug).Info("applicationEventQueueLoop received event",
-					"event", eventlooptypes.StringEventLoopEvent(eventLoopMessage))
+// returns true if the event loop should be terminated, false otherwise.
+func processApplicationEventQueueLoopMessage(ctx context.Context, newEvent RequestMessage, state *applicationEventQueueLoopState, input chan RequestMessage, k8sClient client.Client, log logr.Logger) bool {
 
-			}
+	const (
+		terminateEventLoop_false = false
+		terminateEventLoop_true  = true
+	)
+
+	eventLoopMessage := newEvent.Message.Event
+
+	if eventLoopMessage != nil {
+		if !(eventLoopMessage.EventType == eventlooptypes.UpdateDeploymentStatusTick && disableDeploymentStatusTickLogging) {
+			log.V(logutil.LogLevel_Debug).Info("applicationEventQueueLoop received event",
+				"event", eventlooptypes.StringEventLoopEvent(eventLoopMessage))
+
+		}
+	}
+
+	// If we've received a new event from the workspace event loop
+	if newEvent.Message.MessageType == eventlooptypes.ApplicationEventLoopMessageType_Event {
+
+		if eventLoopMessage == nil {
+			log.Error(nil, "SEVERE: applicationEventQueueLoop event was nil", "thing", newEvent.Message.MessageType)
+			return terminateEventLoop_false
 		}
 
-		// If we've received a new event from the workspace event loop
-		if newEvent.Message.MessageType == eventlooptypes.ApplicationEventLoopMessageType_Event {
+		// First check if the event loop has shutdown, and therefore we should reject the request
+		workRejected := state.deploymentEventRunnerShutdown && state.syncOperationEventRunnerShutdown
 
-			if eventLoopMessage == nil {
-				log.Error(nil, "SEVERE: applicationEventQueueLoop event was nil", "thing", newEvent.Message.MessageType)
-				continue
-			}
-
-			// First check if the event loop has shutdown, and therefore we should reject the request
-			workRejected := deploymentEventRunnerShutdown && syncOperationEventRunnerShutdown
-
-			// We reject the message from the workspace event loop if we have already shutdown
-			// - the workspace event loop will receive the rejection, and start up a new event loop
-			if newEvent.ResponseChan != nil {
-
-				// Inform the event loop if we have accepted/rejected their message
-				newEvent.ResponseChan <- ResponseMessage{
-					RequestAccepted: !workRejected,
-				}
-
-				// Terminate this event loop once we inform the workspace event loop that we have shutdown.
-				if workRejected {
-					break out
-				}
-			}
-
-			// Otherwise, if the response chan is nil, but work is rejected, just continue
-			if workRejected {
-				continue
-			}
-
-			// From this point on, the work has been accepted
-
-			log := log.WithValues("event", eventlooptypes.StringEventLoopEvent(eventLoopMessage))
-
-			if eventLoopMessage.ReqResource == eventlooptypes.GitOpsDeploymentTypeName {
-
-				if !deploymentEventRunnerShutdown {
-					waitingDeploymentEvents = append(waitingDeploymentEvents, &newEvent)
-				} else {
-					log.V(logutil.LogLevel_Debug).Info("Ignoring post-shutdown deployment event")
-				}
-
-			} else if eventLoopMessage.ReqResource == eventlooptypes.GitOpsDeploymentSyncRunTypeName {
-
-				if !syncOperationEventRunnerShutdown {
-					waitingSyncOperationEvents = append(waitingSyncOperationEvents, &newEvent)
-				} else {
-					log.V(logutil.LogLevel_Debug).Info("Ignoring post-shutdown sync operation event")
-				}
-			} else if eventLoopMessage.ReqResource == eventlooptypes.GitOpsDeploymentManagedEnvironmentTypeName {
-
-				if !deploymentEventRunnerShutdown {
-					waitingDeploymentEvents = append(waitingDeploymentEvents, &newEvent)
-				} else {
-					log.V(logutil.LogLevel_Debug).Info("Ignoring post-shutdown managed environment event")
-				}
-
-			} else if eventLoopMessage.EventType == eventlooptypes.UpdateDeploymentStatusTick {
-
-				if !deploymentEventRunnerShutdown {
-					waitingDeploymentEvents = append(waitingDeploymentEvents, &newEvent)
-				} else {
-					log.V(logutil.LogLevel_Debug).Info("Ignoring post-shutdown deployment event")
-				}
-
-			} else {
-				log.Error(nil, "SEVERE: unexpected event resource type in applicationEventQueueLoop")
-			}
-
-			// If we've received a work complete notification...
-		} else if newEvent.Message.MessageType == eventlooptypes.ApplicationEventLoopMessageType_WorkComplete {
-
-			if eventLoopMessage == nil {
-				log.Error(nil, "SEVERE: applicationEventQueueLoop event was nil", "thing", newEvent.Message.MessageType)
-				continue
-			}
-
-			if newEvent.ResponseChan != nil {
-				log.Error(nil, "SEVERE: WorkComplete does not support non-nil ResponseChan")
-			}
-
-			log := log.WithValues("event", eventlooptypes.StringEventLoopEvent(eventLoopMessage))
-
-			if !(eventLoopMessage.EventType == eventlooptypes.UpdateDeploymentStatusTick && disableDeploymentStatusTickLogging) {
-
-				log.V(logutil.LogLevel_Debug).Info("applicationEventQueueLoop received work complete event")
-			}
-
-			if eventLoopMessage.EventType == eventlooptypes.UpdateDeploymentStatusTick {
-				// After we finish processing a previous status tick, start the timer to queue up a new one.
-				// This ensures we are always reminded to do a status update.
-				activeDeploymentEvent = nil
-				startNewStatusUpdateTimer(ctx, k8sClient, input, log)
-
-			} else if eventLoopMessage.ReqResource == eventlooptypes.GitOpsDeploymentTypeName ||
-				eventLoopMessage.ReqResource == eventlooptypes.GitOpsDeploymentManagedEnvironmentTypeName {
-
-				if activeDeploymentEvent.Message.Event != newEvent.Message.Event {
-					log.Error(nil, "SEVERE: unmatched deployment event work item",
-						"activeDeploymentEvent", eventlooptypes.StringEventLoopEvent(activeDeploymentEvent.Message.Event))
-				}
-				activeDeploymentEvent = nil
-
-				deploymentEventRunnerShutdown = newEvent.Message.ShutdownSignalled
-				if deploymentEventRunnerShutdown {
-					log.Info("Deployment signalled shutdown")
-				}
-
-			} else if eventLoopMessage.ReqResource == eventlooptypes.GitOpsDeploymentSyncRunTypeName {
-
-				if activeSyncOperationEvent.Message.Event != newEvent.Message.Event {
-					log.Error(nil, "SEVERE: unmatched sync operation event work item",
-						"activeSyncOperationEvent", eventlooptypes.StringEventLoopEvent(activeSyncOperationEvent.Message.Event))
-				}
-				activeSyncOperationEvent = nil
-				syncOperationEventRunnerShutdown = newEvent.Message.ShutdownSignalled
-				if syncOperationEventRunnerShutdown {
-					log.Info("Sync operation signalled shutdown")
-				}
-
-			} else {
-				log.Error(nil, "SEVERE: unexpected event resource type in applicationEventQueueLoop")
-			}
-
-			// If the parent workspace event loop is requesting our status...
-		} else if newEvent.Message.MessageType == eventlooptypes.ApplicationEventLoopMessageType_StatusCheck {
-
-			if newEvent.ResponseChan == nil { // sanity check the response chan
-				log.Error(nil, "SEVERE: StatusCheck does not support nil ResponseChan")
-				continue
-			}
-
-			workRejected := deploymentEventRunnerShutdown && syncOperationEventRunnerShutdown
+		// We reject the message from the workspace event loop if we have already shutdown
+		// - the workspace event loop will receive the rejection, and start up a new event loop
+		if newEvent.ResponseChan != nil {
 
 			// Inform the event loop if we have accepted/rejected their message
 			newEvent.ResponseChan <- ResponseMessage{
 				RequestAccepted: !workRejected,
 			}
 
-			// Terminate the event loop once we inform the workspace event loop that we have shutdown.
+			// Terminate this event loop once we inform the workspace event loop that we have shutdown.
 			if workRejected {
-				break out
+				return terminateEventLoop_true
+			}
+		}
+
+		// Otherwise, if the response chan is nil, but work is rejected, just continue
+		if workRejected {
+			return terminateEventLoop_false
+		}
+
+		// From this point on, the work has been accepted
+
+		log := log.WithValues("event", eventlooptypes.StringEventLoopEvent(eventLoopMessage))
+
+		if eventLoopMessage.ReqResource == eventlooptypes.GitOpsDeploymentTypeName {
+
+			if !state.deploymentEventRunnerShutdown {
+				state.waitingDeploymentEvents = append(state.waitingDeploymentEvents, &newEvent)
+			} else {
+				log.V(logutil.LogLevel_Debug).Info("Ignoring post-shutdown deployment event")
+			}
+
+		} else if eventLoopMessage.ReqResource == eventlooptypes.GitOpsDeploymentSyncRunTypeName {
+
+			if !state.syncOperationEventRunnerShutdown {
+				state.waitingSyncOperationEvents = append(state.waitingSyncOperationEvents, &newEvent)
+			} else {
+				log.V(logutil.LogLevel_Debug).Info("Ignoring post-shutdown sync operation event")
+			}
+		} else if eventLoopMessage.ReqResource == eventlooptypes.GitOpsDeploymentManagedEnvironmentTypeName {
+
+			if !state.deploymentEventRunnerShutdown {
+				state.waitingDeploymentEvents = append(state.waitingDeploymentEvents, &newEvent)
+			} else {
+				log.V(logutil.LogLevel_Debug).Info("Ignoring post-shutdown managed environment event")
+			}
+
+		} else if eventLoopMessage.EventType == eventlooptypes.UpdateDeploymentStatusTick {
+
+			if !state.deploymentEventRunnerShutdown {
+				state.waitingDeploymentEvents = append(state.waitingDeploymentEvents, &newEvent)
+			} else {
+				log.V(logutil.LogLevel_Debug).Info("Ignoring post-shutdown deployment event")
 			}
 
 		} else {
-			log.Error(nil, "SEVERE: Unrecognized workspace event type", "type", newEvent.Message.MessageType)
+			log.Error(nil, "SEVERE: unexpected event resource type in applicationEventQueueLoop")
 		}
 
-		// If we are not currently doing any deployment work, and there are events waiting, then send the next event to the runner
-		if len(waitingDeploymentEvents) > 0 && activeDeploymentEvent == nil && !deploymentEventRunnerShutdown {
+		// If we've received a work complete notification...
+	} else if newEvent.Message.MessageType == eventlooptypes.ApplicationEventLoopMessageType_WorkComplete {
 
-			activeDeploymentEvent = waitingDeploymentEvents[0]
-			waitingDeploymentEvents = waitingDeploymentEvents[1:]
-
-			// Send the work to the runner
-			if !(activeDeploymentEvent.Message.Event.EventType == eventlooptypes.UpdateDeploymentStatusTick &&
-				disableDeploymentStatusTickLogging == true) {
-				log.V(logutil.LogLevel_Debug).Info("About to send work to depl event runner",
-					"event", eventlooptypes.StringEventLoopEvent(activeDeploymentEvent.Message.Event))
-			}
-
-			deploymentEventRunner <- activeDeploymentEvent.Message.Event
-
-			if !(activeDeploymentEvent.Message.Event.EventType == eventlooptypes.UpdateDeploymentStatusTick &&
-				disableDeploymentStatusTickLogging == true) {
-
-				log.V(logutil.LogLevel_Debug).Info("Sent work to depl event runner",
-					"event", eventlooptypes.StringEventLoopEvent(activeDeploymentEvent.Message.Event))
-
-			}
+		if eventLoopMessage == nil {
+			log.Error(nil, "SEVERE: applicationEventQueueLoop event was nil", "thing", newEvent.Message.MessageType)
+			return terminateEventLoop_false
 		}
 
-		// If we are not currently doing any sync operation work, and there are events waiting, then send the next event to the runner
-		if len(waitingSyncOperationEvents) > 0 && activeSyncOperationEvent == nil && !syncOperationEventRunnerShutdown {
-
-			activeSyncOperationEvent = waitingSyncOperationEvents[0]
-			waitingSyncOperationEvents = waitingSyncOperationEvents[1:]
-
-			// Send the work to the runner
-			syncOperationEventRunner <- activeSyncOperationEvent.Message.Event
-			log.V(logutil.LogLevel_Debug).Info("Sent work to sync op runner",
-				"event", eventlooptypes.StringEventLoopEvent(activeSyncOperationEvent.Message.Event))
-
+		if newEvent.ResponseChan != nil {
+			log.Error(nil, "SEVERE: WorkComplete does not support non-nil ResponseChan")
 		}
 
-		// If the deployment runner has shutdown, and there are no active or waiting sync operation events,
-		// then it is safe to shut down the sync runner too.
-		if deploymentEventRunnerShutdown && len(waitingSyncOperationEvents) == 0 &&
-			activeSyncOperationEvent == nil && !syncOperationEventRunnerShutdown {
+		log := log.WithValues("event", eventlooptypes.StringEventLoopEvent(eventLoopMessage))
 
-			syncOperationEventRunnerShutdown = true
-			if syncOperationEventRunnerShutdown {
-				log.Info("Sync operation runner shutdown due to shutdown by deployment runner")
+		if !(eventLoopMessage.EventType == eventlooptypes.UpdateDeploymentStatusTick && disableDeploymentStatusTickLogging) {
+
+			log.V(logutil.LogLevel_Debug).Info("applicationEventQueueLoop received work complete event")
+		}
+
+		if eventLoopMessage.EventType == eventlooptypes.UpdateDeploymentStatusTick {
+			// After we finish processing a previous status tick, start the timer to queue up a new one.
+			// This ensures we are always reminded to do a status update.
+			state.activeDeploymentEvent = nil
+			startNewStatusUpdateTimer(ctx, k8sClient, input, log)
+
+		} else if eventLoopMessage.ReqResource == eventlooptypes.GitOpsDeploymentTypeName ||
+			eventLoopMessage.ReqResource == eventlooptypes.GitOpsDeploymentManagedEnvironmentTypeName {
+
+			if state.activeDeploymentEvent.Message.Event != newEvent.Message.Event {
+				log.Error(nil, "SEVERE: unmatched deployment event work item",
+					"activeDeploymentEvent", eventlooptypes.StringEventLoopEvent(state.activeDeploymentEvent.Message.Event))
 			}
+			state.activeDeploymentEvent = nil
+
+			state.deploymentEventRunnerShutdown = newEvent.Message.ShutdownSignalled
+			if state.deploymentEventRunnerShutdown {
+				log.Info("Deployment signalled shutdown")
+			}
+
+		} else if eventLoopMessage.ReqResource == eventlooptypes.GitOpsDeploymentSyncRunTypeName {
+
+			if state.activeSyncOperationEvent.Message.Event != newEvent.Message.Event {
+				log.Error(nil, "SEVERE: unmatched sync operation event work item",
+					"activeSyncOperationEvent", eventlooptypes.StringEventLoopEvent(state.activeSyncOperationEvent.Message.Event))
+			}
+			state.activeSyncOperationEvent = nil
+			state.syncOperationEventRunnerShutdown = newEvent.Message.ShutdownSignalled
+			if state.syncOperationEventRunnerShutdown {
+				log.Info("Sync operation signalled shutdown")
+			}
+
+		} else {
+			log.Error(nil, "SEVERE: unexpected event resource type in applicationEventQueueLoop")
+		}
+
+		// If the parent workspace event loop is requesting our status...
+	} else if newEvent.Message.MessageType == eventlooptypes.ApplicationEventLoopMessageType_StatusCheck {
+
+		if newEvent.ResponseChan == nil { // sanity check the response chan
+			log.Error(nil, "SEVERE: StatusCheck does not support nil ResponseChan")
+			return terminateEventLoop_false
+		}
+
+		workRejected := state.deploymentEventRunnerShutdown && state.syncOperationEventRunnerShutdown
+
+		// Inform the event loop if we have accepted/rejected their message
+		newEvent.ResponseChan <- ResponseMessage{
+			RequestAccepted: !workRejected,
+		}
+
+		// Terminate the event loop once we inform the workspace event loop that we have shutdown.
+		if workRejected {
+			return terminateEventLoop_true
+		}
+
+	} else {
+		log.Error(nil, "SEVERE: Unrecognized workspace event type", "type", newEvent.Message.MessageType)
+	}
+
+	// If we are not currently doing any deployment work, and there are events waiting, then send the next event to the runner
+	if len(state.waitingDeploymentEvents) > 0 && state.activeDeploymentEvent == nil && !state.deploymentEventRunnerShutdown {
+
+		state.activeDeploymentEvent = state.waitingDeploymentEvents[0]
+		state.waitingDeploymentEvents = state.waitingDeploymentEvents[1:]
+
+		// Send the work to the runner
+
+		if !(state.activeDeploymentEvent.Message.Event.EventType == eventlooptypes.UpdateDeploymentStatusTick &&
+			disableDeploymentStatusTickLogging == true) {
+			log.V(logutil.LogLevel_Debug).Info("About to send work to depl event runner",
+				"event", eventlooptypes.StringEventLoopEvent(state.activeDeploymentEvent.Message.Event))
+		}
+
+		state.deploymentEventRunner <- state.activeDeploymentEvent.Message.Event
+
+		if !(state.activeDeploymentEvent.Message.Event.EventType == eventlooptypes.UpdateDeploymentStatusTick &&
+			disableDeploymentStatusTickLogging == true) {
+
+			log.V(logutil.LogLevel_Debug).Info("Sent work to depl event runner",
+				"event", eventlooptypes.StringEventLoopEvent(state.activeDeploymentEvent.Message.Event))
+
 		}
 	}
+
+	// If we are not currently doing any sync operation work, and there are events waiting, then send the next event to the runner
+	if len(state.waitingSyncOperationEvents) > 0 && state.activeSyncOperationEvent == nil && !state.syncOperationEventRunnerShutdown {
+
+		state.activeSyncOperationEvent = state.waitingSyncOperationEvents[0]
+		state.waitingSyncOperationEvents = state.waitingSyncOperationEvents[1:]
+
+		// Send the work to the runner
+		state.syncOperationEventRunner <- state.activeSyncOperationEvent.Message.Event
+		log.V(logutil.LogLevel_Debug).Info("Sent work to sync op runner",
+			"event", eventlooptypes.StringEventLoopEvent(state.activeSyncOperationEvent.Message.Event))
+
+	}
+
+	// If the deployment runner has shutdown, and there are no active or waiting sync operation events,
+	// then it is safe to shut down the sync runner too.
+	if state.deploymentEventRunnerShutdown && len(state.waitingSyncOperationEvents) == 0 &&
+		state.activeSyncOperationEvent == nil && !state.syncOperationEventRunnerShutdown {
+
+		state.syncOperationEventRunnerShutdown = true
+		if state.syncOperationEventRunnerShutdown {
+			log.Info("Sync operation runner shutdown due to shutdown by deployment runner")
+		}
+	}
+
+	return terminateEventLoop_false
 }
 
 // startNewStatusUpdateTimer will send a timer tick message to the application event loop in X seconds.

--- a/backend/eventloop/application_event_loop/application_event_loop_test.go
+++ b/backend/eventloop/application_event_loop/application_event_loop_test.go
@@ -117,7 +117,7 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 							Event: &eventlooptypes.EventLoopEvent{
 								EventType:   eventlooptypes.SyncRunModified,
 								ReqResource: eventlooptypes.GitOpsDeploymentSyncRunTypeName,
-								WorkspaceID: string(workspaceUID),
+								WorkspaceID: workspaceUID,
 							},
 							ShutdownSignalled: false,
 						},
@@ -160,7 +160,7 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 							Event: &eventlooptypes.EventLoopEvent{
 								EventType:   eventlooptypes.SyncRunModified,
 								ReqResource: eventlooptypes.GitOpsDeploymentSyncRunTypeName,
-								WorkspaceID: string(workspaceUID),
+								WorkspaceID: workspaceUID,
 							},
 							ShutdownSignalled: false,
 						},
@@ -225,7 +225,7 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 							Event: &eventlooptypes.EventLoopEvent{
 								EventType:   eventlooptypes.DeploymentModified,
 								ReqResource: eventlooptypes.GitOpsDeploymentTypeName,
-								WorkspaceID: string(workspaceUID),
+								WorkspaceID: workspaceUID,
 							},
 							ShutdownSignalled: false,
 						},
@@ -268,7 +268,7 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 							Event: &eventlooptypes.EventLoopEvent{
 								EventType:   eventlooptypes.DeploymentModified,
 								ReqResource: eventlooptypes.GitOpsDeploymentTypeName,
-								WorkspaceID: string(workspaceUID),
+								WorkspaceID: workspaceUID,
 							},
 							ShutdownSignalled: false,
 						},
@@ -335,7 +335,7 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 							Event: &eventlooptypes.EventLoopEvent{
 								EventType:   eventlooptypes.ManagedEnvironmentModified,
 								ReqResource: eventlooptypes.GitOpsDeploymentManagedEnvironmentTypeName,
-								WorkspaceID: string(workspaceUID),
+								WorkspaceID: workspaceUID,
 							},
 							ShutdownSignalled: false,
 						},
@@ -382,7 +382,7 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 							MessageType: eventlooptypes.ApplicationEventLoopMessageType_Event,
 							Event: &eventlooptypes.EventLoopEvent{
 								EventType:   eventlooptypes.UpdateDeploymentStatusTick,
-								WorkspaceID: string(workspaceUID),
+								WorkspaceID: workspaceUID,
 							},
 							ShutdownSignalled: false,
 						},
@@ -408,7 +408,7 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 							MessageType: eventlooptypes.ApplicationEventLoopMessageType_WorkComplete,
 							Event: &eventlooptypes.EventLoopEvent{
 								EventType:   eventlooptypes.UpdateDeploymentStatusTick,
-								WorkspaceID: string(workspaceUID),
+								WorkspaceID: workspaceUID,
 							},
 							ShutdownSignalled: false,
 						},


### PR DESCRIPTION
#### Description:
- Move the contents of `applicationEventQueueLoop` into a separate struct, so that the state can be verified by unit tests
- Move the existing logic (which processesindividual application event messages) into a new function `processApplicationEventQueueLoopMessage`
- Call `processApplicationEventQueueLoopMessage` via new unit tests
- 
#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
