### PR TITLE
DeploymentTarget reconciler should add the DT finalizer in all cases

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetbinder_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetbinder_controller.go
@@ -448,6 +448,11 @@ func findMatchingDTForDTC(ctx context.Context, k8sClient client.Client, dtc appl
 // 3. DT should have the cluster credentials.
 func doesDTMatchDTC(dt applicationv1alpha1.DeploymentTarget, dtc applicationv1alpha1.DeploymentTargetClaim) (err error) {
 	mismatchErr := mismatchErrWrap(dt.Name, dtc.Name, dtc.Namespace)
+
+	if dt.Spec.ClaimRef != "" && dt.Spec.ClaimRef != dtc.Name {
+		return mismatchErr("DeploymentTarget already references another DeploymentTargetClaim via DeploymentTarget's .spec.claimRef field")
+	}
+
 	if dt.Spec.DeploymentTargetClassName != dtc.Spec.DeploymentTargetClassName {
 		return mismatchErr("deploymentTargetClassName does not match")
 	}

--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetreclaimer_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetreclaimer_controller.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -85,6 +84,14 @@ func (r *DeploymentTargetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
+	// Add the deletion finalizer if it is absent.
+	if addFinalizer(&dt, FinalizerDT) {
+		if err := r.Client.Update(ctx, &dt); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to add finalizer %s to DeploymentTarget %s in namespace %s: %v", FinalizerDT, dt.Name, dt.Namespace, err)
+		}
+		log.Info("Added finalizer to DeploymentTarget", "finalizer", FinalizerDT)
+	}
+
 	// Retrieve and sanity check the DeploymentTargetClass of the DT
 	dtClass, err := findMatchingDTClassForDT(ctx, dt, r.Client)
 	if err != nil {
@@ -100,14 +107,6 @@ func (r *DeploymentTargetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	// Add the deletion finalizer if it is absent.
-	if addFinalizer(&dt, FinalizerDT) {
-		if err = r.Client.Update(ctx, &dt); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to add finalizer %s to DeploymentTarget %s in namespace %s: %v", FinalizerDT, dt.Name, dt.Namespace, err)
-		}
-		log.Info("Added finalizer to DeploymentTarget", "finalizer", FinalizerDT)
-	}
-
 	// If the DeploymentTarget is not deleted, verify if it has a corresponding DTC
 	if dt.Spec.ClaimRef != "" && dt.DeletionTimestamp == nil {
 		dtc := &applicationv1alpha1.DeploymentTargetClaim{
@@ -117,8 +116,7 @@ func (r *DeploymentTargetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			},
 		}
 
-		err = r.Client.Get(ctx, client.ObjectKeyFromObject(dtc), dtc)
-		if err != nil {
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(dtc), dtc); err != nil {
 			if !apierr.IsNotFound(err) {
 				return ctrl.Result{}, err
 			}
@@ -141,6 +139,8 @@ func (r *DeploymentTargetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// The DeploymentTarget is not currently being deleted, so no more work to do.
 		return ctrl.Result{}, nil
 	}
+
+	// From this point on in this function, the DeletionTimestamp is necessarily set
 
 	// Handle deletion if the DT has a deletion timestamp set.
 	var sr *codereadytoolchainv1alpha1.SpaceRequest
@@ -166,7 +166,7 @@ func (r *DeploymentTargetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	// The ReclaimPolicy is necessarily deleted, from this point on in the function
+	// The ReclaimPolicy is necessarily equal to 'Delete', from this point on in the function
 
 	if addFinalizer(sr, codereadytoolchainv1alpha1.FinalizerName) {
 		if err := r.Client.Update(ctx, sr); err != nil {
@@ -184,9 +184,8 @@ func (r *DeploymentTargetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Delete the SpaceRequest if it has not been deleted
 	if sr.DeletionTimestamp == nil {
 
-		log.Info("deleting SpaceRequest", "spaceRequest", sr)
-		err = r.Client.Delete(ctx, sr)
-		if err != nil {
+		log.Info("Deleting SpaceRequest", "spaceRequest", sr)
+		if err := r.Client.Delete(ctx, sr); err != nil {
 			return ctrl.Result{}, err
 		}
 
@@ -203,7 +202,7 @@ func (r *DeploymentTargetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		r.Clock = sharedutil.NewClock()
 	}
 
-	// If SpaceRequest still exists after 2 minutes and has a condition reason of  UnableToTerminate...
+	// If SpaceRequest still exists after 2 minutes and has a condition reason of UnableToTerminate...
 	if r.Clock.Now().After(sr.GetDeletionTimestamp().Add(time.Minute*2)) &&
 		readyCond.Reason == codereadytoolchainv1alpha1.SpaceTerminatingFailedReason {
 
@@ -215,7 +214,7 @@ func (r *DeploymentTargetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	log.Info("Requeuing since SpaceRequest is still terminating", "spaceRequestStatusPhase", dt.Status.Phase, "deleteionTimestamp", sr.GetDeletionTimestamp())
+	log.Info("Requeuing DeploymentTarget, since SpaceRequest is still terminating", "spaceRequestStatusPhase", dt.Status.Phase, "deletionTimestamp", sr.GetDeletionTimestamp())
 
 	// OTOH, if the SpaceRequest has not timed out yet, then requeue
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
@@ -273,8 +272,6 @@ func findMatchingDTClassForDT(ctx context.Context, dt applicationv1alpha1.Deploy
 func (r *DeploymentTargetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	manager := ctrl.NewControllerManagedBy(mgr).
 		For(&applicationv1alpha1.DeploymentTarget{}).
-		WithEventFilter(predicate.Or(
-			DeploymentTargetDeletePredicate())).
 		Watches(
 			&source.Kind{Type: &codereadytoolchainv1alpha1.SpaceRequest{}},
 			handler.EnqueueRequestsFromMapFunc(r.findDeploymentTargetsForSpaceRequests))

--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetreclaimer_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetreclaimer_controller_test.go
@@ -63,9 +63,16 @@ var _ = Describe("Test DeploymentTargetReclaimController", func() {
 			When("A DeploymentTarget which is not referenced by any other CRs is created", func() {
 				It("should set the finalizer on the DeploymentTarget", func() {
 
+					By("creating a default DeploymentTargetClass")
+					dtcls := generateDeploymentTargetClass(func(dtc *appstudiosharedv1.DeploymentTargetClass) {
+						dtc.Spec.ReclaimPolicy = appstudiosharedv1.ReclaimPolicy_Delete
+					})
+					err := k8sClient.Create(ctx, &dtcls)
+					Expect(err).To(BeNil())
+
 					By("creating a default DeploymentTarget")
 					dt := generateReclaimDeploymentTarget()
-					err := k8sClient.Create(ctx, &dt)
+					err = k8sClient.Create(ctx, &dt)
 					Expect(err).To(BeNil())
 
 					By("reconcile with a DeploymentTarget")

--- a/tests-e2e/appstudio/deploymenttargetclaim_binder_test.go
+++ b/tests-e2e/appstudio/deploymenttargetclaim_binder_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	appstudiocontrollers "github.com/redhat-appstudio/managed-gitops/appstudio-controller/controllers/appstudio.redhat.com"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	dtfixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/deploymenttarget"
 	dtcfixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/deploymenttargetclaim"
@@ -100,6 +101,8 @@ var _ = Describe("DeploymentTargetClaim Binding controller tests", func() {
 				dtcfixture.HasAnnotation(appstudiosharedv1.AnnBindCompleted, appstudiosharedv1.AnnBinderValueTrue),
 			))
 
+			Eventually(&dt).Should(k8s.HasFinalizers([]string{appstudiocontrollers.FinalizerDT}, k8sClient))
+
 			Eventually(dt, "2m", "1s").Should(
 				dtfixture.HasStatusPhase(appstudiosharedv1.DeploymentTargetPhase_Bound))
 		})
@@ -128,6 +131,8 @@ var _ = Describe("DeploymentTargetClaim Binding controller tests", func() {
 
 			Eventually(dt, "2m", "1s").Should(
 				dtfixture.HasStatusPhase(appstudiosharedv1.DeploymentTargetPhase_Bound))
+
+			Eventually(&dt).Should(k8s.HasFinalizers([]string{appstudiocontrollers.FinalizerDT}, k8sClient))
 		})
 
 		It("should bind with a best match DT in the absence of provisioner/user created DT", func() {

--- a/tests-e2e/fixture/fixture.go
+++ b/tests-e2e/fixture/fixture.go
@@ -179,12 +179,13 @@ func cleanUpOldKubeSystemResources(clientConfig *rest.Config) error {
 
 	for idx := range saList.Items {
 		sa := saList.Items[idx]
-		// Skip any service accounts that DON'T contain argocd
-		if !strings.Contains(sa.Name, "argocd") {
+		// Skip any service accounts that DON'T contain argocd, and skip argocd-manager
+		if !strings.Contains(sa.Name, "argocd") || sa.Name == "argocd-manager" {
 			continue
 		}
 
 		if err := k8sClient.Delete(context.Background(), &sa); err != nil {
+			fmt.Println("unable to delete service account", sa)
 			return err
 		}
 	}


### PR DESCRIPTION
#### Description:
- Updated DeploymentTarget Reconciler so that it will ensure the finalizer is ALWAYS added to the DeploymentTarget.
- Updated unit/e2e tests to verify the finalizer is set
- Wrote a quick unit test for findDeploymentTargetsForSpaceRequests

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/RHTAPBUGS-494

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
