### PR TITLE
Move sanity test before the log statement to avoid panic in 'workspace_event_loop_test' unit tests

### DIFF
--- a/backend/eventloop/workspace_event_loop.go
+++ b/backend/eventloop/workspace_event_loop.go
@@ -253,15 +253,16 @@ func processWorkspaceEventLoopMessage(ctx context.Context, event eventlooptypes.
 func handleWorkspaceEventLoopMessage(ctx context.Context, event eventlooptypes.EventLoopMessage, wrapperEvent workspaceEventLoopMessage,
 	state workspaceEventLoopInternalState) {
 
+	if event.Event == nil {
+		state.log.Error(nil, "SEVERE: event was nil in workspaceEventLoopRouter")
+		return
+	}
+
 	log := state.log.WithValues("namespace", event.Event.Request.Namespace)
 
 	// First, sanity check the event
 	if event.MessageType == eventlooptypes.ApplicationEventLoopMessageType_WorkComplete {
 		log.Error(nil, "SEVERE: invalid message type received in workspaceEventLoopRouter")
-		return
-	}
-	if event.Event == nil {
-		log.Error(nil, "SEVERE: event was nil in workspaceEventLoopRouter")
 		return
 	}
 


### PR DESCRIPTION
#### Description:

Unit test are currently failing here:

```
• [PANICKED] [0.000 seconds]
Workspace Event Loop Test processWorkspaceEventLoopMessage tests shouldn't forward the event if it is completed/nil/unknown [It] reject the event if it is nil
/home/runner/work/managed-gitops/managed-gitops/backend/eventloop/workspace_event_loop_test.go:671

  Timeline >>
  STEP: verify that the event is not forwarded @ 09/11/23 11:19:17.316
  [PANICKED] in [It] - /opt/hostedtoolcache/go/1.19.12/x64/src/runtime/panic.go:260 @ 09/11/23 11:19:17.317
  << Timeline

  [PANICKED] Test Panicked
  In [It] at: /opt/hostedtoolcache/go/1.19.12/x64/src/runtime/panic.go:260 @ 09/11/23 11:19:17.317

  runtime error: invalid memory address or nil pointer dereference

  Full Stack Trace
    github.com/redhat-appstudio/managed-gitops/backend/eventloop.handleWorkspaceEventLoopMessage({0x1e3f8e8, 0xc0000cc000}, {0x220c549?, 0x0?, 0x94?}, {{0x1b3e19f?, 0x0?}, {0x19b8220?, 0xc000ea0630?}}, {0x0, ...})
    	/home/runner/work/managed-gitops/managed-gitops/backend/eventloop/workspace_event_loop.go:256 +0xca
    github.com/redhat-appstudio/managed-gitops/backend/eventloop.processWorkspaceEventLoopMessage({0x1e3f8e8?, 0xc0000cc000?}, {0x40d834?, 0x0?, 0xc0?}, {{0x1b3e19f?, 0x2c51b00?}, {0x19b8220?, 0xc000ea0630?}}, {0x0, ...}, ...)
    	/home/runner/work/managed-gitops/managed-gitops/backend/eventloop/workspace_event_loop.go:235 +0xbe
    github.com/redhat-appstudio/managed-gitops/backend/eventloop.glob..func7.3.3({0x5?, 0x0?, 0x0?}, {0x1b3e19f, 0x5})
    	/home/runner/work/managed-gitops/managed-gitops/backend/eventloop/workspace_event_loop_test.go:661 +0x1f6
    reflect.Value.call({0x18b0560?, 0xc000012120?, 0x13?}, {0x1b3c958, 0x4}, {0xc000ccf800, 0x2, 0x2?})
    	/opt/hostedtoolcache/go/1.19.12/x64/src/reflect/value.go:584 +0x8c5
    reflect.Value.Call({0x18b0560?, 0xc000012120?, 0x1e538a0?}, {0xc000ccf800?, 0xc000c0c770?, 0x18a0c00?})
    	/opt/hostedtoolcache/go/1.19.12/x64/src/reflect/value.go:368 +0xbc
```

Fix is to the function which is called by the unit test, to allow it avoid a panic if `event.Event` is nil.

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
