### PR TITLE
Fix race condition in AppProjectRepository reconciliation and remove RepositoryCredential field

### DIFF
--- a/backend-shared/db/app_project_repository.go
+++ b/backend-shared/db/app_project_repository.go
@@ -133,23 +133,23 @@ func (dbq *PostgreSQLDatabaseQueries) UpdateAppProjectRepository(ctx context.Con
 
 }
 
-func (dbq *PostgreSQLDatabaseQueries) DeleteAppProjectRepositoryByRepoCredId(ctx context.Context, obj *AppProjectRepository) (int, error) {
+func (dbq *PostgreSQLDatabaseQueries) DeleteAppProjectRepositoryByAppProjectRepositoryID(ctx context.Context, obj *AppProjectRepository) (int, error) {
 
 	if err := validateQueryParamsEntity(obj, dbq); err != nil {
 		return 0, err
 	}
 
-	if err := isEmptyValues("DeleteAppProjectRepositoryByRepoCredId",
-		"repositorycredentials_id", obj.RepositorycredentialsID,
+	if err := isEmptyValues("DeleteAppProjectRepositoryByAppProjectRepositoryID",
+		"appprojectRepositoryID", obj.AppprojectRepositoryID,
 	); err != nil {
 		return 0, err
 	}
 
 	deleteResult, err := dbq.dbConnection.Model(obj).
-		Where("repositorycredentials_id = ?", obj.RepositorycredentialsID).
+		Where("appproject_repository_id = ?", obj.AppprojectRepositoryID).
 		Context(ctx).Delete()
 	if err != nil {
-		return 0, fmt.Errorf("error on deleting AppProjectRepository: %v", err)
+		return 0, fmt.Errorf("error on deleting AppProjectRepository by primary key: %v", err)
 	}
 
 	return deleteResult.RowsAffected(), nil

--- a/backend-shared/db/app_project_repository.go
+++ b/backend-shared/db/app_project_repository.go
@@ -111,7 +111,6 @@ func (dbq *PostgreSQLDatabaseQueries) UpdateAppProjectRepository(ctx context.Con
 	if err := isEmptyValues("UpdateAppProjectRepository",
 		"appproject_repository_id", obj.AppprojectRepositoryID,
 		"clusteruser_id", obj.Clusteruser_id,
-		"repositorycredentials_id", obj.RepositorycredentialsID,
 		"repo_url", obj.RepoURL); err != nil {
 		return err
 	}
@@ -197,6 +196,5 @@ func (obj *AppProjectRepository) GetAsLogKeyValues() []interface{} {
 
 	return []interface{}{"appproject_repository_id", obj.AppprojectRepositoryID,
 		"clusteruser_id", obj.Clusteruser_id,
-		"repositorycredentials_id", obj.RepositorycredentialsID,
 		"repo_url", obj.RepoURL}
 }

--- a/backend-shared/db/app_project_repository_test.go
+++ b/backend-shared/db/app_project_repository_test.go
@@ -47,11 +47,10 @@ var _ = Describe("AppProjectRepository Test", func() {
 
 		By("Verify whether AppProjectRepository is created")
 		appProjectRepository := db.AppProjectRepository{
-			AppprojectRepositoryID:  "test-app-project-repository",
-			Clusteruser_id:          clusterUser.Clusteruser_id,
-			RepositorycredentialsID: repoCred.RepositoryCredentialsID,
-			RepoURL:                 repoCred.PrivateURL,
-			SeqID:                   int64(seq),
+			AppprojectRepositoryID: "test-app-project-repository",
+			Clusteruser_id:         clusterUser.Clusteruser_id,
+			RepoURL: repoCred.PrivateURL,
+			SeqID:   int64(seq),
 		}
 
 		err = dbq.CreateAppProjectRepository(ctx, &appProjectRepository)
@@ -88,11 +87,10 @@ var _ = Describe("AppProjectRepository Test", func() {
 
 		By("Verify whether AppProjectRepository is created")
 		appProjectRepository1 := db.AppProjectRepository{
-			AppprojectRepositoryID:  "test-app-project-repository-1",
-			Clusteruser_id:          clusterUser.Clusteruser_id,
-			RepositorycredentialsID: repoCred.RepositoryCredentialsID,
-			RepoURL:                 repoCred.PrivateURL,
-			SeqID:                   int64(seq),
+			AppprojectRepositoryID: "test-app-project-repository-1",
+			Clusteruser_id:         clusterUser.Clusteruser_id,
+			RepoURL: repoCred.PrivateURL,
+			SeqID:   int64(seq),
 		}
 
 		err = dbq.CreateAppProjectRepository(ctx, &appProjectRepository1)

--- a/backend-shared/db/app_project_repository_test.go
+++ b/backend-shared/db/app_project_repository_test.go
@@ -73,7 +73,7 @@ var _ = Describe("AppProjectRepository Test", func() {
 		Expect(appProjectRepositoryCount).To(Equal(1))
 
 		By("Verify whether AppProjectRepository is deleted")
-		rowsAffected, err := dbq.DeleteAppProjectRepositoryByRepoCredId(ctx, &appProjectRepository)
+		rowsAffected, err := dbq.DeleteAppProjectRepositoryByClusterUserAndRepoURL(ctx, &appProjectRepository)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rowsAffected).Should(Equal(1))
 

--- a/backend-shared/db/app_project_repository_test.go
+++ b/backend-shared/db/app_project_repository_test.go
@@ -49,8 +49,8 @@ var _ = Describe("AppProjectRepository Test", func() {
 		appProjectRepository := db.AppProjectRepository{
 			AppprojectRepositoryID: "test-app-project-repository",
 			Clusteruser_id:         clusterUser.Clusteruser_id,
-			RepoURL: repoCred.PrivateURL,
-			SeqID:   int64(seq),
+			RepoURL:                repoCred.PrivateURL,
+			SeqID:                  int64(seq),
 		}
 
 		err = dbq.CreateAppProjectRepository(ctx, &appProjectRepository)
@@ -89,8 +89,8 @@ var _ = Describe("AppProjectRepository Test", func() {
 		appProjectRepository1 := db.AppProjectRepository{
 			AppprojectRepositoryID: "test-app-project-repository-1",
 			Clusteruser_id:         clusterUser.Clusteruser_id,
-			RepoURL: repoCred.PrivateURL,
-			SeqID:   int64(seq),
+			RepoURL:                repoCred.PrivateURL,
+			SeqID:                  int64(seq),
 		}
 
 		err = dbq.CreateAppProjectRepository(ctx, &appProjectRepository1)

--- a/backend-shared/db/db_field_constants.go
+++ b/backend-shared/db/db_field_constants.go
@@ -78,7 +78,6 @@ const (
 	RepositoryCredentialsRepoCredEngineIDLength                             = 48
 	AppProjectRepositoryAppprojectRepositoryIDLength                        = 48
 	AppProjectRepositoryClusteruserIDLength                                 = 48
-	AppProjectRepositoryRepositorycredentialsIDLength                       = 48
 	AppProjectRepositoryRepoURLLength                                       = 256
 	AppProjectManagedEnvironmentAppprojectManagedenvIDLength                = 48
 	AppProjectManagedEnvironmentManagedEnvironmentIDLength                  = 48
@@ -203,7 +202,6 @@ var DbFieldMap = map[string]int{
 	"RepositoryCredentialsRepoCredEngineIDLength":                             RepositoryCredentialsRepoCredEngineIDLength,
 	"AppProjectRepositoryAppprojectRepositoryIDLength":                        AppProjectRepositoryAppprojectRepositoryIDLength,
 	"AppProjectRepositoryClusteruserIDLength":                                 AppProjectRepositoryClusteruserIDLength,
-	"AppProjectRepositoryRepositorycredentialsIDLength":                       AppProjectRepositoryRepositorycredentialsIDLength,
 	"AppProjectRepositoryRepoURLLength":                                       AppProjectRepositoryRepoURLLength,
 	"AppProjectManagedEnvironmentAppprojectManagedenvIDLength":                AppProjectManagedEnvironmentAppprojectManagedenvIDLength,
 	"AppProjectManagedEnvironmentManagedEnvironmentIDLength":                  AppProjectManagedEnvironmentManagedEnvironmentIDLength,

--- a/backend-shared/db/queries.go
+++ b/backend-shared/db/queries.go
@@ -197,6 +197,46 @@ type DatabaseQueries interface {
 
 	// Get KubernetesToDBResourceMapping in a batch. Batch size defined by 'limit' and starting point of batch is defined by 'offset'.
 	GetKubernetesToDBResourceMappingBatch(ctx context.Context, k8sToDBResourceMapping *[]KubernetesToDBResourceMapping, limit, offset int) error
+
+	// CreateAppProjectRepository creates AppProjectRepository in database
+	CreateAppProjectRepository(ctx context.Context, obj *AppProjectRepository) error
+
+	// GetAppProjectRepositoryByClusterUserAndRepoURL retrieves AppProjectRepository by cluster user id and repoURL
+	GetAppProjectRepositoryByClusterUserAndRepoURL(ctx context.Context, obj *AppProjectRepository) error
+
+	// ListAppProjectRepositoryByClusterUserId retrieves the list of appProjectRepositories
+	ListAppProjectRepositoryByClusterUserId(ctx context.Context,
+		clusteruser_id string, appProjectRepositories *[]AppProjectRepository) error
+
+	// UpdateAppProjectRepository updates AppProjectRepository
+	UpdateAppProjectRepository(ctx context.Context, obj *AppProjectRepository) error
+
+	// DeleteAppProjectRepositoryByRepoCredId deletes appProjectRepository by repo id
+	// DeleteAppProjectRepositoryByRepoCredId(ctx context.Context, obj *AppProjectRepository) (int, error)
+
+	DeleteAppProjectRepositoryByAppProjectRepositoryID(ctx context.Context, obj *AppProjectRepository) (int, error)
+
+	// DeleteAppProjectRepositoryByClusterUserAndRepoURL deletes appProjectRepository by clusteruser_id and repo_url
+	DeleteAppProjectRepositoryByClusterUserAndRepoURL(ctx context.Context, obj *AppProjectRepository) (int, error)
+
+	// CountAppProjectRepositoryByClusterUserID number of appProjectRepository by clusteruser_id
+	CountAppProjectRepositoryByClusterUserID(ctx context.Context, obj *AppProjectRepository) (int, error)
+
+	// CreateAppProjectManagedEnvironment creates appProjectManagedEnv in database
+	CreateAppProjectManagedEnvironment(ctx context.Context, obj *AppProjectManagedEnvironment) error
+
+	// GetAppProjectManagedEnvironmentByManagedEnvId retrieves appProjectManagedEnv by managedEnvID
+	GetAppProjectManagedEnvironmentByManagedEnvId(ctx context.Context, obj *AppProjectManagedEnvironment) error
+
+	// ListAppProjectManagedEnvironmentByClusterUserId returns a list of all appProjectManagedEnv that reference the specified clusteruser_id row.
+	ListAppProjectManagedEnvironmentByClusterUserId(ctx context.Context,
+		clusteruser_id string, appProjectManagedEnvs *[]AppProjectManagedEnvironment) error
+
+	// DeleteAppProjectManagedEnvironmentByManagedEnvId deletes appProjectManagedEnv by managedEnvID
+	DeleteAppProjectManagedEnvironmentByManagedEnvId(ctx context.Context, obj *AppProjectManagedEnvironment) (int, error)
+
+	// CountAppProjectManagedEnvironmentByClusterUserID number of appProjectManagedEnv by clusteruser_id
+	CountAppProjectManagedEnvironmentByClusterUserID(ctx context.Context, obj *AppProjectManagedEnvironment) (int, error)
 }
 
 // ApplicationScopedQueries are the set of database queries that act on application DB resources:
@@ -291,43 +331,6 @@ type ApplicationScopedQueries interface {
 	// based on the primary key of the corresponding database row (for example, ManagedEnvironment)
 	GetAPICRForDatabaseUID(ctx context.Context, apiCRToDatabaseMapping *APICRToDatabaseMapping) error
 
-	// CreateAppProjectRepository creates AppProjectRepository in database
-	CreateAppProjectRepository(ctx context.Context, obj *AppProjectRepository) error
-
-	// GetAppProjectRepositoryByClusterUserAndRepoURL retrieves AppProjectRepository by cluster user id and repoURL
-	GetAppProjectRepositoryByClusterUserAndRepoURL(ctx context.Context, obj *AppProjectRepository) error
-
-	// ListAppProjectRepositoryByClusterUserId retrieves the list of appProjectRepositories
-	ListAppProjectRepositoryByClusterUserId(ctx context.Context,
-		clusteruser_id string, appProjectRepositories *[]AppProjectRepository) error
-
-	// UpdateAppProjectRepository updates AppProjectRepository
-	UpdateAppProjectRepository(ctx context.Context, obj *AppProjectRepository) error
-
-	// DeleteAppProjectRepositoryByRepoCredId deletes appProjectRepository by repo id
-	DeleteAppProjectRepositoryByRepoCredId(ctx context.Context, obj *AppProjectRepository) (int, error)
-
-	// DeleteAppProjectRepositoryByClusterUserAndRepoURL deletes appProjectRepository by clusteruser_id and repo_url
-	DeleteAppProjectRepositoryByClusterUserAndRepoURL(ctx context.Context, obj *AppProjectRepository) (int, error)
-
-	// CountAppProjectRepositoryByClusterUserID number of appProjectRepository by clusteruser_id
-	CountAppProjectRepositoryByClusterUserID(ctx context.Context, obj *AppProjectRepository) (int, error)
-
-	// CreateAppProjectManagedEnvironment creates appProjectManagedEnv in database
-	CreateAppProjectManagedEnvironment(ctx context.Context, obj *AppProjectManagedEnvironment) error
-
-	// GetAppProjectManagedEnvironmentByManagedEnvId retrieves appProjectManagedEnv by managedEnvID
-	GetAppProjectManagedEnvironmentByManagedEnvId(ctx context.Context, obj *AppProjectManagedEnvironment) error
-
-	// ListAppProjectManagedEnvironmentByClusterUserId returns a list of all appProjectManagedEnv that reference the specified clusteruser_id row.
-	ListAppProjectManagedEnvironmentByClusterUserId(ctx context.Context,
-		clusteruser_id string, appProjectManagedEnvs *[]AppProjectManagedEnvironment) error
-
-	// DeleteAppProjectManagedEnvironmentByManagedEnvId deletes appProjectManagedEnv by managedEnvID
-	DeleteAppProjectManagedEnvironmentByManagedEnvId(ctx context.Context, obj *AppProjectManagedEnvironment) (int, error)
-
-	// CountAppProjectManagedEnvironmentByClusterUserID number of appProjectManagedEnv by clusteruser_id
-	CountAppProjectManagedEnvironmentByClusterUserID(ctx context.Context, obj *AppProjectManagedEnvironment) (int, error)
 	CreateApplicationOwner(ctx context.Context, obj *ApplicationOwner) error
 	DeleteApplicationOwner(ctx context.Context, applicationowner_application_id string) (int, error)
 	GetApplicationOwnerByApplicationID(ctx context.Context, obj *ApplicationOwner) error

--- a/backend-shared/db/test_utils.go
+++ b/backend-shared/db/test_utils.go
@@ -174,8 +174,8 @@ func SetupForTestingDBGinkgo() error {
 
 	for idx := range appProjectRepositories {
 		item := appProjectRepositories[idx]
-		if strings.HasPrefix(item.Clusteruser_id, "test-") {
-			rowsAffected, err := dbq.DeleteAppProjectRepositoryByClusterUserAndRepoURL(ctx, &item)
+		if strings.HasPrefix(item.Clusteruser_id, "test-") || strings.HasPrefix(item.RepoURL, "http://github.com/test-") {
+			rowsAffected, err := dbq.DeleteAppProjectRepositoryByAppProjectRepositoryID(ctx, &item)
 			Expect(err).ToNot(HaveOccurred())
 			if err == nil {
 				Expect(rowsAffected).Should(Equal(1))

--- a/backend-shared/db/types.go
+++ b/backend-shared/db/types.go
@@ -514,9 +514,6 @@ type AppProjectRepository struct {
 	// -- Foreign key to: ClusterUser.clusteruser_id
 	Clusteruser_id string `pg:"clusteruser_id"`
 
-	// -- Foreign key to: RepositoryCredentials.repositorycredentials_id
-	RepositorycredentialsID string `pg:"repositorycredentials_id"`
-
 	SeqID int64 `pg:"seq_id"`
 
 	RepoURL string `pg:"repo_url,notnull"`

--- a/backend-shared/db/unreliable_db_client.go
+++ b/backend-shared/db/unreliable_db_client.go
@@ -1008,11 +1008,11 @@ func (cdb *ChaosDBClient) UpdateAppProjectRepository(ctx context.Context, obj *A
 	return cdb.InnerClient.UpdateAppProjectRepository(ctx, obj)
 }
 
-func (cdb *ChaosDBClient) DeleteAppProjectRepositoryByRepoCredId(ctx context.Context, obj *AppProjectRepository) (int, error) {
-	if err := shouldSimulateFailure("DeleteAppProjectRepositoryByRepoCredId", obj); err != nil {
+func (cdb *ChaosDBClient) DeleteAppProjectRepositoryByAppProjectRepositoryID(ctx context.Context, obj *AppProjectRepository) (int, error) {
+	if err := shouldSimulateFailure("DeleteAppProjectRepositoryByAppProjectRepositoryID", obj); err != nil {
 		return 0, err
 	}
-	return cdb.InnerClient.DeleteAppProjectRepositoryByRepoCredId(ctx, obj)
+	return cdb.InnerClient.DeleteAppProjectRepositoryByAppProjectRepositoryID(ctx, obj)
 }
 
 func (cdb *ChaosDBClient) DeleteAppProjectRepositoryByClusterUserAndRepoURL(ctx context.Context, obj *AppProjectRepository) (int, error) {

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -198,7 +198,7 @@ gosec: go_sec
 # Remove the vendor and bin folders
 .PHONY: clean
 clean:
-	rm -rf vendor/ bin/
+	rm -rf vendor/ bin/ cover.out
 
 # Remove the vendor and bin folders
 .PHONY: clean-exec

--- a/backend/eventloop/application_event_loop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_test.go
@@ -1225,7 +1225,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			err := k8sClient.Update(ctx, gitopsDepl)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = removeFinalizerIfExist(ctx, k8sClient, gitopsDepl, testFinalizer)
+			err = removeFinalizerIfExists(ctx, k8sClient, gitopsDepl, testFinalizer)
 			Expect(err).ToNot(HaveOccurred())
 
 			gitopsDeplUpdated := false
@@ -1238,7 +1238,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 		})
 
 		It("should not update if the finalizer is not found", func() {
-			err := removeFinalizerIfExist(ctx, k8sClient, gitopsDepl, managedgitopsv1alpha1.DeletionFinalizer)
+			err := removeFinalizerIfExists(ctx, k8sClient, gitopsDepl, managedgitopsv1alpha1.DeletionFinalizer)
 			Expect(err).ToNot(HaveOccurred())
 
 			gitopsDeplUpdated := false
@@ -1255,7 +1255,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			gitopsDepl.Finalizers = append(gitopsDepl.Finalizers, managedgitopsv1alpha1.DeletionFinalizer)
-			err = removeFinalizerIfExist(ctx, k8sClient, gitopsDepl, managedgitopsv1alpha1.DeletionFinalizer)
+			err = removeFinalizerIfExists(ctx, k8sClient, gitopsDepl, managedgitopsv1alpha1.DeletionFinalizer)
 			Expect(err).ToNot(HaveOccurred())
 
 			gitopsDeplUpdated := false
@@ -1281,7 +1281,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			Expect(errors.IsConflict(err)).To(BeTrue())
 
 			By("verify if the conflict will be handled by retrying")
-			err = removeFinalizerIfExist(ctx, k8sClient, gitopsDepl, managedgitopsv1alpha1.DeletionFinalizer)
+			err = removeFinalizerIfExists(ctx, k8sClient, gitopsDepl, managedgitopsv1alpha1.DeletionFinalizer)
 			Expect(err).ToNot(HaveOccurred())
 
 			gitopsDeplUpdated := false

--- a/backend/eventloop/db_reconciler_test.go
+++ b/backend/eventloop/db_reconciler_test.go
@@ -351,7 +351,7 @@ var _ = Describe("DB Clean-up Function Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Call cleanOrphanedEntriesfromTable_ACTDM function.")
-				cleanOrphanedEntriesfromTable_ACTDM(ctx, dbq, k8sClient, nil, true, log)
+				cleanOrphanedEntriesfromTable_ACTDM(ctx, dbq, k8sClient, MockSRLK8sClientFactory{fakeClient: k8sClient}, true, log)
 
 				By("Verify that no entry is deleted from DB.")
 				err = dbq.GetManagedEnvironmentById(ctx, &managedEnvironmentDb)
@@ -389,7 +389,7 @@ var _ = Describe("DB Clean-up Function Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Call cleanOrphanedEntriesfromTable_ACTDM function.")
-				cleanOrphanedEntriesfromTable_ACTDM(ctx, dbq, k8sClient, nil, true, log)
+				cleanOrphanedEntriesfromTable_ACTDM(ctx, dbq, k8sClient, MockSRLK8sClientFactory{fakeClient: k8sClient}, true, log)
 
 				By("Verify that entries for the ManagedEnvironment which is not available in cluster, are deleted from DB.")
 

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -644,9 +644,8 @@ func reconcileAppProjectRepositories(ctx context.Context, gitRepoURLUnnormalized
 		}
 
 		newAppProjectRepo := db.AppProjectRepository{
-			Clusteruser_id:          clusterUser.Clusteruser_id,
-			RepositorycredentialsID: "",
-			RepoURL:                 gitURLOfMissingAppProjectRepoRow,
+			Clusteruser_id: clusterUser.Clusteruser_id,
+			RepoURL:        gitURLOfMissingAppProjectRepoRow,
 		}
 		if err := dbQueries.CreateAppProjectRepository(ctx, &newAppProjectRepo); err != nil {
 			return fmt.Errorf("unable to create AppProjectRepository: %w . repository: %v", err, newAppProjectRepo)

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -597,7 +597,9 @@ func reconcileAppProjectRepositories(ctx context.Context, gitRepoURLUnnormalized
 
 	// For each existing entry in the database, find the corresponding expected entry, and reconcile any differences
 
-	for _, appProjectRepoInNamepace := range appProjectReposInNamepace {
+	for idx := range appProjectReposInNamepace {
+
+		appProjectRepoInNamepace := appProjectReposInNamepace[idx]
 
 		gitURLOfDatabaseRow := NormalizeGitURL(appProjectRepoInNamepace.RepoURL)
 

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -46,7 +46,7 @@ type SharedResourceEventLoop struct {
 	inputChannel chan sharedResourceLoopMessage
 }
 
-// ReconcileAppProjectRepositories ensures that the necessary AppProjectRepository database rows exists in the database, and that that they are consistent with the GitOpsDeployment/GitOpsDeploymentRepositoryCredentials defined in the given Namespace.
+// ReconcileAppProjectRepositories ensures that the necessary AppProjectRepository database rows exists in the database, and that they are consistent with the GitOpsDeployment/GitOpsDeploymentRepositoryCredentials defined in the given Namespace.
 //
 // parameters:
 // - gitRepoURLUnnormalizedOfRequest is the repository URL defined in the GitOpDeployment or GitOpsDeploymentRepositoryCredential for which
@@ -524,7 +524,7 @@ func internalProcessMessage_reconcileAppProjectRepositories(ctx context.Context,
 	return reconcileAppProjectRepositories(ctx, payload.repoURLUnnormalizedFromRequest, namespace, workspaceClient, dbQueries, l)
 }
 
-// reconcileAppProjectRepositories ensures that the necessary AppProjectRepository database rows exists in the database, and that that they are consistent with the GitOpsDeployment/GitOpsDeploymentRepositoryCredentials defined in the Namespace.
+// reconcileAppProjectRepositories ensures that the necessary AppProjectRepository database rows exists in the database, and that they are consistent with the GitOpsDeployment/GitOpsDeploymentRepositoryCredentials defined in the Namespace.
 //
 // parameters:
 // - gitRepoURLUnnormalizedOfRequest is the repository URL defined in the GitOpDeployment or GitOpsDeploymentRepositoryCredential for which

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_repositorycredential.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_repositorycredential.go
@@ -580,7 +580,7 @@ func generateValidRepositoryCredentialsConditions(repositoryCredential *managedg
 
 func validateRepositoryCredentials(rawRepoURL string, secret *corev1.Secret) error {
 
-	normalizedRepoUrl := normalizeGitURL(rawRepoURL)
+	normalizedRepoUrl := NormalizeGitURL(rawRepoURL)
 	rem := git.NewRemote(memory.NewStorage(), &config.RemoteConfig{
 		Name: "origin",
 		URLs: []string{normalizedRepoUrl},
@@ -630,9 +630,9 @@ var (
 	sshURLRegex = regexp.MustCompile("^(ssh://)?([^/:]*?)@[^@]+$")
 )
 
-// normalizeGitURL normalizes a git URL for purposes of comparison, as well as preventing redundant
+// NormalizeGitURL normalizes a git URL for purposes of comparison, as well as preventing redundant
 // local clones (by normalizing various forms of a URL to a consistent location).
-func normalizeGitURL(repo string) string {
+func NormalizeGitURL(repo string) string {
 	repo = strings.ToLower(strings.TrimSpace(repo))
 	if yes, _ := isSSHURL(repo); yes {
 		if !strings.HasPrefix(repo, "ssh://") {

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_repositorycredential_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_repositorycredential_test.go
@@ -43,7 +43,7 @@ var _ = Describe("SharedResourceEventLoop Repository Credential Tests", func() {
 
 		DescribeTable("Test scenarios for normalizeGitURL", func(repoUrl, normalizedRepoUrl string) {
 
-			Expect(normalizeGitURL(repoUrl)).To(Equal(normalizedRepoUrl))
+			Expect(NormalizeGitURL(repoUrl)).To(Equal(normalizedRepoUrl))
 		},
 			Entry("Https Url", "https://github.com/redhat-appstudio/test.git", "https://github.com/redhat-appstudio/test"),
 			Entry("Git Url", "git@github.com:redhat-appstudio/managed-gitops.git", "git@github.com/redhat-appstudio/managed-gitops"),

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_repositorycredential_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_repositorycredential_test.go
@@ -43,7 +43,7 @@ var _ = Describe("SharedResourceEventLoop Repository Credential Tests", func() {
 
 		DescribeTable("Test scenarios for normalizeGitURL", func(repoUrl, normalizedRepoUrl string) {
 
-			Expect(NormalizeGitURL(repoUrl)).To(Equal(normalizedRepoUrl))
+			Expect(normalizeGitURL(repoUrl)).To(Equal(normalizedRepoUrl))
 		},
 			Entry("Https Url", "https://github.com/redhat-appstudio/test.git", "https://github.com/redhat-appstudio/test"),
 			Entry("Git Url", "git@github.com:redhat-appstudio/managed-gitops.git", "git@github.com/redhat-appstudio/managed-gitops"),

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
@@ -722,10 +722,9 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 
 			By("creating a AppProjectRepository that is based on the contents of the GitOpsDeployment")
 			appProjectRepoDB := &db.AppProjectRepository{
-				AppprojectRepositoryID:  "test-appProject-ID",
-				Clusteruser_id:          clusterUserDb.Clusteruser_id,
-				RepositorycredentialsID: "",
-				RepoURL:                 normalizeGitURL(gitopsDepl.Spec.Source.RepoURL),
+				AppprojectRepositoryID: "test-appProject-ID",
+				Clusteruser_id:         clusterUserDb.Clusteruser_id,
+				RepoURL:                normalizeGitURL(gitopsDepl.Spec.Source.RepoURL),
 			}
 
 			err = dbq.CreateAppProjectRepository(ctx, appProjectRepoDB)
@@ -767,10 +766,6 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			err = dbq.GetAppProjectRepositoryByClusterUserAndRepoURL(ctx, appProjectRepoDB)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(appProjectRepoDB).NotTo(BeNil())
-
-			By("Verify whether AppProjectRepoCred is updated to point to the repoCred row in the database.")
-			Expect(appProjectRepoDB.RepositorycredentialsID).ToNot(BeNil())
-			// Expect(appProjectRepoDB.RepositorycredentialsID).To(Equal(dbRepoCred.RepositoryCredentialsID))
 
 			By("Deleting resources created by test.")
 			resourcesToBeDeleted = testResources{

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop_test.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop_test.go
@@ -1463,10 +1463,9 @@ var _ = Describe("Operation Controller", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				dbAppProjectRepo := &db.AppProjectRepository{
-					AppprojectRepositoryID:  "test-appProject-repo-id",
-					Clusteruser_id:          testClusterUser.Clusteruser_id,
-					RepositorycredentialsID: repoCredentials.RepositoryCredentialsID,
-					RepoURL:                 "test-url",
+					AppprojectRepositoryID: "test-appProject-repo-id",
+					Clusteruser_id:         testClusterUser.Clusteruser_id,
+					RepoURL:                "test-url",
 				}
 
 				err = dbQueries.CreateAppProjectRepository(ctx, dbAppProjectRepo)
@@ -1924,10 +1923,9 @@ var _ = Describe("Operation Controller", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				dbAppProjectRepo := &db.AppProjectRepository{
-					AppprojectRepositoryID:  "test-appProject-repo-id",
-					Clusteruser_id:          testClusterUser.Clusteruser_id,
-					RepositorycredentialsID: repoCredentials.RepositoryCredentialsID,
-					RepoURL:                 "test-url",
+					AppprojectRepositoryID: "test-appProject-repo-id",
+					Clusteruser_id:         testClusterUser.Clusteruser_id,
+					RepoURL:                "test-url",
 				}
 
 				err = dbQueries.CreateAppProjectRepository(ctx, dbAppProjectRepo)

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop_test.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop_test.go
@@ -2897,10 +2897,8 @@ func deleteTestResources(ctx context.Context, dbQueries db.AllDatabaseQueries, r
 
 	// Delete AppProjectRepository
 	if resourcesToBeDeleted.AppProjectRepositoryID != "" {
-		appProjectRepository := &db.AppProjectRepository{
-			RepositorycredentialsID: resourcesToBeDeleted.RepositoryCredentialsID,
-		}
-		rowsAffected, err = dbQueries.DeleteAppProjectRepositoryByRepoCredId(ctx, appProjectRepository)
+
+		rowsAffected, err = dbQueries.DeleteAppProjectRepositoryByAppProjectRepositoryID(ctx, &db.AppProjectRepository{AppprojectRepositoryID: resourcesToBeDeleted.AppProjectRepositoryID})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rowsAffected).To(Equal(1))
 	}

--- a/db-schema.sql
+++ b/db-schema.sql
@@ -540,11 +540,6 @@ CREATE TABLE AppProjectRepository (
 	-- Foreign key to: ClusterUser.clusteruser_id
 	clusteruser_id VARCHAR (48) NOT NULL,
 	CONSTRAINT fk_clusteruser_id FOREIGN KEY (clusteruser_id) REFERENCES ClusterUser(clusteruser_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
-
-	-- Describes which repositorycredentials the user has access to (UID)
-	-- Foreign key to: RepositoryCredentials.repositorycredentials_id
-	repositorycredentials_id VARCHAR ( 48 ),
-	CONSTRAINT fk_repositorycredentials_id FOREIGN KEY (repositorycredentials_id) REFERENCES RepositoryCredentials(repositorycredentials_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
 	
 	-- Normalized Repo URL
 	repo_url VARCHAR (256) NOT NULL,

--- a/docs/sandboxing-via-appprojects.md
+++ b/docs/sandboxing-via-appprojects.md
@@ -106,8 +106,6 @@ As of this writing, the current short-term solution to this (and which is unrela
 
 **New database table - AppProjectRepository:**
 
-
-
 * `ClusterUser (foreign key)`
     * DB index on this field, to allow us to quickly retrieve all items for a particular user.
 * `RepositoryCredential (foreign key, nullable)`
@@ -120,8 +118,8 @@ This row tracks which Git repository URLs a particular user can access.
 
 There should also exist a uniqueness constraint on the _(cluster user, normalized repository url) tuple_, to eliminate the case where multiple AppProjectRepository point to the same Git repository (which itself wouldn’t be the end of the world, but this is an easy way to eliminate this risk).
 
-To generate a list of all of the repositories a user can access, so that we can insert those values into an AppProject, one would do: `SELECT * from AppProjectRepository WHERE user = (user id)``
-* As above, ensuring we have an index on user should keep this query efficient.
+To generate a list of all of the repositories a user can access, so that we can insert those values into an AppProject, one would do: `SELECT * from AppProjectRepository WHERE user = (user id)`
+* As above, ensuring we have an index on user that should ensure this query remains efficient.
 
 **New database table - AppProjectManagedEnvironment:**
 
@@ -188,8 +186,6 @@ The backend component will receive the create/modify event in application_event_
 **New behaviour - when an Operation pointing to an Application is reconciled:**
 
 When we process an Operation that points to an Application, before we generate (or update) the corresponding Argo CD Application, we should do the following:
-
-
 
 * Generate the expected AppProject resource:
     * Get the ClusterUser from the operation_owner_user_id

--- a/tests-e2e/Makefile
+++ b/tests-e2e/Makefile
@@ -68,7 +68,7 @@ gosec: go_sec ## Run the gosec tool
 # Remove the vendor and bin folders
 .PHONY: clean
 clean: ## Remove the vendor and bin folders
-	rm -rf vendor/ bin/
+	rm -rf vendor/ bin/ coverage.out
 
 #required for test execution from OpenShift CI
 test-backward-compatibility:

--- a/tests-e2e/core/gitopsdeployment_test.go
+++ b/tests-e2e/core/gitopsdeployment_test.go
@@ -264,7 +264,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 			err = k8s.Create(&gitOpsDeploymentResource1, k8sClient)
 			Expect(err).To(Succeed())
 
-			gitOpsDeploymentResource2 := gitopsDeplFixture.BuildGitOpsDeploymentResource(fixture.GitopsDeploymentName,
+			gitOpsDeploymentResource2 := gitopsDeplFixture.BuildGitOpsDeploymentResource(fixture.GitopsDeploymentName+"2",
 				fixture.RepoURL, "resources/test-data/sample-gitops-repository/environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 

--- a/tests-e2e/core/gitopsdeployment_test.go
+++ b/tests-e2e/core/gitopsdeployment_test.go
@@ -254,8 +254,8 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 		It("should ensure that when 2 GitOpsDeployments are created and point to the same repo url, and one is deleted, the AppProjectRepository for the other still exists", func() {
 
 			Expect(fixture.EnsureCleanSlate()).To(Succeed())
-			gitOpsDeploymentResource1 := gitopsDeplFixture.BuildGitOpsDeploymentResource(name,
-				repoURL, "resources/test-data/sample-gitops-repository/environments/overlays/dev",
+			gitOpsDeploymentResource1 := gitopsDeplFixture.BuildGitOpsDeploymentResource(fixture.GitopsDeploymentName,
+				fixture.RepoURL, "resources/test-data/sample-gitops-repository/environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
 			k8sClient, err := fixture.GetE2ETestUserWorkspaceKubeClient()
@@ -264,8 +264,8 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 			err = k8s.Create(&gitOpsDeploymentResource1, k8sClient)
 			Expect(err).To(Succeed())
 
-			gitOpsDeploymentResource2 := gitopsDeplFixture.BuildGitOpsDeploymentResource(name+"2",
-				repoURL, "resources/test-data/sample-gitops-repository/environments/overlays/dev",
+			gitOpsDeploymentResource2 := gitopsDeplFixture.BuildGitOpsDeploymentResource(fixture.GitopsDeploymentName,
+				fixture.RepoURL, "resources/test-data/sample-gitops-repository/environments/overlays/dev",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Automated)
 
 			err = k8s.Create(&gitOpsDeploymentResource2, k8sClient)
@@ -304,7 +304,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(appProject), appProject)).Error().ToNot(HaveOccurred())
 
-			Expect(appProject.Spec.SourceRepos).Should(ContainElement(repoURL))
+			Expect(appProject.Spec.SourceRepos).Should(ContainElement(fixture.RepoURL))
 
 			By("deleting the second GitOpsDeployment targeting the git repository")
 			Expect(k8sClient.Delete(ctx, &gitOpsDeploymentResource2)).Error().ToNot(HaveOccurred())
@@ -313,7 +313,7 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(appProject), appProject)).Error().ToNot(HaveOccurred())
 
-			Expect(appProject.Spec.SourceRepos).Should(ContainElement(repoURL), "it should still reference the repoURL from the GitOpsDeployment")
+			Expect(appProject.Spec.SourceRepos).Should(ContainElement(fixture.RepoURL), "it should still reference the repoURL from the GitOpsDeployment")
 
 			By("deleting the first GitOpsDeployment targeting the git repository")
 			Expect(k8sClient.Delete(ctx, &gitOpsDeploymentResource1)).Error().ToNot(HaveOccurred())

--- a/tests-e2e/fixture/fixture.go
+++ b/tests-e2e/fixture/fixture.go
@@ -337,7 +337,11 @@ func cleanUpOldSnapshotEnvironmentBindingAPIs(namespace string, k8sClient client
 func cleanUpOldDeploymentTargetClaimAPIs(ns string, k8sClient client.Client) error {
 	dtcList := appstudiosharedv1.DeploymentTargetClaimList{}
 	if err := k8sClient.List(context.Background(), &dtcList, &client.ListOptions{Namespace: ns}); err != nil {
-		return err
+		if !apierr.IsNotFound(err) {
+			return err
+		} else { // ignore not found
+			return nil
+		}
 	}
 
 	for i := range dtcList.Items {

--- a/utilities/db-migration/migration_test/add_test_values/add_db_values.go
+++ b/utilities/db-migration/migration_test/add_test_values/add_db_values.go
@@ -136,10 +136,9 @@ var (
 	}
 
 	AddTest_PreAppProjectRepository = db.AppProjectRepository{
-		AppprojectRepositoryID:  "test-app-project-repo",
-		RepositorycredentialsID: AddTest_PreRepositoryCredentials.RepositoryCredentialsID,
-		Clusteruser_id:          AddTest_PreClusterUser.Clusteruser_id,
-		RepoURL:                 AddTest_PreRepositoryCredentials.PrivateURL,
+		AppprojectRepositoryID: "test-app-project-repo",
+		Clusteruser_id:         AddTest_PreClusterUser.Clusteruser_id,
+		RepoURL:                AddTest_PreRepositoryCredentials.PrivateURL,
 	}
 
 	AddTest_PreAppProjectManagedEnv = db.AppProjectManagedEnvironment{

--- a/utilities/db-migration/migrations/000019_v19.down.sql
+++ b/utilities/db-migration/migrations/000019_v19.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE AppProjectRepository ADD COLUMN repositorycredentials_id VARCHAR ( 48 );

--- a/utilities/db-migration/migrations/000019_v19.up.sql
+++ b/utilities/db-migration/migrations/000019_v19.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE AppProjectRepository DROP COLUMN repositorycredentials_id;


### PR DESCRIPTION
#### Description:
- The logic for determining what `AppProjectRepository` rows should exist in the database is now entirely within the `reconcileAppProjectRepositories` function of the shared resource loop
- This avoids a potential race condition where multiple GitOpsDeployments/RepositoryCredentials were reconciling AppProjects at the same time.
    - To be clear: this race condition was due to a flaw in *my* proposal in the original design document, and not an issue with the implementation itself by the GitOps Service EE team.
- The existing AppProjectRepository reconcile functions now call the shared resource loop function

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-705

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
