### PR TITLE
Store the full contents of Application status in a single DB field

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -183,7 +183,7 @@ jobs:
       - name: "Migrate database to version x"
         run: |
           cd $GITHUB_WORKSPACE/utilities/db-migration
-          go run main.go migrate_to 18
+          go run main.go migrate_to 20
 
       - name: "Run migration tests to add data in database"
         run: |

--- a/backend-shared/db/applicationstates.go
+++ b/backend-shared/db/applicationstates.go
@@ -49,9 +49,7 @@ func (dbq *PostgreSQLDatabaseQueries) CreateApplicationState(ctx context.Context
 
 	if err := isEmptyValues("CreateApplicationState",
 		"Applicationstate_application_id", obj.Applicationstate_application_id,
-		"Health", obj.Health,
-		"Sync_Status", obj.Sync_Status,
-		"ReconciledState", obj.ReconciledState); err != nil {
+		"ArgoCD_Application_Status", obj.ArgoCD_Application_Status); err != nil {
 		return err
 	}
 
@@ -63,7 +61,7 @@ func (dbq *PostgreSQLDatabaseQueries) CreateApplicationState(ctx context.Context
 	// validateFieldLength function is not modified as that is written for Strings
 	// and after adding check for byte array it would get messy. As of now This is the only place byte array has to be checked,
 	// if multiple places need this it new function can be created in utils.
-	noOfBytesInObj := binary.Size(obj.Resources)
+	noOfBytesInObj := binary.Size(obj.ArgoCD_Application_Status)
 	maxSize := DbFieldMap["ApplicationStateResourcesLength"]
 	if noOfBytesInObj > maxSize {
 		return fmt.Errorf("resources value exceeds maximum size: max: %d, actual: %d", maxSize, noOfBytesInObj)
@@ -89,9 +87,7 @@ func (dbq *PostgreSQLDatabaseQueries) UpdateApplicationState(ctx context.Context
 
 	if err := isEmptyValues("UpdateApplicationState",
 		"Applicationstate_application_id", obj.Applicationstate_application_id,
-		"Health", obj.Health,
-		"Sync_Status", obj.Sync_Status,
-		"ReconciledState", obj.ReconciledState); err != nil {
+		"ArgoCD_Application_Status", obj.ArgoCD_Application_Status); err != nil {
 		return err
 	}
 
@@ -103,7 +99,7 @@ func (dbq *PostgreSQLDatabaseQueries) UpdateApplicationState(ctx context.Context
 	// validateFieldLength function is not modified as that is written for Strings
 	// and after adding check for byte array it would get messy. As of now This is the only place byte array has to be checked,
 	// if multiple places need this it new function can be created in utils.
-	noOfBytesInObj := binary.Size(obj.Resources)
+	noOfBytesInObj := binary.Size(obj.ArgoCD_Application_Status)
 	maxSize := DbFieldMap["ApplicationStateResourcesLength"]
 	if noOfBytesInObj > maxSize {
 		return fmt.Errorf("resources value exceeds maximum size: max: %d, actual: %d", maxSize, noOfBytesInObj)

--- a/backend-shared/db/applicationstates.go
+++ b/backend-shared/db/applicationstates.go
@@ -62,7 +62,7 @@ func (dbq *PostgreSQLDatabaseQueries) CreateApplicationState(ctx context.Context
 	// and after adding check for byte array it would get messy. As of now This is the only place byte array has to be checked,
 	// if multiple places need this it new function can be created in utils.
 	noOfBytesInObj := binary.Size(obj.ArgoCD_Application_Status)
-	maxSize := DbFieldMap["ApplicationStateResourcesLength"]
+	maxSize := DbFieldMap["ApplicationStateStatusLength"]
 	if noOfBytesInObj > maxSize {
 		return fmt.Errorf("resources value exceeds maximum size: max: %d, actual: %d", maxSize, noOfBytesInObj)
 	}
@@ -100,7 +100,7 @@ func (dbq *PostgreSQLDatabaseQueries) UpdateApplicationState(ctx context.Context
 	// and after adding check for byte array it would get messy. As of now This is the only place byte array has to be checked,
 	// if multiple places need this it new function can be created in utils.
 	noOfBytesInObj := binary.Size(obj.ArgoCD_Application_Status)
-	maxSize := DbFieldMap["ApplicationStateResourcesLength"]
+	maxSize := DbFieldMap["ApplicationStateStatusLength"]
 	if noOfBytesInObj > maxSize {
 		return fmt.Errorf("resources value exceeds maximum size: max: %d, actual: %d", maxSize, noOfBytesInObj)
 	}

--- a/backend-shared/db/db_field_constants.go
+++ b/backend-shared/db/db_field_constants.go
@@ -157,6 +157,7 @@ var DbFieldMap = map[string]int{
 	"ApplicationStateRevisionLength":                                          ApplicationStateRevisionLength,
 	"ApplicationStateSyncStatusLength":                                        ApplicationStateSyncStatusLength,
 	"ApplicationStateResourcesLength":                                         262144, /*Size is defined here because table doesn't have byte Array limit.*/
+	"ApplicationStateStatusLength":                                            262144,
 	"ApplicationStateReconciledStateLength":                                   ApplicationStateReconciledStateLength,
 	"DeploymentToApplicationMappingDeploymenttoapplicationmappingUIDIDLength": DeploymentToApplicationMappingDeploymenttoapplicationmappingUIDIDLength,
 	"DeploymentToApplicationMappingNameLength":                                DeploymentToApplicationMappingNameLength,

--- a/backend-shared/db/db_field_constants.go
+++ b/backend-shared/db/db_field_constants.go
@@ -42,11 +42,6 @@ const (
 	ApplicationEngineInstanceInstIDLength                                   = 48
 	ApplicationManagedEnvironmentIDLength                                   = 48
 	ApplicationStateApplicationstateApplicationIDLength                     = 48
-	ApplicationStateHealthLength                                            = 30
-	ApplicationStateMessageLength                                           = 1024
-	ApplicationStateRevisionLength                                          = 1024
-	ApplicationStateSyncStatusLength                                        = 30
-	ApplicationStateReconciledStateLength                                   = 4096
 	DeploymentToApplicationMappingDeploymenttoapplicationmappingUIDIDLength = 48
 	DeploymentToApplicationMappingNameLength                                = 256
 	DeploymentToApplicationMappingNamespaceLength                           = 96
@@ -152,13 +147,7 @@ var DbFieldMap = map[string]int{
 	"ApplicationEngineInstanceInstIDLength":                                   ApplicationEngineInstanceInstIDLength,
 	"ApplicationManagedEnvironmentIDLength":                                   ApplicationManagedEnvironmentIDLength,
 	"ApplicationStateApplicationstateApplicationIDLength":                     ApplicationStateApplicationstateApplicationIDLength,
-	"ApplicationStateHealthLength":                                            ApplicationStateHealthLength,
-	"ApplicationStateMessageLength":                                           ApplicationStateMessageLength,
-	"ApplicationStateRevisionLength":                                          ApplicationStateRevisionLength,
-	"ApplicationStateSyncStatusLength":                                        ApplicationStateSyncStatusLength,
-	"ApplicationStateResourcesLength":                                         262144, /*Size is defined here because table doesn't have byte Array limit.*/
 	"ApplicationStateStatusLength":                                            262144,
-	"ApplicationStateReconciledStateLength":                                   ApplicationStateReconciledStateLength,
 	"DeploymentToApplicationMappingDeploymenttoapplicationmappingUIDIDLength": DeploymentToApplicationMappingDeploymenttoapplicationmappingUIDIDLength,
 	"DeploymentToApplicationMappingNameLength":                                DeploymentToApplicationMappingNameLength,
 	"DeploymentToApplicationMappingDeploymentNameLength":                      DeploymentToApplicationMappingNameLength,

--- a/backend-shared/db/guardrow_test.go
+++ b/backend-shared/db/guardrow_test.go
@@ -138,11 +138,7 @@ var _ = Describe("Test to verify update/delete operations are not globally scope
 
 			applicationStateFirst := &db.ApplicationState{
 				Applicationstate_application_id: applicationFirst.Application_id,
-				Health:                          "Progressing",
-				Sync_Status:                     "Unknown",
-				Resources:                       make([]byte, 10),
-				ReconciledState:                 "test-reconciledState",
-				Conditions:                      []byte("sample"),
+				ArgoCD_Application_Status:       []byte("sample-status"),
 			}
 
 			err = dbq.CreateApplicationState(ctx, applicationStateFirst)
@@ -160,22 +156,14 @@ var _ = Describe("Test to verify update/delete operations are not globally scope
 
 			applicationStateSecond := &db.ApplicationState{
 				Applicationstate_application_id: applicationSecond.Application_id,
-				Health:                          "Progressing",
-				Sync_Status:                     "Unknown",
-				Resources:                       make([]byte, 10),
-				Conditions:                      []byte("sample"),
-				ReconciledState:                 "sample",
+				ArgoCD_Application_Status:       []byte("sample-status"),
 			}
 
 			err = dbq.CreateApplicationState(ctx, applicationStateSecond)
 			Expect(err).ToNot(HaveOccurred())
 			applicationStateSecond = &db.ApplicationState{
 				Applicationstate_application_id: applicationSecond.Application_id,
-				Health:                          "Progressing",
-				Sync_Status:                     "Sync",
-				Resources:                       make([]byte, 10),
-				Conditions:                      []byte("sample"),
-				ReconciledState:                 "sample",
+				ArgoCD_Application_Status:       []byte("sample-status"),
 			}
 
 			err = dbq.UpdateApplicationState(ctx, applicationStateSecond)
@@ -185,8 +173,8 @@ var _ = Describe("Test to verify update/delete operations are not globally scope
 			err = dbq.GetApplicationStateById(ctx, applicationStateSecond)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(applicationStateSecond.Sync_Status).Should(Equal("Sync"))
-			Expect(applicationStateFirst.Sync_Status).ShouldNot(Equal(applicationStateSecond.Sync_Status))
+			Expect(applicationStateFirst.ArgoCD_Application_Status).Should(Equal([]byte("sample-status")))
+			Expect(applicationStateFirst.ArgoCD_Application_Status).Should(Equal(applicationStateSecond.ArgoCD_Application_Status))
 
 			rowsAffected, err := dbq.DeleteApplicationStateById(ctx, applicationStateSecond.Applicationstate_application_id)
 			Expect(err).ToNot(HaveOccurred())

--- a/backend-shared/db/types.go
+++ b/backend-shared/db/types.go
@@ -282,36 +282,7 @@ type ApplicationState struct {
 	// -- Foreign key to Application.application_id
 	Applicationstate_application_id string `pg:"applicationstate_application_id,pk"`
 
-	// -- Possible values:
-	// -- * Healthy
-	// -- * Progressing
-	// -- * Degraded
-	// -- * Suspended
-	// -- * Missing
-	// -- * Unknown
-	Health string `pg:"health"`
-
-	// -- Possible values:
-	// -- * Synced
-	// -- * OutOfSync
-	// -- * Unknown
-	Sync_Status string `pg:"sync_status"`
-
-	Message string `pg:"message"`
-
-	Revision string `pg:"revision"`
-
-	Resources []byte `pg:"resources"`
-
-	OperationState []byte `pg:"operation_state"`
-
-	// -- human_readable_health ( 512 ) NOT NULL,
-	// -- human_readable_sync ( 512 ) NOT NULL,
-	// -- human_readable_state ( 512 ) NOT NULL,
-
-	ReconciledState string `pg:"reconciled_state"`
-
-	Conditions []byte `pg:"conditions"`
+	ArgoCD_Application_Status []byte `pg:"argocd_application_status"`
 }
 
 // DeploymentToApplicationMapping represents relationship from GitOpsDeployment CR in the namespace, to an Application table row

--- a/backend-shared/db/util/utils_test.go
+++ b/backend-shared/db/util/utils_test.go
@@ -1090,11 +1090,7 @@ var _ = Describe("Test utility functions.", func() {
 
 			applicationState := db.ApplicationState{
 				Applicationstate_application_id: application.Application_id,
-				Health:                          "Progressing",
-				Sync_Status:                     "Unknown",
-				Resources:                       make([]byte, 10),
-				ReconciledState:                 "test-reconciledState",
-				Conditions:                      []byte("sample"),
+				ArgoCD_Application_Status:       []byte("sample"),
 			}
 
 			operation := &db.Operation{

--- a/backend-shared/util/fauxargocd/faux_argo_cd.go
+++ b/backend-shared/util/fauxargocd/faux_argo_cd.go
@@ -1,5 +1,9 @@
 package fauxargocd
 
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 // This package is a partial clone of the Argo CD Application Go struct, containing a subset of the Application CR
 // fields.
 //
@@ -10,7 +14,8 @@ package fauxargocd
 type FauxApplication struct {
 	FauxTypeMeta   `json:"fauxtypemeta"`
 	FauxObjectMeta `json:"fauxobjectmeta"`
-	Spec           FauxApplicationSpec `json:"spec"`
+	Spec           FauxApplicationSpec   `json:"spec"`
+	Status         FauxApplicationStatus `json:"status"`
 }
 
 type FauxObjectMeta struct {
@@ -111,3 +116,309 @@ type Backoff struct {
 	// MaxDuration is the maximum amount of time allowed for the backoff strategy
 	MaxDuration string `json:"maxDuration,omitempty" protobuf:"bytes,3,opt,name=maxDuration"`
 }
+
+type FauxApplicationStatus struct {
+	// Resources is a list of Kubernetes resources managed by this application
+	Resources []ResourceStatus `json:"resources,omitempty" protobuf:"bytes,1,opt,name=resources"`
+	// Sync contains information about the application's current sync status
+	Sync SyncStatus `json:"sync,omitempty" protobuf:"bytes,2,opt,name=sync"`
+	// Health contains information about the application's current health status
+	Health HealthStatus `json:"health,omitempty" protobuf:"bytes,3,opt,name=health"`
+	// Conditions is a list of currently observed application conditions
+	Conditions []ApplicationCondition `json:"conditions,omitempty" protobuf:"bytes,5,opt,name=conditions"`
+	// OperationState contains information about any ongoing operations, such as a sync
+	OperationState *OperationState `json:"operationState,omitempty" protobuf:"bytes,7,opt,name=operationState"`
+}
+
+// ResourceStatus holds the current sync and health status of a resource
+// TODO: describe members of this type
+type ResourceStatus struct {
+	Group           string         `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
+	Version         string         `json:"version,omitempty" protobuf:"bytes,2,opt,name=version"`
+	Kind            string         `json:"kind,omitempty" protobuf:"bytes,3,opt,name=kind"`
+	Namespace       string         `json:"namespace,omitempty" protobuf:"bytes,4,opt,name=namespace"`
+	Name            string         `json:"name,omitempty" protobuf:"bytes,5,opt,name=name"`
+	Status          SyncStatusCode `json:"status,omitempty" protobuf:"bytes,6,opt,name=status"`
+	Health          *HealthStatus  `json:"health,omitempty" protobuf:"bytes,7,opt,name=health"`
+	Hook            bool           `json:"hook,omitempty" protobuf:"bytes,8,opt,name=hook"`
+	RequiresPruning bool           `json:"requiresPruning,omitempty" protobuf:"bytes,9,opt,name=requiresPruning"`
+	SyncWave        int64          `json:"syncWave,omitempty" protobuf:"bytes,10,opt,name=syncWave"`
+}
+
+// SyncStatusCode is a type which represents possible comparison results
+type SyncStatusCode string
+
+// Possible comparison results
+const (
+	// SyncStatusCodeUnknown indicates that the status of a sync could not be reliably determined
+	SyncStatusCodeUnknown SyncStatusCode = "Unknown"
+	// SyncStatusCodeOutOfSync indicates that desired and live states match
+	SyncStatusCodeSynced SyncStatusCode = "Synced"
+	// SyncStatusCodeOutOfSync indicates that there is a drift between desired and live states
+	SyncStatusCodeOutOfSync SyncStatusCode = "OutOfSync"
+)
+
+// HealthStatus contains information about the currently observed health state of an application or resource
+type HealthStatus struct {
+	// Status holds the status code of the application or resource
+	Status HealthStatusCode `json:"status,omitempty" protobuf:"bytes,1,opt,name=status"`
+	// Message is a human-readable informational message describing the health status
+	Message string `json:"message,omitempty" protobuf:"bytes,2,opt,name=message"`
+}
+
+// Represents resource health status
+type HealthStatusCode string
+
+const (
+	// Indicates that health assessment failed and actual health status is unknown
+	HealthStatusUnknown HealthStatusCode = "Unknown"
+	// Progressing health status means that resource is not healthy but still have a chance to reach healthy state
+	HealthStatusProgressing HealthStatusCode = "Progressing"
+	// Resource is 100% healthy
+	HealthStatusHealthy HealthStatusCode = "Healthy"
+	// Assigned to resources that are suspended or paused. The typical example is a
+	// [suspended](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#suspend) CronJob.
+	HealthStatusSuspended HealthStatusCode = "Suspended"
+	// Degrade status is used if resource status indicates failure or resource could not reach healthy state
+	// within some timeout.
+	HealthStatusDegraded HealthStatusCode = "Degraded"
+	// Indicates that resource is missing in the cluster.
+	HealthStatusMissing HealthStatusCode = "Missing"
+)
+
+// SyncStatus contains information about the currently observed live and desired states of an application
+type SyncStatus struct {
+	// Status is the sync state of the comparison
+	Status SyncStatusCode `json:"status" protobuf:"bytes,1,opt,name=status,casttype=SyncStatusCode"`
+	// ComparedTo contains information about what has been compared
+	ComparedTo FauxComparedTo `json:"comparedTo,omitempty" protobuf:"bytes,2,opt,name=comparedTo"`
+	// Revision contains information about the revision the comparison has been performed to
+	Revision string `json:"revision,omitempty" protobuf:"bytes,3,opt,name=revision"`
+	// Revisions contains information about the revisions of multiple sources the comparison has been performed to
+	Revisions []string `json:"revisions,omitempty" protobuf:"bytes,4,opt,name=revisions"`
+}
+
+// ApplicationSources contains list of required information about the sources of an application
+type ApplicationSources []ApplicationSource
+
+// ApplicationConditionType represents type of application condition. Type name has following convention:
+// prefix "Error" means error condition
+// prefix "Warning" means warning condition
+// prefix "Info" means informational condition
+type ApplicationConditionType = string
+
+const (
+	// ApplicationConditionDeletionError indicates that controller failed to delete application
+	ApplicationConditionDeletionError = "DeletionError"
+	// ApplicationConditionInvalidSpecError indicates that application source is invalid
+	ApplicationConditionInvalidSpecError = "InvalidSpecError"
+	// ApplicationConditionComparisonError indicates controller failed to compare application state
+	ApplicationConditionComparisonError = "ComparisonError"
+	// ApplicationConditionSyncError indicates controller failed to automatically sync the application
+	ApplicationConditionSyncError = "SyncError"
+	// ApplicationConditionUnknownError indicates an unknown controller error
+	ApplicationConditionUnknownError = "UnknownError"
+	// ApplicationConditionSharedResourceWarning indicates that controller detected resources which belongs to more than one application
+	ApplicationConditionSharedResourceWarning = "SharedResourceWarning"
+	// ApplicationConditionRepeatedResourceWarning indicates that application source has resource with same Group, Kind, Name, Namespace multiple times
+	ApplicationConditionRepeatedResourceWarning = "RepeatedResourceWarning"
+	// ApplicationConditionExcludedResourceWarning indicates that application has resource which is configured to be excluded
+	ApplicationConditionExcludedResourceWarning = "ExcludedResourceWarning"
+	// ApplicationConditionOrphanedResourceWarning indicates that application has orphaned resources
+	ApplicationConditionOrphanedResourceWarning = "OrphanedResourceWarning"
+)
+
+// ApplicationCondition contains details about an application condition, which is usally an error or warning
+type ApplicationCondition struct {
+	// Type is an application condition type
+	Type ApplicationConditionType `json:"type" protobuf:"bytes,1,opt,name=type"`
+	// Message contains human-readable message indicating details about condition
+	Message string `json:"message" protobuf:"bytes,2,opt,name=message"`
+	// LastTransitionTime is the time the condition was last observed
+	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,3,opt,name=lastTransitionTime"`
+}
+
+// OperationState contains information about state of a running operation
+type OperationState struct {
+	// Operation is the original requested operation
+	Operation Operation `json:"operation" protobuf:"bytes,1,opt,name=operation"`
+	// Phase is the current phase of the operation
+	Phase OperationPhase `json:"phase" protobuf:"bytes,2,opt,name=phase"`
+	// Message holds any pertinent messages when attempting to perform operation (typically errors).
+	Message string `json:"message,omitempty" protobuf:"bytes,3,opt,name=message"`
+	// SyncResult is the result of a Sync operation
+	SyncResult *SyncOperationResult `json:"syncResult,omitempty" protobuf:"bytes,4,opt,name=syncResult"`
+	// StartedAt contains time of operation start
+	StartedAt metav1.Time `json:"startedAt" protobuf:"bytes,6,opt,name=startedAt"`
+	// FinishedAt contains time of operation completion
+	FinishedAt *metav1.Time `json:"finishedAt,omitempty" protobuf:"bytes,7,opt,name=finishedAt"`
+	// RetryCount contains time of operation retries
+	RetryCount int64 `json:"retryCount,omitempty" protobuf:"bytes,8,opt,name=retryCount"`
+}
+
+type OperationPhase string
+
+const (
+	OperationRunning     OperationPhase = "Running"
+	OperationTerminating OperationPhase = "Terminating"
+	OperationFailed      OperationPhase = "Failed"
+	OperationError       OperationPhase = "Error"
+	OperationSucceeded   OperationPhase = "Succeeded"
+)
+
+// Operation contains information about a requested or running operation
+type Operation struct {
+	// Sync contains parameters for the operation
+	Sync *SyncOperation `json:"sync,omitempty" protobuf:"bytes,1,opt,name=sync"`
+	// InitiatedBy contains information about who initiated the operations
+	InitiatedBy OperationInitiator `json:"initiatedBy,omitempty" protobuf:"bytes,2,opt,name=initiatedBy"`
+	// Info is a list of informational items for this operation
+	Info []*Info `json:"info,omitempty" protobuf:"bytes,3,name=info"`
+	// Retry controls the strategy to apply if a sync fails
+	Retry RetryStrategy `json:"retry,omitempty" protobuf:"bytes,4,opt,name=retry"`
+}
+
+// OperationInitiator contains information about the initiator of an operation
+type OperationInitiator struct {
+	// Username contains the name of a user who started operation
+	Username string `json:"username,omitempty" protobuf:"bytes,1,opt,name=username"`
+	// Automated is set to true if operation was initiated automatically by the application controller.
+	Automated bool `json:"automated,omitempty" protobuf:"bytes,2,opt,name=automated"`
+}
+
+type Info struct {
+	Name  string `json:"name" protobuf:"bytes,1,name=name"`
+	Value string `json:"value" protobuf:"bytes,2,name=value"`
+}
+
+// SyncOperation contains details about a sync operation.
+type SyncOperation struct {
+	// Revision is the revision (Git) or chart version (Helm) which to sync the application to
+	// If omitted, will use the revision specified in app spec.
+	Revision string `json:"revision,omitempty" protobuf:"bytes,1,opt,name=revision"`
+	// Prune specifies to delete resources from the cluster that are no longer tracked in git
+	Prune bool `json:"prune,omitempty" protobuf:"bytes,2,opt,name=prune"`
+	// DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
+	DryRun bool `json:"dryRun,omitempty" protobuf:"bytes,3,opt,name=dryRun"`
+	// SyncStrategy describes how to perform the sync
+	SyncStrategy *SyncStrategy `json:"syncStrategy,omitempty" protobuf:"bytes,4,opt,name=syncStrategy"`
+	// Resources describes which resources shall be part of the sync
+	Resources []SyncOperationResource `json:"resources,omitempty" protobuf:"bytes,6,opt,name=resources"`
+	// Source overrides the source definition set in the application.
+	// This is typically set in a Rollback operation and is nil during a Sync operation
+	Source *ApplicationSource `json:"source,omitempty" protobuf:"bytes,7,opt,name=source"`
+	// Manifests is an optional field that overrides sync source with a local directory for development
+	Manifests []string `json:"manifests,omitempty" protobuf:"bytes,8,opt,name=manifests"`
+	// SyncOptions provide per-sync sync-options, e.g. Validate=false
+	SyncOptions SyncOptions `json:"syncOptions,omitempty" protobuf:"bytes,9,opt,name=syncOptions"`
+	// Sources overrides the source definition set in the application.
+	// This is typically set in a Rollback operation and is nil during a Sync operation
+	Sources ApplicationSources `json:"sources,omitempty" protobuf:"bytes,10,opt,name=sources"`
+	// Revisions is the list of revision (Git) or chart version (Helm) which to sync each source in sources field for the application to
+	// If omitted, will use the revision specified in app spec.
+	Revisions []string `json:"revisions,omitempty" protobuf:"bytes,11,opt,name=revisions"`
+}
+
+// SyncStrategy controls the manner in which a sync is performed
+type SyncStrategy struct {
+	// Apply will perform a `kubectl apply` to perform the sync.
+	Apply *SyncStrategyApply `json:"apply,omitempty" protobuf:"bytes,1,opt,name=apply"`
+	// Hook will submit any referenced resources to perform the sync. This is the default strategy
+	Hook *SyncStrategyHook `json:"hook,omitempty" protobuf:"bytes,2,opt,name=hook"`
+}
+
+// SyncStrategyApply uses `kubectl apply` to perform the apply
+type SyncStrategyApply struct {
+	// Force indicates whether or not to supply the --force flag to `kubectl apply`.
+	// The --force flag deletes and re-create the resource, when PATCH encounters conflict and has
+	// retried for 5 times.
+	Force bool `json:"force,omitempty" protobuf:"bytes,1,opt,name=force"`
+}
+
+// SyncStrategyHook will perform a sync using hooks annotations.
+// If no hook annotation is specified falls back to `kubectl apply`.
+type SyncStrategyHook struct {
+	// Embed SyncStrategyApply type to inherit any `apply` options
+	// +optional
+	SyncStrategyApply `json:",inline" protobuf:"bytes,1,opt,name=syncStrategyApply"`
+}
+
+// SyncOperationResource contains resources to sync.
+type SyncOperationResource struct {
+	Group     string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
+	Kind      string `json:"kind" protobuf:"bytes,2,opt,name=kind"`
+	Name      string `json:"name" protobuf:"bytes,3,opt,name=name"`
+	Namespace string `json:"namespace,omitempty" protobuf:"bytes,4,opt,name=namespace"`
+	// nolint:govet
+	Exclude bool `json:"-"`
+}
+
+// SyncOperationResult represent result of sync operation
+type SyncOperationResult struct {
+	// Resources contains a list of sync result items for each individual resource in a sync operation
+	Resources ResourceResults `json:"resources,omitempty" protobuf:"bytes,1,opt,name=resources"`
+	// Revision holds the revision this sync operation was performed to
+	Revision string `json:"revision" protobuf:"bytes,2,opt,name=revision"`
+	// Source records the application source information of the sync, used for comparing auto-sync
+	Source ApplicationSource `json:"source,omitempty" protobuf:"bytes,3,opt,name=source"`
+	// Source records the application source information of the sync, used for comparing auto-sync
+	Sources ApplicationSources `json:"sources,omitempty" protobuf:"bytes,4,opt,name=sources"`
+	// Revisions holds the revision this sync operation was performed for respective indexed source in sources field
+	Revisions []string `json:"revisions,omitempty" protobuf:"bytes,5,opt,name=revisions"`
+}
+
+// ResourceResults defines a list of resource results for a given operation
+type ResourceResults []*ResourceResult
+
+// ResourceResult holds the operation result details of a specific resource
+type ResourceResult struct {
+	// Group specifies the API group of the resource
+	Group string `json:"group" protobuf:"bytes,1,opt,name=group"`
+	// Version specifies the API version of the resource
+	Version string `json:"version" protobuf:"bytes,2,opt,name=version"`
+	// Kind specifies the API kind of the resource
+	Kind string `json:"kind" protobuf:"bytes,3,opt,name=kind"`
+	// Namespace specifies the target namespace of the resource
+	Namespace string `json:"namespace" protobuf:"bytes,4,opt,name=namespace"`
+	// Name specifies the name of the resource
+	Name string `json:"name" protobuf:"bytes,5,opt,name=name"`
+	// Status holds the final result of the sync. Will be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
+	Status ResultCode `json:"status,omitempty" protobuf:"bytes,6,opt,name=status"`
+	// Message contains an informational or error message for the last sync OR operation
+	Message string `json:"message,omitempty" protobuf:"bytes,7,opt,name=message"`
+	// HookType specifies the type of the hook. Empty for non-hook resources
+	HookType HookType `json:"hookType,omitempty" protobuf:"bytes,8,opt,name=hookType"`
+	// HookPhase contains the state of any operation associated with this resource OR hook
+	// This can also contain values for non-hook resources.
+	HookPhase OperationPhase `json:"hookPhase,omitempty" protobuf:"bytes,9,opt,name=hookPhase"`
+	// SyncPhase indicates the particular phase of the sync that this result was acquired in
+	SyncPhase SyncPhase `json:"syncPhase,omitempty" protobuf:"bytes,10,opt,name=syncPhase"`
+}
+
+type SyncPhase string
+
+const (
+	SyncPhasePreSync  = "PreSync"
+	SyncPhaseSync     = "Sync"
+	SyncPhasePostSync = "PostSync"
+	SyncPhaseSyncFail = "SyncFail"
+)
+
+type HookType string
+
+const (
+	HookTypePreSync  HookType = "PreSync"
+	HookTypeSync     HookType = "Sync"
+	HookTypePostSync HookType = "PostSync"
+	HookTypeSkip     HookType = "Skip"
+	HookTypeSyncFail HookType = "SyncFail"
+)
+
+type ResultCode string
+
+const (
+	ResultCodeSynced       ResultCode = "Synced"
+	ResultCodeSyncFailed   ResultCode = "SyncFailed"
+	ResultCodePruned       ResultCode = "Pruned"
+	ResultCodePruneSkipped ResultCode = "PruneSkipped"
+)

--- a/backend-shared/util/fauxargocd/faux_argo_cd.go
+++ b/backend-shared/util/fauxargocd/faux_argo_cd.go
@@ -131,7 +131,6 @@ type FauxApplicationStatus struct {
 }
 
 // ResourceStatus holds the current sync and health status of a resource
-// TODO: describe members of this type
 type ResourceStatus struct {
 	Group           string         `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	Version         string         `json:"version,omitempty" protobuf:"bytes,2,opt,name=version"`

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -1366,6 +1366,10 @@ func extractResourceStatus(resources []fauxargocd.ResourceStatus) []managedgitop
 }
 
 func extractOperationState(fauxOpState *fauxargocd.OperationState) (*managedgitopsv1alpha1.OperationState, error) {
+	if fauxOpState == nil {
+		return nil, nil
+	}
+
 	opStateBytes, err := json.Marshal(fauxOpState)
 	if err != nil {
 		return nil, err

--- a/backend/eventloop/application_event_loop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_test.go
@@ -1045,7 +1045,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 		)
 		It("should return an empty resourceStatus if the input slice is empty", func() {
 			resourcesStatus := extractResourceStatus([]fauxargocd.ResourceStatus{})
-			Expect(resourcesStatus).To(HaveLen(0))
+			Expect(resourcesStatus).To(BeEmpty())
 		})
 
 		It("should convert the input faux ResourceStatus to GitOpsDeployment ResourceStatus", func() {
@@ -1105,7 +1105,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 			}
 
 			opState, err := extractOperationState(&inputState)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(*opState).To(Equal(expectedState))
 		})
 	})

--- a/backend/eventloop/db_reconciler_test.go
+++ b/backend/eventloop/db_reconciler_test.go
@@ -79,9 +79,7 @@ var _ = Describe("DB Clean-up Function Tests", func() {
 			// Create ApplicationState entry
 			applicationState = db.ApplicationState{
 				Applicationstate_application_id: application.Application_id,
-				Health:                          "Healthy",
-				Sync_Status:                     "Synced",
-				ReconciledState:                 "Healthy",
+				ArgoCD_Application_Status:       []byte("sample-status"),
 			}
 			err = dbq.CreateApplicationState(ctx, &applicationState)
 			Expect(err).ToNot(HaveOccurred())
@@ -199,6 +197,7 @@ var _ = Describe("DB Clean-up Function Tests", func() {
 			By("Verify that entries for the GitOpsDeployment which is not available in cluster, are deleted from DB.")
 
 			err = dbq.GetApplicationStateById(ctx, &applicationStateOne)
+			Expect(err).To(HaveOccurred())
 			Expect(db.IsResultNotFoundError(err)).To(BeTrue())
 
 			err = dbq.GetSyncOperationById(ctx, &syncOperationOne)
@@ -1218,9 +1217,7 @@ var _ = Describe("DB Clean-up Function Tests", func() {
 
 			applicationState := db.ApplicationState{
 				Applicationstate_application_id: applicationNew.Application_id,
-				Health:                          "Healthy",
-				Sync_Status:                     "Synced",
-				ReconciledState:                 "Healthy",
+				ArgoCD_Application_Status:       []byte("sample-status"),
 			}
 			err = dbq.CreateApplicationState(ctx, &applicationState)
 			Expect(err).ToNot(HaveOccurred())

--- a/cluster-agent/controllers/argoproj.io/application_controller_test.go
+++ b/cluster-agent/controllers/argoproj.io/application_controller_test.go
@@ -2,7 +2,6 @@ package argoprojio
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -107,6 +106,19 @@ var _ = Describe("Application Controller", func() {
 								Namespace: "test-namespace",
 								Name:      "managed-env-123",
 							},
+							Sources: appv1.ApplicationSources{},
+						},
+					},
+					Conditions: []appv1.ApplicationCondition{
+						{
+							Type:               appv1.ApplicationConditionSyncError,
+							Message:            "Failed to sync",
+							LastTransitionTime: &metav1.Time{Time: time.Now()},
+						},
+						{
+							Type:               appv1.ApplicationConditionOrphanedResourceWarning,
+							Message:            "orphaned resource warning",
+							LastTransitionTime: &metav1.Time{Time: time.Now()},
 						},
 					},
 				},
@@ -132,6 +144,21 @@ var _ = Describe("Application Controller", func() {
 			// Prevent race conditions between tests, by shutting down the cache after each test
 			reconciler.Cache.DebugOnly_Shutdown(context.Background())
 		})
+
+		extractAppStatus := func(status []byte) *appv1.ApplicationStatus {
+			GinkgoT().Helper()
+
+			argocdStatusBytes, err := sharedutil.DecompressObject(status)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(argocdStatusBytes).ToNot(BeNil())
+
+			appStatus := &appv1.ApplicationStatus{}
+			err = yaml.Unmarshal(argocdStatusBytes, appStatus)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(appStatus).ToNot(BeNil())
+
+			return appStatus
+		}
 
 		It("Create New Application CR in namespace and database and verify that ApplicationState is created", func() {
 			By("Close database connection")
@@ -172,14 +199,29 @@ var _ = Describe("Application Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verify that Health and Status of ArgoCD Application is equal to the Health and Status of Application in database")
-			Expect(applicationState.Health).To(Equal(string(guestbookApp.Status.Health.Status)))
-			Expect(applicationState.Sync_Status).To(Equal(string(guestbookApp.Status.Sync.Status)))
+			appStatus := extractAppStatus(applicationState.ArgoCD_Application_Status)
+			Expect(appStatus.Health.Status).To(Equal(guestbookApp.Status.Health.Status))
+			Expect(appStatus.Sync.Status).To(Equal(guestbookApp.Status.Sync.Status))
 
 			By("verify that the OperationState is not populated since the Application's OperationState doesn't exist")
-			Expect(applicationState.OperationState).To(BeNil())
+			Expect(appStatus.OperationState).To(BeNil())
+
+			By("verify if the conditions field is set")
+			Expect(appStatus.Conditions).To(HaveLen(len(guestbookApp.Status.Conditions)))
+			for i, cond := range appStatus.Conditions {
+				other := guestbookApp.Status.Conditions[i]
+				Expect(cond.Type).To(Equal(other.Type))
+				Expect(cond.Message).To(Equal(other.Message))
+			}
+
+			By("verify if the comparedTo field is set")
+			// We have to replace the destination name because the controller will update it with the
+			// ManagedEnvironment ID before saving it in ApplicationState DB
+			appStatus.Sync.ComparedTo.Destination.Name = guestbookApp.Status.Sync.ComparedTo.Destination.Name
+			Expect(appStatus.Sync.ComparedTo).To(Equal(guestbookApp.Status.Sync.ComparedTo))
 		})
 
-		It("Verify if the OperationState DB field is populated with Application CR's .status.OperationState", func() {
+		It("Verify if the ApplicationState DB is updated if the Application CR's .status is updated", func() {
 			By("Close database connection")
 			defer dbQueries.CloseDatabase()
 			defer testTeardown()
@@ -191,6 +233,15 @@ var _ = Describe("Application Controller", func() {
 				Message:    "sample message",
 				RetryCount: 10,
 			}
+
+			By("update the conditions")
+			updatedCondition := []appv1.ApplicationCondition{
+				{
+					Type:    appv1.ApplicationConditionDeletionError,
+					Message: "new deletion error",
+				},
+			}
+			guestbookApp.Status.Conditions = updatedCondition
 
 			By("Add databaseID label to applicationID")
 			databaseID := guestbookApp.Labels[dbID]
@@ -224,26 +275,24 @@ var _ = Describe("Application Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verify that Health and Status of ArgoCD Application is equal to the Health and Status of Application in database")
-			Expect(applicationState.Health).To(Equal(string(guestbookApp.Status.Health.Status)))
-			Expect(applicationState.Sync_Status).To(Equal(string(guestbookApp.Status.Sync.Status)))
+			appStatus := extractAppStatus(applicationState.ArgoCD_Application_Status)
+			Expect(appStatus.Health.Status).To(Equal(guestbookApp.Status.Health.Status))
+			Expect(appStatus.Sync.Status).To(Equal(guestbookApp.Status.Sync.Status))
 
 			By("verify that the OperationState is populated in the ApplicationState")
-			Expect(applicationState.OperationState).ToNot(BeNil())
+			Expect(appStatus.OperationState).ToNot(BeNil())
 
 			compareOpState := func(appState *db.ApplicationState, app *appv1.Application) {
-				opStateBytes, err := sharedutil.DecompressObject(applicationState.OperationState)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(opStateBytes).ToNot(BeNil())
+				appStatus = extractAppStatus(applicationState.ArgoCD_Application_Status)
 
-				opState := &managedgitopsv1alpha1.OperationState{}
-				err = yaml.Unmarshal(opStateBytes, opState)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(opState.Message).To(Equal(guestbookApp.Status.OperationState.Message))
-				Expect(opState.RetryCount).To(Equal(guestbookApp.Status.OperationState.RetryCount))
+				Expect(appStatus.OperationState.Message).To(Equal(guestbookApp.Status.OperationState.Message))
+				Expect(appStatus.OperationState.RetryCount).To(Equal(guestbookApp.Status.OperationState.RetryCount))
 			}
 
 			compareOpState(applicationState, guestbookApp)
+
+			By("verify if the condition is updated")
+			Expect(appStatus.Conditions).To(Equal(guestbookApp.Status.Conditions))
 
 			By("remove .status.OperationState and verify if the ApplicationState is updated")
 			guestbookApp.Status.OperationState = nil
@@ -257,7 +306,8 @@ var _ = Describe("Application Controller", func() {
 			By("verify that the OperationState is updated in the ApplicationState")
 			err = reconciler.DB.GetApplicationStateById(ctx, applicationState)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(applicationState.OperationState).To(BeNil())
+			appStatus = extractAppStatus(applicationState.ArgoCD_Application_Status)
+			Expect(appStatus.OperationState).To(BeNil())
 
 			By("add .status.OperationState and verify if the ApplicationState is updated")
 			guestbookApp.Status.OperationState = &appv1.OperationState{
@@ -274,7 +324,8 @@ var _ = Describe("Application Controller", func() {
 			By("verify that the OperationState is updated in the ApplicationState")
 			err = reconciler.DB.GetApplicationStateById(ctx, applicationState)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(applicationState.OperationState).ToNot(BeNil())
+			appStatus = extractAppStatus(applicationState.ArgoCD_Application_Status)
+			Expect(appStatus.OperationState).ToNot(BeNil())
 
 			compareOpState(applicationState, guestbookApp)
 		})
@@ -296,15 +347,9 @@ var _ = Describe("Application Controller", func() {
 				Managed_environment_id:  managedEnvironment.Managedenvironment_id,
 			}
 
-			reconciledStateString, _, err := dummyApplicationComparedToField()
-			Expect(err).ToNot(HaveOccurred())
-
 			applicationState := &db.ApplicationState{
 				Applicationstate_application_id: applicationDB.Application_id,
-				Health:                          "Progressing",
-				Sync_Status:                     "OutOfSync",
-				ReconciledState:                 reconciledStateString,
-				Conditions:                      []byte("sample-condition"),
+				ArgoCD_Application_Status:       []byte("test-status"),
 			}
 
 			By("Create Application in Database")
@@ -329,9 +374,9 @@ var _ = Describe("Application Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verify that Health and Status of ArgoCD Application is equal to the Health and Status of Application in database")
-			Expect(applicationState.Health).To(Equal(string(guestbookApp.Status.Health.Status)))
-			Expect(applicationState.Sync_Status).To(Equal(string(guestbookApp.Status.Sync.Status)))
-
+			appStatus := extractAppStatus(applicationState.ArgoCD_Application_Status)
+			Expect(appStatus.Health.Status).To(Equal(guestbookApp.Status.Health.Status))
+			Expect(appStatus.Sync.Status).To(Equal(guestbookApp.Status.Sync.Status))
 		})
 
 		It("Calls Reconcile on an Argo CD Application resource that doesn't exist", func() {
@@ -540,397 +585,6 @@ var _ = Describe("Application Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).ToNot(BeNil())
 
-		})
-
-		It("Test to check whether reconciled state is stored in database", func() {
-			By("Close database connection")
-			defer dbQueries.CloseDatabase()
-			defer testTeardown()
-			Expect(err).ToNot(HaveOccurred())
-
-			ctx = context.Background()
-
-			By("Add databaseID label to applicationID")
-			databaseID := guestbookApp.Labels[dbID]
-			applicationDB := &db.Application{
-				Application_id:          databaseID,
-				Name:                    name,
-				Spec_field:              "{}",
-				Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
-				Managed_environment_id:  managedEnvironment.Managedenvironment_id,
-			}
-
-			applicationStateDB := &db.ApplicationState{
-				Applicationstate_application_id: applicationDB.Application_id,
-			}
-
-			By("Create Application in Database")
-			err = reconciler.DB.CreateApplication(ctx, applicationDB)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Verify ApplicationState is not present in database")
-			err = reconciler.DB.GetApplicationStateById(ctx, applicationStateDB)
-			Expect(err).To(HaveOccurred())
-			Expect(db.IsResultNotFoundError(err)).To(BeTrue())
-
-			By("Create a new ArgoCD Application")
-			err = reconciler.Create(ctx, guestbookApp)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Call reconcile function")
-			result, err := reconciler.Reconcile(ctx, newRequest(namespace, name))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).ToNot(BeNil())
-
-			err = reconciler.DB.GetApplicationStateById(ctx, applicationStateDB)
-			Expect(applicationStateDB.ReconciledState).ToNot(BeNil())
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Verify ReconciledState is stored in db")
-			comparedTo := fauxargocd.FauxComparedTo{}
-
-			err = json.Unmarshal([]byte(applicationStateDB.ReconciledState), &comparedTo)
-			Expect(err).ToNot(HaveOccurred())
-
-			reconciledStateObj, err := convertReconciledStateStringToObject(applicationStateDB.ReconciledState)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Checking for new values in database object
-			Expect(reconciledStateObj.Source.Path).To(Equal(guestbookApp.Status.Sync.ComparedTo.Source.Path))
-			Expect(reconciledStateObj.Source.RepoURL).To(Equal(guestbookApp.Status.Sync.ComparedTo.Source.RepoURL))
-			Expect(reconciledStateObj.Source.TargetRevision).To(Equal(guestbookApp.Status.Sync.ComparedTo.Source.TargetRevision))
-			Expect(reconciledStateObj.Destination.Namespace).To(Equal(guestbookApp.Status.Sync.ComparedTo.Destination.Namespace))
-
-		})
-
-		It("Test to check whether existing value in reconciled state updated to new value when comparedTo field of ArgoCD Application changes", func() {
-			By("Close database connection")
-			defer dbQueries.CloseDatabase()
-			defer testTeardown()
-
-			ctx = context.Background()
-
-			By("Add databaseID label to applicationID")
-			databaseID := guestbookApp.Labels[dbID]
-			applicationDB := &db.Application{
-				Application_id:          databaseID,
-				Name:                    name,
-				Spec_field:              "{}",
-				Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
-				Managed_environment_id:  managedEnvironment.Managedenvironment_id,
-			}
-
-			reconciledStateString, reconciledObj, err := dummyApplicationComparedToField()
-			Expect(reconciledObj.Destination.Namespace).ToNot(Equal(guestbookApp.Status.Sync.ComparedTo.Destination.Namespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			// applicationState which already exists in database
-			applicationState := &db.ApplicationState{
-				Applicationstate_application_id: applicationDB.Application_id,
-				Health:                          "Healthy",
-				Sync_Status:                     "Synced",
-				ReconciledState:                 reconciledStateString,
-			}
-
-			By("Create a new ArgoCD Application")
-			err = reconciler.Create(ctx, guestbookApp)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Create Application in Database")
-			err = reconciler.DB.CreateApplication(ctx, applicationDB)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Create ApplicationState in Database")
-			err = reconciler.DB.CreateApplicationState(ctx, applicationState)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Call reconcile function")
-			result, err := reconciler.Reconcile(ctx, newRequest(namespace, name))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).ToNot(BeNil())
-
-			applicationStateget := &db.ApplicationState{
-				Applicationstate_application_id: applicationDB.Application_id,
-			}
-
-			By("Verify ReconcidedState in ApplicationState is updated in database")
-			err = reconciler.DB.GetApplicationStateById(ctx, applicationStateget)
-			Expect(err).ToNot(HaveOccurred())
-
-			reconciledStateObj, err := convertReconciledStateStringToObject(applicationStateget.ReconciledState)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Checking for new values in database object
-			Expect(reconciledStateObj.Source.Path).To(Equal(guestbookApp.Status.Sync.ComparedTo.Source.Path))
-			Expect(reconciledStateObj.Source.RepoURL).To(Equal(guestbookApp.Status.Sync.ComparedTo.Source.RepoURL))
-			Expect(reconciledStateObj.Source.TargetRevision).To(Equal(guestbookApp.Status.Sync.ComparedTo.Source.TargetRevision))
-			Expect(reconciledStateObj.Destination.Namespace).To(Equal(guestbookApp.Status.Sync.ComparedTo.Destination.Namespace))
-		})
-
-		It("Test to check whether conditions field is stored in database", func() {
-			By("Close database connection")
-			defer dbQueries.CloseDatabase()
-			defer testTeardown()
-			Expect(err).ToNot(HaveOccurred())
-
-			ctx = context.Background()
-
-			appConditions := []appv1.ApplicationCondition{
-				{
-					Type:               appv1.ApplicationConditionSyncError,
-					Message:            "Failed to sync",
-					LastTransitionTime: &metav1.Time{Time: time.Now()},
-				},
-				{
-					Type:               appv1.ApplicationConditionOrphanedResourceWarning,
-					Message:            "orphaned resource warning",
-					LastTransitionTime: &metav1.Time{Time: time.Now()},
-				},
-			}
-			guestbookApp.Status.Conditions = append(guestbookApp.Status.Conditions, appConditions...)
-
-			By("Add databaseID label to applicationID")
-			databaseID := guestbookApp.Labels[dbID]
-			applicationDB := &db.Application{
-				Application_id:          databaseID,
-				Name:                    name,
-				Spec_field:              "{}",
-				Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
-				Managed_environment_id:  managedEnvironment.Managedenvironment_id,
-			}
-
-			applicationStateDB := &db.ApplicationState{
-				Applicationstate_application_id: applicationDB.Application_id,
-			}
-
-			By("Create Application in Database")
-			err = reconciler.DB.CreateApplication(ctx, applicationDB)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("GetApplicationStateById to verify SyncError field is empty in database")
-			err = reconciler.DB.GetApplicationStateById(ctx, applicationStateDB)
-			Expect(err).To(HaveOccurred())
-			Expect(db.IsResultNotFoundError(err)).To(BeTrue())
-			Expect(applicationStateDB.Conditions).To(BeNil())
-
-			By("Create a new ArgoCD Application")
-			err = reconciler.Create(ctx, guestbookApp)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Call reconcile function")
-			result, err := reconciler.Reconcile(ctx, newRequest(namespace, name))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).ToNot(BeNil())
-
-			err = reconciler.DB.GetApplicationStateById(ctx, applicationStateDB)
-			Expect(applicationStateDB.ReconciledState).ToNot(BeNil())
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Verifying that the ApplicationState DB row has been updated to match the Application conditions")
-			resultConditions := []appv1.ApplicationCondition{}
-			err = yaml.Unmarshal(applicationStateDB.Conditions, &resultConditions)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resultConditions).To(HaveLen(len(guestbookApp.Status.Conditions)))
-		})
-
-		It("Test to verify if the conditions is empty if there are no Application conditions", func() {
-			By("Close database connection")
-			defer dbQueries.CloseDatabase()
-			defer testTeardown()
-			Expect(err).ToNot(HaveOccurred())
-
-			ctx = context.Background()
-
-			guestbookApp := &appv1.Application{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: namespace,
-					Labels: map[string]string{
-						dbID: "test-my-application",
-					},
-				},
-				Spec: appv1.ApplicationSpec{
-					Source: &appv1.ApplicationSource{
-						Path:           "guestbook",
-						TargetRevision: "HEAD",
-						RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
-					},
-					Destination: appv1.ApplicationDestination{
-						Namespace: "guestbook",
-						Server:    "https://kubernetes.default.svc",
-					},
-					Project: "default",
-				},
-				Status: appv1.ApplicationStatus{
-					Health: appv1.HealthStatus{
-						Status: "Healthy",
-					},
-					Sync: appv1.SyncStatus{
-						Status: "Synced",
-						ComparedTo: appv1.ComparedTo{
-							Source: appv1.ApplicationSource{
-								Path:           "test-path",
-								RepoURL:        "test-url",
-								TargetRevision: "test-branch",
-							},
-							Destination: appv1.ApplicationDestination{
-								Namespace: "test-namespace",
-								Name:      "managed-env-123",
-							},
-						},
-					},
-				},
-			}
-
-			By("Add databaseID label to applicationID")
-			databaseID := guestbookApp.Labels[dbID]
-			applicationDB := &db.Application{
-				Application_id:          databaseID,
-				Name:                    name,
-				Spec_field:              "{}",
-				Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
-				Managed_environment_id:  managedEnvironment.Managedenvironment_id,
-			}
-
-			applicationStateDB := &db.ApplicationState{
-				Applicationstate_application_id: applicationDB.Application_id,
-			}
-
-			By("Create Application in Database")
-			err = reconciler.DB.CreateApplication(ctx, applicationDB)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("GetApplicationStateById to verify SyncError field is empty in database")
-			err = reconciler.DB.GetApplicationStateById(ctx, applicationStateDB)
-			Expect(err).To(HaveOccurred())
-			Expect(db.IsResultNotFoundError(err)).To(BeTrue())
-			Expect(applicationStateDB.Conditions).To(BeEmpty())
-
-			By("Create a new ArgoCD Application")
-			err = reconciler.Create(ctx, guestbookApp)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Call reconcile function")
-			result, err := reconciler.Reconcile(ctx, newRequest(namespace, name))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).ToNot(BeNil())
-
-			err = reconciler.DB.GetApplicationStateById(ctx, applicationStateDB)
-			Expect(applicationStateDB.ReconciledState).ToNot(BeNil())
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Verifying that the ApplicationState DB row has been updated to match the Application conditions")
-			Expect(applicationStateDB.Conditions).To(BeEmpty())
-		})
-
-		It("Test to check whether existing condition value is updated to new value when conditions.Message of ArgoCD Application changes", func() {
-			By("Close database connection")
-			defer dbQueries.CloseDatabase()
-			defer testTeardown()
-
-			ctx = context.Background()
-
-			By("Add databaseID label to applicationID")
-			databaseID := guestbookApp.Labels[dbID]
-			applicationDB := &db.Application{
-				Application_id:          databaseID,
-				Name:                    name,
-				Spec_field:              "{}",
-				Engine_instance_inst_id: gitopsEngineInstance.Gitopsengineinstance_id,
-				Managed_environment_id:  managedEnvironment.Managedenvironment_id,
-			}
-
-			reconciledStateString, reconciledObj, err := dummyApplicationComparedToField()
-			Expect(reconciledObj.Destination.Namespace).ToNot(Equal(guestbookApp.Status.Sync.ComparedTo.Destination.Namespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			appConditions := []appv1.ApplicationCondition{
-				{
-					Type:               appv1.ApplicationConditionSyncError,
-					Message:            "Failed to sync",
-					LastTransitionTime: &metav1.Time{Time: time.Now()},
-				},
-			}
-
-			conditionBytes, err := yaml.Marshal(&appConditions)
-			Expect(err).ToNot(HaveOccurred())
-
-			// applicationState which already exists in database
-			applicationState := &db.ApplicationState{
-				Applicationstate_application_id: applicationDB.Application_id,
-				Health:                          "Healthy",
-				Sync_Status:                     "Synced",
-				ReconciledState:                 reconciledStateString,
-				Conditions:                      conditionBytes,
-			}
-
-			By("Create a new ArgoCD Application")
-			err = reconciler.Create(ctx, guestbookApp)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Create Application in Database")
-			err = reconciler.DB.CreateApplication(ctx, applicationDB)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Create ApplicationState in Database")
-			err = reconciler.DB.CreateApplicationState(ctx, applicationState)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Call reconcile function")
-			result, err := reconciler.Reconcile(ctx, newRequest(namespace, name))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).ToNot(BeNil())
-
-			applicationStateget := &db.ApplicationState{
-				Applicationstate_application_id: applicationDB.Application_id,
-			}
-
-			err = reconciler.DB.GetApplicationStateById(ctx, applicationStateget)
-			Expect(err).ToNot(HaveOccurred())
-
-			outputConditions := []appv1.ApplicationCondition{}
-			err = yaml.Unmarshal(applicationStateget.Conditions, &outputConditions)
-			Expect(err).ToNot(HaveOccurred())
-
-			compareConditions := func(cond1, cond2 []appv1.ApplicationCondition) {
-				Expect(cond1).To(HaveLen(len(cond2)))
-
-				for i, cond := range cond1 {
-					other := cond2[i]
-					Expect(cond.Type).To(Equal(other.Type))
-					Expect(cond.Message).To(Equal(other.Message))
-				}
-			}
-
-			compareConditions(appConditions, outputConditions)
-
-			By("update ApplicationState conditions")
-			newConditions := []appv1.ApplicationCondition{
-				{
-					Type:               appv1.ApplicationConditionComparisonError,
-					Message:            "Failed to compare",
-					LastTransitionTime: &metav1.Time{Time: time.Now()},
-				},
-			}
-
-			conditionBytes, err = yaml.Marshal(&newConditions)
-			Expect(err).ToNot(HaveOccurred())
-
-			applicationState.Conditions = conditionBytes
-			err = reconciler.DB.UpdateApplicationState(ctx, applicationState)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Call reconcile function")
-			result, err = reconciler.Reconcile(ctx, newRequest(namespace, name))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).ToNot(BeNil())
-
-			By("Verifying that the ApplicationState DB row has been updated to match the Application Conditions")
-
-			err = yaml.Unmarshal(applicationState.Conditions, &outputConditions)
-			Expect(err).ToNot(HaveOccurred())
-
-			compareConditions(outputConditions, newConditions)
 		})
 	})
 
@@ -1372,37 +1026,4 @@ func createDummyApplicationData() (fauxargocd.FauxApplication, string, appv1.App
 	}
 
 	return dummyApplicationSpec, string(dummyApplicationSpecBytes), dummyArgoCdApplication, nil
-}
-
-func dummyApplicationComparedToField() (string, fauxargocd.FauxComparedTo, error) {
-
-	fauxcomparedTo := fauxargocd.FauxComparedTo{
-		Source: fauxargocd.ApplicationSource{
-			RepoURL:        "test-url",
-			Path:           "test-path",
-			TargetRevision: "test-branch",
-		},
-		Destination: fauxargocd.ApplicationDestination{
-			Namespace: "test-namespace-1",
-			Name:      "managed-env-123",
-		},
-	}
-
-	fauxcomparedToBytes, err := yaml.Marshal(fauxcomparedTo)
-	if err != nil {
-		return "", fauxcomparedTo, err
-	}
-
-	return string(fauxcomparedToBytes), fauxcomparedTo, nil
-}
-
-// Unmarshal the reconciledState stored in db
-func convertReconciledStateStringToObject(reconciledState string) (fauxargocd.FauxComparedTo, error) {
-	comparedTo := fauxargocd.FauxComparedTo{}
-
-	err := json.Unmarshal([]byte(reconciledState), &comparedTo)
-	if err != nil {
-		return comparedTo, err
-	}
-	return comparedTo, nil
 }

--- a/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache_test.go
+++ b/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache_test.go
@@ -43,9 +43,7 @@ var _ = Describe("application_info_cache Test", func() {
 
 			testAppState := db.ApplicationState{
 				Applicationstate_application_id: application.Application_id,
-				Health:                          "Healthy",
-				Sync_Status:                     "Synced",
-				ReconciledState:                 "32",
+				ArgoCD_Application_Status:       []byte("sample-status"),
 			}
 			errCreate := aic.CreateApplicationState(ctx, testAppState)
 			Expect(errCreate).ToNot(HaveOccurred())
@@ -61,7 +59,7 @@ var _ = Describe("application_info_cache Test", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fromCache).To(BeTrue())
 
-			testAppState.Health = "Unhealthy"
+			testAppState.ArgoCD_Application_Status = []byte("Unhealthy")
 			errUpdate := aic.UpdateApplicationState(ctx, testAppState)
 			Expect(errUpdate).ToNot(HaveOccurred())
 
@@ -124,9 +122,7 @@ var _ = Describe("application_info_cache Test", func() {
 			// create an applicationstate then try to get it
 			testAppState := db.ApplicationState{
 				Applicationstate_application_id: testId,
-				Health:                          "Healthy",
-				Sync_Status:                     "Synced",
-				ReconciledState:                 "32",
+				ArgoCD_Application_Status:       []byte("test-status"),
 			}
 			err = dbq.CreateApplicationState(ctx, &testAppState)
 			Expect(err).ToNot(HaveOccurred())

--- a/db-schema.sql
+++ b/db-schema.sql
@@ -283,42 +283,8 @@ CREATE TABLE ApplicationState (
 	applicationstate_application_id  VARCHAR ( 48 ) PRIMARY KEY,
 	CONSTRAINT fk_app_id FOREIGN KEY (applicationstate_application_id) REFERENCES Application(application_id) ON DELETE NO ACTION ON UPDATE NO ACTION,
 
-	-- health field comes directly from Argo CD Application CR's .status.health field
-	-- Possible values:
-	-- * Healthy
-	-- * Progressing
-	-- * Degraded
-	-- * Suspended
-	-- * Missing
-	-- * Unknown (this is returned by Argo CD, but is also used when Argo CD's health field is "")
-	health VARCHAR (30) NOT NULL,
-
-	-- message field comes directly from Argo CD Application CR's .status.healthStatus.Message
-	message VARCHAR (1024),
-
-	-- revision field comes directly from Argo CD Application CR's .status.SyncStatus.Revision field
-	revision VARCHAR (1024),
-
-	-- sync_status field comes directly from Argo CD Application CR's .status.SyncStatus field
-	-- Possible values:
-	-- * Synced
-	-- * OutOfSync
-	-- * Unknown (this is used when Argo CD's status field is "")
-	sync_status VARCHAR (30) NOT NULL,
-
-	-- resources field comes directly from Argo CD Application CR's .Status.Resources field
-	resources bytea,
-
-	-- reconciled_state is a JSON string, which contains the contents of the Argo CD Application's .status.sync.comparedTo, but
-	-- with the 'destination' field adjusted to refer to the database's ManagedEnvironment primary key, rather than to the name 
-	-- of the Argo CD cluster secret.
-	reconciled_state VARCHAR (4096),
-
-	-- operation_state comes directly from Argo CD Application CR's .status.operationState field 
-	operation_state bytea,
-
-	-- conditions field comes directly from Argo CD Application CR's .status.conditions field
-	conditions bytea
+	-- argocd_application_status field contains the entire status of the Argo CD Application
+	argocd_application_status bytea 
 );
 
 -- Represents the relationship from GitOpsDeployment CR in the API namespace, to an Application table row.

--- a/utilities/db-migration/migration_test/add_test_values/add_db_values.go
+++ b/utilities/db-migration/migration_test/add_test_values/add_db_values.go
@@ -65,11 +65,7 @@ var (
 
 	AddTest_PreApplicationState = db.ApplicationState{
 		Applicationstate_application_id: AddTest_PreApplicationDB.Application_id,
-		Health:                          "Healthy",
-		Sync_Status:                     "Synced",
-		ReconciledState:                 "test-reconcile",
-		OperationState:                  []byte("operation_state"),
-		Conditions:                      []byte("conditions"),
+		ArgoCD_Application_Status:       []byte("sample-status"),
 	}
 
 	AddTest_PreDTAM = db.DeploymentToApplicationMapping{

--- a/utilities/db-migration/migration_test/verify_test_values/verify_db_values_test.go
+++ b/utilities/db-migration/migration_test/verify_test_values/verify_db_values_test.go
@@ -110,7 +110,6 @@ var _ = Describe("Test to verify that the data added to database is still presen
 			err = dbq.GetApplicationStateById(ctx, &applicationState)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(addtestvalues.AddTest_PreApplicationState).To(Equal(applicationState))
-			Expect(addtestvalues.AddTest_PreApplicationState.Conditions).To(Equal(applicationState.Conditions))
 
 			By("Get a deployment to application mapping to the application")
 			dtam := db.DeploymentToApplicationMapping{

--- a/utilities/db-migration/migrations/000020_v20.down.sql
+++ b/utilities/db-migration/migrations/000020_v20.down.sql
@@ -1,0 +1,10 @@
+ALTER TABLE ApplicationState DROP COLUMN argocd_application_status;
+
+ALTER TABLE ApplicationState ADD COLUMN health VARCHAR (30) NOT NULL;
+ALTER TABLE ApplicationState ADD COLUMN message VARCHAR (1024);
+ALTER TABLE ApplicationState ADD COLUMN revision VARCHAR (1024);
+ALTER TABLE ApplicationState ADD COLUMN sync_status VARCHAR (30) NOT NULL;
+ALTER TABLE ApplicationState ADD COLUMN resources bytea;
+ALTER TABLE ApplicationState ADD COLUMN reconciled_state VARCHAR ( 4096 );
+ALTER TABLE ApplicationState ADD COLUMN operation_state bytea;
+ALTER TABLE ApplicationState ADD COLUMN conditions bytea;

--- a/utilities/db-migration/migrations/000020_v20.down.sql
+++ b/utilities/db-migration/migrations/000020_v20.down.sql
@@ -1,9 +1,9 @@
 ALTER TABLE ApplicationState DROP COLUMN argocd_application_status;
 
-ALTER TABLE ApplicationState ADD COLUMN health VARCHAR (30) NOT NULL;
+ALTER TABLE ApplicationState ADD COLUMN health VARCHAR (30) NOT NULL DEFAULT 'Unknown';
 ALTER TABLE ApplicationState ADD COLUMN message VARCHAR (1024);
 ALTER TABLE ApplicationState ADD COLUMN revision VARCHAR (1024);
-ALTER TABLE ApplicationState ADD COLUMN sync_status VARCHAR (30) NOT NULL;
+ALTER TABLE ApplicationState ADD COLUMN sync_status VARCHAR (30) NOT NULL DEFAULT 'Unknown';
 ALTER TABLE ApplicationState ADD COLUMN resources bytea;
 ALTER TABLE ApplicationState ADD COLUMN reconciled_state VARCHAR ( 4096 );
 ALTER TABLE ApplicationState ADD COLUMN operation_state bytea;

--- a/utilities/db-migration/migrations/000020_v20.up.sql
+++ b/utilities/db-migration/migrations/000020_v20.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ApplicationState DROP COLUMN health, DROP COLUMN sync_status, DROP COLUMN message, DROP COLUMN revision,DROP COLUMN resources,DROP COLUMN operation_state,DROP COLUMN reconciled_state, DROP COLUMN conditions;
+
+ALTER TABLE ApplicationState ADD COLUMN argocd_application_status bytea;


### PR DESCRIPTION
#### Description:
- Introduce a single status field in the ApplicationState DB
- Remove the individual status fields from the ApplicationState DB
- Update the backend and cluster agent to process the single status field

#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/GITOPSRVCE-738