### PR TITLE
Update .ci base-image Dockerfile go version

### DIFF
--- a/.ci/base-image/Dockerfile
+++ b/.ci/base-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18
+FROM registry.ci.openshift.org/openshift/release:golang-1.19
 
 # make sure Go doesn't use the vendors folder, unless we want to
 ENV GOFLAGS=""


### PR DESCRIPTION
#### Description:
- As part of updating our Argo CD dependency to 2.7.11, we had to update to use golang 1.19.  The .ci/base-image/Dockerfile should be updated as well.