### PR TITLE
Improve test coverage of backend pt1

### DIFF
--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
@@ -285,8 +285,8 @@ func getManagedEnvironmentCRs(ctx context.Context,
 
 	if managedEnvironmentCR.Spec.ClusterCredentialsSecret == "" {
 		return managedgitopsv1alpha1.GitOpsDeploymentManagedEnvironment{}, corev1.Secret{}, resourceExists,
-			fmt.Errorf("secret '%s' referenced by managed environment '%s' in '%s', is invalid",
-				managedEnvironmentCR.Spec.ClusterCredentialsSecret, managedEnvironmentCR.Name, managedEnvironmentCR.Namespace)
+			fmt.Errorf("no secret specified by managed environment '%s' in '%s'",
+				managedEnvironmentCR.Name, managedEnvironmentCR.Namespace)
 	}
 
 	// Retrieve the Secret CR from the workspace

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
@@ -1007,7 +1007,7 @@ func locateContextThatMatchesAPIURL(config *clientcmdapi.Config, apiURL string) 
 		}
 	}
 	if matchingClusterName == "" {
-		return "", clientcmdapi.Context{}, fmt.Errorf("the kubeconfig did not have a cluster entry that matched the API URL '%s", apiURL)
+		return "", clientcmdapi.Context{}, fmt.Errorf("the kubeconfig did not have a cluster entry that matched the API URL '%s'", apiURL)
 	}
 
 	// Look for the context that matches the cluster above

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv_test.go
@@ -1193,6 +1193,7 @@ var _ = Describe("SharedResourceEventLoop ManagedEnvironment-related Test", func
 			src, err := internalProcessMessage_ReconcileSharedManagedEnv(ctx, k8sClient, managedEnv.Name, managedEnv.Namespace,
 				false, *namespace, mockFactory, dbQueries, log)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(src.ManagedEnv).ToNot(BeNil())
 
 			By("updating the existing managed environment with an invalid namespace")
 			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: managedEnv.Namespace, Name: managedEnv.Name}, managedEnv)


### PR DESCRIPTION
#### Description:
- Improve the test coverage of 'internalProcessMessage_internalReconcileSharedManagedEnv', 'createNewClusterCredentials', 'locateContextThatMatchesAPIURL', in backend component.

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-694

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
