### PR TITLE
Unit tests for waitForOperationToComplete, isOperationComplete (#688)

### DIFF
--- a/backend-shared/util/operations/types.go
+++ b/backend-shared/util/operations/types.go
@@ -107,7 +107,7 @@ func createOperationInternal(ctx context.Context, waitForOperation bool, dbOpera
 	}
 
 	if operationNamespace == "" {
-		l.Error(err, "Invalid: Operation namespace is empty")
+		l.Error(err, "Invalid: Operation namespace is empty, OperationID: %s", dbOperationParam.Operation_id)
 		return nil, nil, fmt.Errorf("invalid Operation namespace")
 
 	}

--- a/backend-shared/util/operations/types_test.go
+++ b/backend-shared/util/operations/types_test.go
@@ -202,6 +202,26 @@ var _ = Describe("Testing CreateOperation function.", func() {
 
 		})
 
+		It("should pass a non-existent DB Operation to isOperationComplete, to test error handling.", func() {
+			_, _, _, gitopsEngineInstance, _, err := db.CreateSampleData(dbq)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("define a sample operation")
+			sampleOperation := &db.Operation{
+				Operation_id:            "test-engine-operation",
+				Instance_id:             gitopsEngineInstance.Gitopsengineinstance_id,
+				Resource_id:             "test-fake-resource-id",
+				Resource_type:           "GitopsEngineInstance",
+				Operation_owner_user_id: "test-user",
+			}
+
+			// Now directly call isOperationComplete to test the error handling
+			isComplete, err := IsOperationComplete(ctx, sampleOperation, dbq)
+			Expect(isComplete).To(BeFalse())
+			Expect(err).To(HaveOccurred())
+
+		})
+
 		It("should test CreateOperation with waitForOperation set to true to indirectly test the waitForOperationToComplete function.", func() {
 			_, managedEnvironment, _, gitopsEngineInstance, _, err := db.CreateSampleData(dbq)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
#### Description:
- This PR does not add the unit tests for service_account.go since it is separate
- The first test tests directly the two functions waitForOperationToComplete and isOperationComplete 
- CreateOperation is not tested thoroughly as well, in particular, there is no test that sets true for waitForOperation. 
   - This PR makes some slight tweaks in product code to accommodate this.
   - The second tests tests the 'old' CreateOperation via the new doCreateOperation.  I added two operations but only one is probably sufficient.  Let me know if you want to remove one of them

#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-688