### PR TITLE
Set codecov to block PRs if they decrease coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -26,4 +26,9 @@ github_checks:
 
 coverage:
   status:
+    project:
+      default:
+        target: auto
+        threshold: 0.2%
+        removed_code_behavior: adjust_base
     patch: off


### PR DESCRIPTION
#### Description:
- Update .codecov.yml to block PRs from merging if they regress coverage by more than 0.2%

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-372

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
