### PR TITLE
Fix intermittent binding controller e2e test

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetreclaimer_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetreclaimer_controller.go
@@ -262,7 +262,7 @@ func findMatchingDTClassForDT(ctx context.Context, dt applicationv1alpha1.Deploy
 		},
 	}
 	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(&dtClass), &dtClass); err != nil {
-		return applicationv1alpha1.DeploymentTargetClass{}, fmt.Errorf("unable to retrieve DeploymentTargetClass '%s' referenced by DeploymentTarget", dtClass.Name)
+		return applicationv1alpha1.DeploymentTargetClass{}, fmt.Errorf("unable to retrieve DeploymentTargetClass '%s' referenced by DeploymentTarget: %w", dtClass.Name, err)
 	}
 
 	return dtClass, nil

--- a/tests-e2e/appstudio/deploymenttargetclaim_binder_test.go
+++ b/tests-e2e/appstudio/deploymenttargetclaim_binder_test.go
@@ -170,7 +170,7 @@ var _ = Describe("DeploymentTargetClaim Binding controller tests", func() {
 				},
 			}
 
-			err = k8sClient.Create(ctx, &fakeDTC)
+			err = k8sClient.Create(ctx, &fakeDT)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("verify if the above DTC is binded with a matching DT")


### PR DESCRIPTION
#### Description:
- The DeploymentTarget reclaimer will unset the claimRef if the specified DTC is not found. In the e2e test, we were creating a fake DT pointing to a DTC which didn't exist and the claimRef field was unset by the reclaimer controller. Hence the binding controller had two matching DTs(the correct DT and the fake DT whose claimRef was unset) available for a single DTC. So, when the binding controller picked the fake DT it resulted in an intermittent failure.
- In order to solve this we create a DTC that binds with the fake DT so that its claimRef field will not be unset.
#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-711