### PR TITLE
Unnecessary Operations CRs/DBs are being created/cleaned (#659)

### DIFF
--- a/backend-shared/util/fauxargocd/faux_argo_cd.go
+++ b/backend-shared/util/fauxargocd/faux_argo_cd.go
@@ -8,8 +8,8 @@ package fauxargocd
 
 // Application is a definition of Application resource.
 type FauxApplication struct {
-	FauxTypeMeta   `json:",inline"`
-	FauxObjectMeta `json:"metadata"`
+	FauxTypeMeta   `json:"fauxtypemeta"`
+	FauxObjectMeta `json:"fauxobjectmeta"`
 	Spec           FauxApplicationSpec `json:"spec"`
 }
 


### PR DESCRIPTION
#### Description:
In the namespace_reconciler, the Name and Namespace fields of the application that we are searching for are blank and so when the reconciler tries to get the application resource, it obviously cannot find it, and so it tries to create the operation, etc. every 30 minutes.

Why is the name and namespace empty?  

			namespacedName := types.NamespacedName{
				Name:      applicationFromDB.Name,
				Namespace: applicationFromDB.Namespace}


The unmarshalling step actually was the issue.  It should actually have failed and errored out, if we had used UnmarshalStrict instaed here:

			// Fetch the Application object from DB
			if err := yaml.Unmarshal([]byte(applicationRowFromDB.Spec_field), &applicationFromDB); err != nil {

and it would have indicated that the two fields are undefined after unmarshaling. The fix corrects this.

There are no existing tests for this, AFAICT

#### Link to JIRA Story (if applicable):

See https://issues.redhat.com/browse/GITOPSRVCE-659