### PR TITLE
Fix 'failed to list resources' debug statement logging at error level

### DIFF
--- a/backend-shared/db/util/utils.go
+++ b/backend-shared/db/util/utils.go
@@ -458,7 +458,9 @@ func GetOrCreateDeploymentToApplicationMapping(ctx context.Context, createDeplTo
 		log.Error(err, "Unable to delete old DeploymentToApplicationMapping, by Namespace and Name")
 		return false, err
 	} else {
-		log.Info("Deleted old DeploymentToApplicationMapping, by Namespace and Name", "resultsDeleted", resultsDeleted)
+		if resultsDeleted > 0 {
+			log.Info("Deleted old DeploymentToApplicationMapping, by Namespace and Name", "resultsDeleted", resultsDeleted)
+		}
 	}
 
 	if err := dbq.CreateDeploymentToApplicationMapping(ctx, createDeplToAppMapping); err != nil {

--- a/backend/eventloop/cluster_reconciler.go
+++ b/backend/eventloop/cluster_reconciler.go
@@ -2,6 +2,7 @@ package eventloop
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -175,7 +176,7 @@ func (c *ClusterReconciler) getAllNamespacedAPIResources(ctx context.Context, lo
 			objList.SetKind(apiResource.Kind)
 
 			if err := c.client.List(ctx, objList, opts...); err != nil {
-				log.V(logutil.LogLevel_Debug).Error(err, "failed to list resources", "resource", apiResource.Kind)
+				log.V(logutil.LogLevel_Debug).Info("failed to list resources", "resource", apiResource.Kind, "error", fmt.Sprintf("%v", err))
 				continue
 			}
 


### PR DESCRIPTION
#### Description:
- On RHTAP clusters, the 'failed to list resources' from `cluster_reconciler.go` is logging at error level, rather than at debug level, due to the use of Error function.

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
