### PR TITLE
GITOPSRVCE-56: Enable AppProject isolation feature flag via environment variable

### DIFF
--- a/backend/config/manager/manager.yaml
+++ b/backend/config/manager/manager.yaml
@@ -45,6 +45,8 @@ spec:
             secretKeyRef:
               key: postgresql-password
               name: gitops-postgresql-staging
+        - name: ENABLE_APPPROJECT_ISOLATION
+          value: "true"
         image: ${COMMON_IMAGE}
         securityContext:
           allowPrivilegeEscalation: false

--- a/cluster-agent/config/manager/manager.yaml
+++ b/cluster-agent/config/manager/manager.yaml
@@ -45,6 +45,8 @@ spec:
             secretKeyRef:
               key: postgresql-password
               name: gitops-postgresql-staging
+        - name: ENABLE_APPPROJECT_ISOLATION
+          value: "true"
         image: ${COMMON_IMAGE}
         livenessProbe:
           httpGet:

--- a/tests-e2e/Makefile
+++ b/tests-e2e/Makefile
@@ -33,8 +33,7 @@ help: ## Display this help.
 
 .PHONY: test
 test: ## Run E2E tests.
-	go test -v -p=1 -timeout=100m -race -count=1 -coverprofile=coverage.out ./...
-	
+    ENABLE_APPPROJECT_ISOLATION="true" go test -v -p=1 -timeout=100m -race -count=1 -coverprofile=coverage.out ./...	
 
 # go-get-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
#### Description:
- Now that we've squashed the bugs, let's finally enable the AppProject isolation feature flag

#### Link to JIRA Story (if applicable): [GITOPSRVCE-56](https://issues.redhat.com/browse/GITOPSRVCE-56)

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
