### PR TITLE
Don't log the contents of non-pointer Secret objects

### DIFF
--- a/backend-shared/util/log/log.go
+++ b/backend-shared/util/log/log.go
@@ -36,8 +36,9 @@ func LogAPIResourceChangeEvent(resourceNamespace string, resourceName string, re
 		log.Error(nil, "resource passed to LogAPIResourceChangeEvent was nil")
 		return
 	}
-	_, isSecret := (resource).(*corev1.Secret)
-	if isSecret {
+	_, isSecretPointer := (resource).(*corev1.Secret)
+	_, isSecretObj := (resource).(corev1.Secret)
+	if isSecretPointer || isSecretObj {
 		log.Info(fmt.Sprintf("API Resource changed for secret resource: %s, name: %s, namespace: %s", string(resourceChangeType), resourceName, resourceNamespace))
 		return
 	}


### PR DESCRIPTION
#### Description:
- At present, it looks like we're only detecting pointers to Secrets as Secrets in the `LogAPIResourceChangeEvent` code. We should instead check for both pointers and struct objects.


#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
