### PR TITLE
Fix panic in isManagedEnvironmentConnectionUserError

### DIFF
--- a/backend/eventloop/workspace_resource_event_loop.go
+++ b/backend/eventloop/workspace_resource_event_loop.go
@@ -269,6 +269,11 @@ func internalProcessWorkspaceResourceMessage(ctx context.Context, msg workspaceR
 
 // isManagedEnvironmentConnectionUserError returns true if the error is likely an error in the cluster credentials provided by the user
 func isManagedEnvironmentConnectionUserError(err error, log logr.Logger) bool {
+
+	if err == nil {
+		return false
+	}
+
 	errStr := err.Error()
 
 	if strings.Contains(errStr, shared_resource_loop.UnableToCreateRestConfigError) {

--- a/backend/eventloop/workspace_resource_event_loop_test.go
+++ b/backend/eventloop/workspace_resource_event_loop_test.go
@@ -35,5 +35,13 @@ var _ = Describe("isManagedEnvironmentConnectionUserError function Test", func()
 			result := isManagedEnvironmentConnectionUserError(err, log)
 			Expect(result).To(BeFalse())
 		})
+
+		It("should return False if error is nil", func() {
+			ctx := context.Background()
+			log := log.FromContext(ctx)
+
+			result := isManagedEnvironmentConnectionUserError(nil, log)
+			Expect(result).To(BeFalse())
+		})
 	})
 })


### PR DESCRIPTION
#### Description:
- `isManagedEnvironmentConnectionUserError` is panic-ing when the error is nil, so check for that case
- Unit test that verifies that case

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
