### PR TITLE
Rename ClusterRole/Bindings to prevent name clash with infra-deployments

### DIFF
--- a/manifests/base/gitops-service-argocd/base/argo-cd-application-controller-clusterrole.yaml
+++ b/manifests/base/gitops-service-argocd/base/argo-cd-application-controller-clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: appstudio-openshift-gitops-argocd-application-controller
+  name: appstudio-gitops-service-argocd-argocd-application-controller
 rules:
   - apiGroups:
       - '*'

--- a/manifests/base/gitops-service-argocd/base/argo-cd-application-controller-clusterrolebinding.yaml
+++ b/manifests/base/gitops-service-argocd/base/argo-cd-application-controller-clusterrolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: appstudio-openshift-gitops-argocd-application-controller
+  name: appstudio-gitops-service-argocd-argocd-application-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: appstudio-openshift-gitops-argocd-application-controller
+  name: appstudio-gitops-service-argocd-argocd-application-controller
 subjects:
   - kind: ServiceAccount
     name: gitops-service-argocd-argocd-application-controller

--- a/manifests/base/gitops-service-argocd/base/argo-cd-server-clusterrole.yaml
+++ b/manifests/base/gitops-service-argocd/base/argo-cd-server-clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: appstudio-openshift-gitops-argocd-server
+  name: appstudio-gitops-service-argocd-argocd-server
 rules:
   - apiGroups:
       - '*'

--- a/manifests/base/gitops-service-argocd/base/argo-cd-server-clusterrolebinding.yaml
+++ b/manifests/base/gitops-service-argocd/base/argo-cd-server-clusterrolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: appstudio-openshift-gitops-argocd-server
+  name: appstudio-gitops-service-argocd-argocd-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: appstudio-openshift-gitops-argocd-server
+  name: appstudio-gitops-service-argocd-argocd-server
 subjects:
   - kind: ServiceAccount
     name: gitops-service-argocd-argocd-server


### PR DESCRIPTION
#### Description:
- Fix any issue where the names of the clusterrole/rolebindings defined for gitops-service-argocd are conflicting with those used by openshift-gitops on infra-deployments.

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
