### PR TITLE
Use WithCallDepth in LogAPIResourceChangeEvent

### DIFF
--- a/backend-shared/util/log/log.go
+++ b/backend-shared/util/log/log.go
@@ -30,7 +30,7 @@ const (
 )
 
 func LogAPIResourceChangeEvent(resourceNamespace string, resourceName string, resource any, resourceChangeType ResourceChangeType, log logr.Logger) {
-	log = log.WithValues("audit", "true")
+	log = log.WithValues("audit", "true").WithCallDepth(1)
 
 	if resource == nil {
 		log.Error(nil, "resource passed to LogAPIResourceChangeEvent was nil")


### PR DESCRIPTION
#### Description:
- Changed the logger created within LogAPIResourceChangeEvent to use the location of the caller instead of the location within LogAPIResourceChangeEvent itself.

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-558

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
