### PR TITLE
Refactor log statements to better use log context, reduce verbosity

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/application_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/application_controller.go
@@ -52,7 +52,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	log := log.FromContext(ctx).
 		WithName(logutil.LogLogger_managed_gitops)
 
-	log.Info("Detected AppStudio Application event:", "request", req)
+	log.V(logutil.LogLevel_Debug).Info("AppStudio Application event", "request", req)
 
 	return ctrl.Result{}, nil
 }

--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetbinder_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetbinder_controller.go
@@ -59,7 +59,10 @@ type DeploymentTargetClaimReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/reconcile
 func (r *DeploymentTargetClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx).
-		WithName(logutil.LogLogger_managed_gitops)
+		WithName(logutil.LogLogger_managed_gitops).WithValues(
+		logutil.Log_K8s_Request_Namespace, req.Namespace,
+		logutil.Log_K8s_Request_Name, req.Name,
+		logutil.Log_Component, logutil.Log_Component_Appstudio_Controller)
 
 	dtc := applicationv1alpha1.DeploymentTargetClaim{
 		ObjectMeta: metav1.ObjectMeta{

--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetreclaimer_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetreclaimer_controller.go
@@ -68,7 +68,11 @@ const (
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/reconcile
 func (r *DeploymentTargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 
-	log := log.FromContext(ctx).WithValues("name", req.Name, "namespace", req.Namespace, "component", "deploymentTargetReclaimer")
+	log := log.FromContext(ctx).
+		WithName(logutil.LogLogger_managed_gitops).WithValues(
+		logutil.Log_K8s_Request_Namespace, req.Namespace,
+		logutil.Log_K8s_Request_Name, req.Name,
+		logutil.Log_Component, logutil.Log_Component_Appstudio_Controller)
 
 	dt := applicationv1alpha1.DeploymentTarget{
 		ObjectMeta: metav1.ObjectMeta{

--- a/appstudio-controller/controllers/appstudio.redhat.com/devsandbox_deployment_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/devsandbox_deployment_controller.go
@@ -64,7 +64,10 @@ func (r *DevsandboxDeploymentReconciler) Reconcile(ctx context.Context, req ctrl
 	var err error
 
 	log := log.FromContext(ctx).
-		WithName(logutil.LogLogger_managed_gitops)
+		WithName(logutil.LogLogger_managed_gitops).WithValues(
+		logutil.Log_Component, logutil.Log_Component_Appstudio_Controller,
+		logutil.Log_K8s_Request_Namespace, req.Namespace,
+		logutil.Log_K8s_Request_Name, req.Name)
 
 	spacerequest := codereadytoolchainv1alpha1.SpaceRequest{
 		ObjectMeta: metav1.ObjectMeta{

--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
@@ -75,7 +75,10 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	log := log.FromContext(ctx).
 		WithName(logutil.LogLogger_managed_gitops).
-		WithValues("request", req)
+		WithValues(
+			logutil.Log_Component, logutil.Log_Component_Appstudio_Controller,
+			logutil.Log_K8s_Request_Namespace, req.Namespace,
+			logutil.Log_K8s_Request_Name, req.Name)
 
 	rClient := sharedutil.IfEnabledSimulateUnreliableClient(r.Client)
 

--- a/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
@@ -74,7 +74,11 @@ const (
 func (r *PromotionRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 
 	log := log.FromContext(ctx).
-		WithName(logutil.LogLogger_managed_gitops)
+		WithName(logutil.LogLogger_managed_gitops).WithValues(
+		logutil.Log_Component, logutil.Log_Component_Appstudio_Controller,
+		logutil.Log_K8s_Request_Namespace, req.Namespace,
+		logutil.Log_K8s_Request_Name, req.Name)
+
 	defer log.V(logutil.LogLevel_Debug).Info("Promotion Run Reconcile() complete.")
 	promotionRun := &appstudioshared.PromotionRun{}
 

--- a/appstudio-controller/controllers/appstudio.redhat.com/sandboxprovisioner_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/sandboxprovisioner_controller.go
@@ -63,7 +63,10 @@ type SandboxProvisionerReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/reconcile
 func (r *SandboxProvisionerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx).
-		WithName(logutil.LogLogger_managed_gitops)
+		WithName(logutil.LogLogger_managed_gitops).WithValues(
+		logutil.Log_Component, logutil.Log_Component_Appstudio_Controller,
+		logutil.Log_K8s_Request_Namespace, req.Namespace,
+		logutil.Log_K8s_Request_Name, req.Name)
 
 	dtc := applicationv1alpha1.DeploymentTargetClaim{
 		ObjectMeta: metav1.ObjectMeta{

--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshot_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshot_controller.go
@@ -48,9 +48,12 @@ type SnapshotReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/reconcile
 func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx).
-		WithName(logutil.LogLogger_managed_gitops)
+		WithName(logutil.LogLogger_managed_gitops).WithValues(
+		logutil.Log_Component, logutil.Log_Component_Appstudio_Controller,
+		logutil.Log_K8s_Request_Namespace, req.Namespace,
+		logutil.Log_K8s_Request_Name, req.Name)
 
-	log.Info("Snapshot event: ", "request", req)
+	log.V(logutil.LogLevel_Debug).Info("Snapshot event", "request", req)
 
 	return ctrl.Result{}, nil
 }

--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
@@ -94,8 +94,10 @@ type SnapshotEnvironmentBindingReconciler struct {
 func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 
 	log := log.FromContext(ctx).
-		WithName(logutil.LogLogger_managed_gitops).
-		WithValues("name", req.Name, "namespace", req.Namespace, "component", "bindingReconcile")
+		WithName(logutil.LogLogger_managed_gitops).WithValues(
+		logutil.Log_Component, logutil.Log_Component_Appstudio_Controller,
+		logutil.Log_K8s_Request_Namespace, req.Namespace,
+		logutil.Log_K8s_Request_Name, req.Name)
 
 	defer log.V(logutil.LogLevel_Debug).Info("Snapshot Environment Binding Reconcile() complete.")
 
@@ -417,9 +419,9 @@ const (
 
 // processExpectedGitOpsDeployment processed the GitOpsDeployment that is expected for a particular Component
 func processExpectedGitOpsDeployment(ctx context.Context, expectedGitopsDeployment apibackend.GitOpsDeployment,
-	binding appstudioshared.SnapshotEnvironmentBinding, k8sClient client.Client, l logr.Logger) error {
+	binding appstudioshared.SnapshotEnvironmentBinding, k8sClient client.Client, logParam logr.Logger) error {
 
-	log := l.WithValues("binding", binding.Name, "gitOpsDeployment", expectedGitopsDeployment.Name, "bindingNamespace", binding.Namespace)
+	log := logParam.WithValues("expectedGitOpsDeploymentName", expectedGitopsDeployment.Name)
 
 	actualGitOpsDeployment := apibackend.GitOpsDeployment{}
 

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_webhook.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeployment_webhook.go
@@ -47,8 +47,9 @@ var _ webhook.Defaulter = &GitOpsDeployment{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *GitOpsDeployment) Default() {
-	gitopsdeploymentlog.Info("default", "name", r.Name)
+	log := gitopsdeploymentlog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeployment")
 
+	log.V(logutil.LogLevel_Debug).Info("default")
 }
 
 //+kubebuilder:webhook:path=/validate-managed-gitops-redhat-com-v1alpha1-gitopsdeployment,mutating=false,failurePolicy=fail,sideEffects=None,groups=managed-gitops.redhat.com,resources=gitopsdeployments,verbs=create;update,versions=v1alpha1,name=vgitopsdeployment.kb.io,admissionReviewVersions=v1
@@ -57,9 +58,13 @@ var _ webhook.Validator = &GitOpsDeployment{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *GitOpsDeployment) ValidateCreate() error {
-	gitopsdeploymentlog.Info("validate create", "name", r.Name)
 
-	if err := r.ValidateGitOpsDeployment(); err != nil {
+	log := gitopsdeploymentlog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeployment")
+
+	log.V(logutil.LogLevel_Debug).Info("validate create")
+
+	if err := r.validateGitOpsDeployment(); err != nil {
+		log.Info("webhook rejected invalid create", "error", fmt.Sprintf("%v", err))
 		return err
 	}
 
@@ -68,9 +73,13 @@ func (r *GitOpsDeployment) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *GitOpsDeployment) ValidateUpdate(old runtime.Object) error {
-	gitopsdeploymentlog.Info("validate update", "name", r.Name)
 
-	if err := r.ValidateGitOpsDeployment(); err != nil {
+	log := gitopsdeploymentlog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeployment")
+
+	log.V(logutil.LogLevel_Debug).Info("validate update")
+
+	if err := r.validateGitOpsDeployment(); err != nil {
+		log.Info("webhook rejected invalid update", "error", fmt.Sprintf("%v", err))
 		return err
 	}
 
@@ -79,12 +88,15 @@ func (r *GitOpsDeployment) ValidateUpdate(old runtime.Object) error {
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *GitOpsDeployment) ValidateDelete() error {
-	gitopsdeploymentlog.Info("validate delete", "name", r.Name)
+
+	log := gitopsdeploymentlog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeployment")
+
+	log.V(logutil.LogLevel_Debug).Info("validate delete")
 
 	return nil
 }
 
-func (r *GitOpsDeployment) ValidateGitOpsDeployment() error {
+func (r *GitOpsDeployment) validateGitOpsDeployment() error {
 
 	// Check whether Type is manual or automated
 	if !(r.Spec.Type == GitOpsDeploymentSpecType_Automated || r.Spec.Type == GitOpsDeploymentSpecType_Manual) {

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_webhook.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentmanagedenvironment_webhook.go
@@ -44,7 +44,10 @@ var _ webhook.Defaulter = &GitOpsDeploymentManagedEnvironment{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *GitOpsDeploymentManagedEnvironment) Default() {
-	gitopsdeploymentmanagedenvironmentlog.Info("default", "name", r.Name)
+
+	log := gitopsdeploymentmanagedenvironmentlog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeploymentManagedEnvironment")
+
+	log.V(logutil.LogLevel_Debug).Info("default", "name", r.Name)
 
 }
 
@@ -54,9 +57,13 @@ var _ webhook.Validator = &GitOpsDeploymentManagedEnvironment{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *GitOpsDeploymentManagedEnvironment) ValidateCreate() error {
-	gitopsdeploymentmanagedenvironmentlog.Info("validate create", "name", r.Name)
+
+	log := gitopsdeploymentmanagedenvironmentlog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeploymentManagedEnvironment")
+
+	log.V(logutil.LogLevel_Debug).Info("validate create")
 
 	if err := r.ValidateGitOpsDeploymentManagedEnv(); err != nil {
+		log.Info("webhook rejected invalid create", "error", fmt.Sprintf("%v", err))
 		return err
 	}
 
@@ -65,9 +72,13 @@ func (r *GitOpsDeploymentManagedEnvironment) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *GitOpsDeploymentManagedEnvironment) ValidateUpdate(old runtime.Object) error {
-	gitopsdeploymentmanagedenvironmentlog.Info("validate update", "name", r.Name)
+
+	log := gitopsdeploymentmanagedenvironmentlog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeploymentManagedEnvironment")
+
+	log.V(logutil.LogLevel_Debug).Info("validate update")
 
 	if err := r.ValidateGitOpsDeploymentManagedEnv(); err != nil {
+		log.Info("webhook rejected invalid update", "error", fmt.Sprintf("%v", err))
 		return err
 	}
 
@@ -76,7 +87,10 @@ func (r *GitOpsDeploymentManagedEnvironment) ValidateUpdate(old runtime.Object) 
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *GitOpsDeploymentManagedEnvironment) ValidateDelete() error {
-	gitopsdeploymentmanagedenvironmentlog.Info("validate delete", "name", r.Name)
+
+	log := gitopsdeploymentmanagedenvironmentlog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeploymentManagedEnvironment")
+
+	log.V(logutil.LogLevel_Debug).Info("validate delete", "name", r.Name)
 
 	return nil
 }

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentrepositorycredential_webhook.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentrepositorycredential_webhook.go
@@ -44,7 +44,9 @@ var _ webhook.Defaulter = &GitOpsDeploymentRepositoryCredential{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *GitOpsDeploymentRepositoryCredential) Default() {
-	gitopsdeploymentrepositorycredentiallog.Info("default", "name", r.Name)
+	log := gitopsdeploymentrepositorycredentiallog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeploymentRepositoryCredential")
+
+	log.V(logutil.LogLevel_Debug).Info("default", "name", r.Name)
 
 }
 
@@ -54,9 +56,13 @@ var _ webhook.Validator = &GitOpsDeploymentRepositoryCredential{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *GitOpsDeploymentRepositoryCredential) ValidateCreate() error {
-	gitopsdeploymentrepositorycredentiallog.Info("validate create", "name", r.Name)
+
+	log := gitopsdeploymentrepositorycredentiallog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeploymentRepositoryCredential")
+
+	log.V(logutil.LogLevel_Debug).Info("validate create")
 
 	if err := r.ValidateGitOpsDeploymentRepoCred(); err != nil {
+		log.Info("webhook rejected invalid create", "error", fmt.Sprintf("%v", err))
 		return err
 	}
 
@@ -65,9 +71,13 @@ func (r *GitOpsDeploymentRepositoryCredential) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *GitOpsDeploymentRepositoryCredential) ValidateUpdate(old runtime.Object) error {
-	gitopsdeploymentrepositorycredentiallog.Info("validate update", "name", r.Name)
+
+	log := gitopsdeploymentrepositorycredentiallog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeploymentRepositoryCredential")
+
+	log.V(logutil.LogLevel_Debug).Info("validate update")
 
 	if err := r.ValidateGitOpsDeploymentRepoCred(); err != nil {
+		log.Info("webhook rejected invalid update", "error", fmt.Sprintf("%v", err))
 		return err
 	}
 
@@ -76,7 +86,10 @@ func (r *GitOpsDeploymentRepositoryCredential) ValidateUpdate(old runtime.Object
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *GitOpsDeploymentRepositoryCredential) ValidateDelete() error {
-	gitopsdeploymentrepositorycredentiallog.Info("validate delete", "name", r.Name)
+
+	log := gitopsdeploymentrepositorycredentiallog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeploymentRepositoryCredential")
+
+	log.V(logutil.LogLevel_Debug).Info("validate delete")
 
 	return nil
 }

--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentsyncrun_webhook.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentsyncrun_webhook.go
@@ -45,8 +45,12 @@ func (r *GitOpsDeploymentSyncRun) SetupWebhookWithManager(mgr ctrl.Manager) erro
 var _ webhook.Defaulter = &GitOpsDeploymentSyncRun{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
+
 func (r *GitOpsDeploymentSyncRun) Default() {
-	gitopsdeploymentsyncrunlog.Info("default", "name", r.Name)
+
+	log := gitopsdeploymentsyncrunlog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeploymentSyncRun")
+
+	log.V(logutil.LogLevel_Debug).Info("default")
 
 }
 
@@ -56,10 +60,15 @@ var _ webhook.Validator = &GitOpsDeploymentSyncRun{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *GitOpsDeploymentSyncRun) ValidateCreate() error {
-	gitopsdeploymentsyncrunlog.Info("validate create", "name", r.Name)
+
+	log := gitopsdeploymentsyncrunlog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeploymentSyncRun")
+
+	log.V(logutil.LogLevel_Debug).Info("validate create")
 
 	if r.Name == invalid_name {
-		return fmt.Errorf(error_invalid_name)
+		err := fmt.Errorf(error_invalid_name)
+		log.Info("webhook rejected invalid create", "error", fmt.Sprintf("%v", err))
+		return err
 	}
 
 	return nil
@@ -67,14 +76,20 @@ func (r *GitOpsDeploymentSyncRun) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *GitOpsDeploymentSyncRun) ValidateUpdate(old runtime.Object) error {
-	gitopsdeploymentsyncrunlog.Info("validate update", "name", r.Name)
+
+	log := gitopsdeploymentsyncrunlog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeploymentSyncRun")
+
+	log.V(logutil.LogLevel_Debug).Info("validate update")
 
 	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *GitOpsDeploymentSyncRun) ValidateDelete() error {
-	gitopsdeploymentsyncrunlog.Info("validate delete", "name", r.Name)
+
+	log := gitopsdeploymentsyncrunlog.WithValues(logutil.Log_K8s_Request_Name, r.Name, logutil.Log_K8s_Request_Namespace, r.Namespace, "kind", "GitOpsDeploymentSyncRun")
+
+	log.V(logutil.LogLevel_Debug).Info("validate delete")
 
 	return nil
 }

--- a/backend-shared/db/test_utils.go
+++ b/backend-shared/db/test_utils.go
@@ -358,7 +358,7 @@ func SetupForTestingDBGinkgo() error {
 	Expect(err).ToNot(HaveOccurred())
 	for idx := range apiCRToDatabaseMappings {
 		item := apiCRToDatabaseMappings[idx]
-		if strings.HasPrefix(item.APIResourceUID, "test-") || strings.HasPrefix(item.DBRelationKey, "test-") {
+		if strings.HasPrefix(item.APIResourceUID, "test-") || strings.HasPrefix(item.APIResourceName, "test-") || strings.HasPrefix(item.DBRelationKey, "test-") {
 			rowsAffected, err := dbq.DeleteAPICRToDatabaseMapping(ctx, &item)
 			Expect(err).ToNot(HaveOccurred())
 			if err == nil {

--- a/backend-shared/db/test_utils.go
+++ b/backend-shared/db/test_utils.go
@@ -93,7 +93,7 @@ func SetupForTestingDBGinkgo() error {
 	// 'testSetup' deletes all database rows that start with 'test-' in the primary key of the row.
 	// This ensures a clean slate for the test run.
 
-	dbq, err := NewUnsafePostgresDBQueries(true, true)
+	dbq, err := NewUnsafePostgresDBQueries(false, true)
 	Expect(err).ToNot(HaveOccurred())
 
 	var specialClusterUser ClusterUser

--- a/backend-shared/db/test_utils.go
+++ b/backend-shared/db/test_utils.go
@@ -205,9 +205,8 @@ func SetupForTestingDBGinkgo() error {
 
 		if instanceToBeDeleted || strings.HasPrefix(operation.Operation_id, "test-") || strings.HasPrefix(operation.Operation_owner_user_id, "test-") || operation.Operation_owner_user_id == specialClusterUser.Clusteruser_id {
 			rowsAffected, err := dbq.CheckedDeleteOperationById(ctx, operation.Operation_id, operation.Operation_owner_user_id)
-			Expect(rowsAffected).Should(Equal(1))
 			Expect(err).ToNot(HaveOccurred())
-
+			Expect(rowsAffected).Should(Equal(1))
 		}
 	}
 

--- a/backend-shared/util/log/log.go
+++ b/backend-shared/util/log/log.go
@@ -21,6 +21,24 @@ const (
 	LogLevel_Warn int = -1
 )
 
+const (
+	Log_Component                                    = "component"
+	Log_Component_Appstudio_Controller               = "appstudio-controller"
+	Log_Component_ClusterAgent                       = "cluster-agent"
+	Log_Component_Backend_ClusterReconciler          = "cluster-reconciler"
+	Log_Component_Backend_DatabaseMetricsReconciler  = "database-metrics-reconciler"
+	Log_Component_Backend_DatabaseReconciler         = "database-reconciler"
+	Log_Component_Backend_RepocredReconciler         = "repocred-reconciler"
+	Log_Component_Backend_WorkspaceResourceEventLoop = "workspace_resource_event_loop"
+
+	Log_K8s_Request_Name        = "requestName"
+	Log_K8s_Request_Namespace   = "requestNamespace"
+	Log_K8s_Request_UID         = "requestUID"
+	Log_K8s_Request_NamespaceID = "requestNamespaceID"
+
+	Log_ApplicationID = "applicationID"
+)
+
 type ResourceChangeType string
 
 const (

--- a/backend-shared/util/log/log.go
+++ b/backend-shared/util/log/log.go
@@ -22,12 +22,13 @@ const (
 )
 
 const (
-	Log_Component                                    = "component"
-	Log_Component_Appstudio_Controller               = "appstudio-controller"
-	Log_Component_ClusterAgent                       = "cluster-agent"
-	Log_Component_Backend_ClusterReconciler          = "cluster-reconciler"
-	Log_Component_Backend_DatabaseMetricsReconciler  = "database-metrics-reconciler"
-	Log_Component_Backend_DatabaseReconciler         = "database-reconciler"
+	Log_Component                                   = "component"
+	Log_Component_Appstudio_Controller              = "appstudio-controller"
+	Log_Component_ClusterAgent                      = "cluster-agent"
+	Log_Component_Backend_ClusterReconciler         = "cluster-reconciler"
+	Log_Component_Backend_DatabaseMetricsReconciler = "database-metrics-reconciler"
+	Log_Component_Backend_DatabaseReconciler        = "database-reconciler"
+	// #nosec G101
 	Log_Component_Backend_RepocredReconciler         = "repocred-reconciler"
 	Log_Component_Backend_WorkspaceResourceEventLoop = "workspace_resource_event_loop"
 

--- a/backend-shared/util/service_account.go
+++ b/backend-shared/util/service_account.go
@@ -53,7 +53,7 @@ func getOrCreateServiceAccount(ctx context.Context, k8sClient client.Client, ser
 		return serviceAccount, nil
 	}
 
-	log = log.WithValues("serviceAccount", serviceAccountName, "namespace", serviceAccountNS)
+	log = log.WithValues("serviceAccount", serviceAccountName, "serviceAccountNS", serviceAccountNS)
 
 	if err := k8sClient.Create(ctx, serviceAccount); err != nil {
 		log.Error(err, "Unable to create ServiceAccount")
@@ -167,7 +167,7 @@ func createServiceAccountTokenSecret(ctx context.Context, k8sClient client.Clien
 		Type: corev1.SecretTypeServiceAccountToken,
 	}
 
-	log = log.WithValues("name", tokenSecret.Name, "namespace", tokenSecret.Namespace)
+	log = log.WithValues("tokenSecretName", tokenSecret.Name, "tokenSecretNamespace", tokenSecret.Namespace)
 
 	if err := k8sClient.Create(ctx, tokenSecret); err != nil {
 		log.Error(err, "Unable to create ServiceAccountToken Secret")
@@ -192,7 +192,7 @@ func createOrUpdateClusterRoleAndRoleBinding(ctx context.Context, uuid string, k
 			return fmt.Errorf("unable to get cluster role: %w", err)
 		}
 
-		log := log.WithValues("name", clusterRole.Name)
+		log := log.WithValues("clusterRoleName", clusterRole.Name)
 
 		clusterRole.Rules = ArgoCDManagerNamespacePolicyRules
 		if err := k8sClient.Create(ctx, clusterRole); err != nil {
@@ -202,7 +202,7 @@ func createOrUpdateClusterRoleAndRoleBinding(ctx context.Context, uuid string, k
 		logutil.LogAPIResourceChangeEvent(clusterRole.Namespace, clusterRole.Name, clusterRole, logutil.ResourceCreated, log)
 
 	} else {
-		log := log.WithValues("name", clusterRole.Name)
+		log := log.WithValues("clusterRoleName", clusterRole.Name)
 
 		clusterRole.Rules = ArgoCDManagerNamespacePolicyRules
 		if err := k8sClient.Update(ctx, clusterRole); err != nil {
@@ -237,7 +237,7 @@ func createOrUpdateClusterRoleAndRoleBinding(ctx context.Context, uuid string, k
 		Namespace: serviceAccountNamespace,
 	}}
 
-	log = log.WithValues("name", clusterRoleBinding.Name)
+	log = log.WithValues("clusterRoleNameBindingName", clusterRoleBinding.Name)
 
 	if update {
 		if err := k8sClient.Update(ctx, clusterRoleBinding); err != nil {

--- a/backend-shared/util/util.go
+++ b/backend-shared/util/util.go
@@ -31,9 +31,9 @@ const (
 
 	ManagedEnvironmentSecretType = "managed-gitops.redhat.com/managed-environment"
 
-	JobKey      = "job"                    // Clean up job key
-	JobKeyValue = "managed-gitops-cleanup" // Clean up job value
-	JobTypeKey  = "jobType"                // Key to identify clean up job type
+	Log_JobKey      = "job"                    // Clean up job key
+	Log_JobKeyValue = "managed-gitops-cleanup" // Clean up job value
+	Log_JobTypeKey  = "jobType"                // Key to identify clean up job type
 )
 
 // ExponentialBackoff: the more times in a row something fails, the longer we wait.

--- a/backend/eventloop/application_event_loop/application_event_loop.go
+++ b/backend/eventloop/application_event_loop/application_event_loop.go
@@ -150,14 +150,13 @@ func applicationEventQueueLoop(ctx context.Context, k8sClient client.Client,
 	aerFactory applicationEventRunnerFactory) {
 
 	log := log.FromContext(ctx).
-		WithValues("workspaceID", workspaceID,
-			"gitOpsDeplName", gitopsDeploymentName,
-			"gitopsDeplNamespace", gitopsDeploymentNamespace,
-			"namespace", gitopsDeploymentNamespace).
+		WithValues(logutil.Log_K8s_Request_NamespaceID, workspaceID,
+			logutil.Log_K8s_Request_Name, gitopsDeploymentName,
+			logutil.Log_K8s_Request_Namespace, gitopsDeploymentNamespace).
 		WithName(logutil.LogLogger_managed_gitops)
 
-	log.Info("applicationEventQueueLoop started.")
-	defer log.Info("applicationEventQueueLoop ended.")
+	log.V(logutil.LogLevel_Debug).Info("applicationEventQueueLoop started.")
+	defer log.V(logutil.LogLevel_Debug).Info("applicationEventQueueLoop ended.")
 
 	state := applicationEventQueueLoopState{
 		activeDeploymentEvent:      nil,

--- a/backend/eventloop/application_event_loop/application_event_runner.go
+++ b/backend/eventloop/application_event_loop/application_event_runner.go
@@ -84,9 +84,11 @@ func applicationEventLoopRunner(inputChannel chan *eventlooptypes.EventLoopEvent
 	outerContext := context.Background()
 	log := log.FromContext(outerContext).
 		WithName(logutil.LogLogger_managed_gitops).
-		WithValues("namespaceID", namespaceID,
-			"debugContext", debugContext,
-			"namespace", gitopsDeploymentNamespace)
+		WithValues(
+			logutil.Log_K8s_Request_NamespaceID, namespaceID,
+			logutil.Log_K8s_Request_Namespace, gitopsDeploymentNamespace,
+			logutil.Log_K8s_Request_Name, gitopsDeploymentName,
+			"debugContext", debugContext)
 
 	log.V(logutil.LogLevel_Debug).Info("applicationEventLoopRunner started")
 

--- a/backend/eventloop/controller_event_loop_test.go
+++ b/backend/eventloop/controller_event_loop_test.go
@@ -47,7 +47,7 @@ type mockWorkspaceEventLoopFactory struct {
 
 var _ workspaceEventLoopRouterFactory = &mockWorkspaceEventLoopFactory{}
 
-func (cetf *mockWorkspaceEventLoopFactory) startWorkspaceEventLoopRouter(workspaceID string) WorkspaceEventLoopRouterStruct {
+func (cetf *mockWorkspaceEventLoopFactory) startWorkspaceEventLoopRouter(namespaceName string, namespaceID string) WorkspaceEventLoopRouterStruct {
 	// Rather than starting a new workspace event loop, instead just return a pre-provided channel
 	return WorkspaceEventLoopRouterStruct{
 		channel: cetf.mockChannel,

--- a/backend/eventloop/db_metrics.go
+++ b/backend/eventloop/db_metrics.go
@@ -33,7 +33,7 @@ func (r *MetricsReconciler) StartDBMetricsReconcilerForMetrics() {
 		ctx := context.Background()
 		log := log.FromContext(ctx).
 			WithName(logutil.LogLogger_managed_gitops).
-			WithValues("component", "database-metrics-reconciler")
+			WithValues(logutil.Log_Component, logutil.Log_Component_Backend_DatabaseMetricsReconciler)
 
 		_, _ = sharedutil.CatchPanic(func() error {
 			operationDbReconcile(ctx, r.DB, r.Client, log)

--- a/backend/eventloop/db_reconciler_test.go
+++ b/backend/eventloop/db_reconciler_test.go
@@ -59,7 +59,7 @@ var _ = Describe("DB Clean-up Function Tests", func() {
 
 			ctx = context.Background()
 			log = logger.FromContext(ctx)
-			dbq, err = db.NewUnsafePostgresDBQueries(true, true)
+			dbq, err = db.NewUnsafePostgresDBQueries(false, true)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, managedEnvironment, _, gitopsEngineInstance, _, err = db.CreateSampleData(dbq)

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_test.go
@@ -1010,7 +1010,8 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dbRepoCred).ToNot(BeNil())
 
-			sharedResourceEventLoopRepoCred, err := sharedResourceEventLoop.ReconcileRepositoryCredential(ctx, k8sClient, repositoryCredentialCRNamespace, cr.Name, MockSRLK8sClientFactory{fakeClient: k8sClient})
+			sharedResourceEventLoopRepoCred, err := sharedResourceEventLoop.ReconcileRepositoryCredential(ctx, k8sClient, repositoryCredentialCRNamespace, cr.Name, MockSRLK8sClientFactory{fakeClient: k8sClient}, log.FromContext(context.Background()))
+
 			Expect(sharedResourceEventLoopRepoCred.RepositoryCredentialsID).To(Equal(dbRepoCred.RepositoryCredentialsID))
 			Expect(err).ToNot(HaveOccurred())
 			// To be used by AfterEach to clean up the resources created by test
@@ -1029,7 +1030,7 @@ var _ = Describe("SharedResourceEventLoop Test", func() {
 
 			go internalSharedResourceEventLoop(sharedResourceEventLoop.inputChannel)
 
-			sharedResourceLoop, err := sharedResourceEventLoop.ReconcileRepositoryCredential(ctx, k8sClient, *namespace, "test-name", MockSRLK8sClientFactory{fakeClient: k8sClient})
+			sharedResourceLoop, err := sharedResourceEventLoop.ReconcileRepositoryCredential(ctx, k8sClient, *namespace, "test-name", MockSRLK8sClientFactory{fakeClient: k8sClient}, log.FromContext(context.Background()))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sharedResourceLoop).To(BeNil())
 

--- a/backend/eventloop/workspace_event_loop_test.go
+++ b/backend/eventloop/workspace_event_loop_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 			tAELF = &testApplicationEventLoopFactory{}
 
 			// Start the workspace event loop with our custom test factory, so that we can capture output
-			workspaceEventLoopRouter = newWorkspaceEventLoopRouterWithFactory(string(apiNamespace.UID), tAELF)
+			workspaceEventLoopRouter = newWorkspaceEventLoopRouterWithFactory(apiNamespace.Name, string(apiNamespace.UID), tAELF)
 
 			k8sClient = fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -445,7 +445,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 			tAELF := &managedEnvironmentTestApplicationEventLoopFactory{
 				outputChannelMap: map[string]chan application_event_loop.RequestMessage{},
 			}
-			workspaceEventLoopRouter := newWorkspaceEventLoopRouterWithFactory(string(apiNamespace.UID), tAELF)
+			workspaceEventLoopRouter := newWorkspaceEventLoopRouterWithFactory(apiNamespace.Name, string(apiNamespace.UID), tAELF)
 
 			k8sClient := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -479,7 +479,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 			tAELF := &managedEnvironmentTestApplicationEventLoopFactory{
 				outputChannelMap: map[string]chan application_event_loop.RequestMessage{},
 			}
-			workspaceEventLoopRouter := newWorkspaceEventLoopRouterWithFactory(string(apiNamespace.UID), tAELF)
+			workspaceEventLoopRouter := newWorkspaceEventLoopRouterWithFactory(apiNamespace.Name, string(apiNamespace.UID), tAELF)
 
 			k8sClient := fake.NewClientBuilder().
 				WithScheme(scheme).
@@ -748,8 +748,9 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 
 				By("simulating a newly initialized workspace event loop")
 				state := workspaceEventLoopInternalState{
-					namespaceID: "namespace-id",
-					log:         log.FromContext(ctx),
+					namespaceID:   "namespace-id",
+					namespaceName: "namespace-name",
+					log:           log.FromContext(ctx),
 					workspaceResourceLoop: &workspaceResourceEventLoop{
 						inputChannel: responseChannel,
 					},
@@ -904,6 +905,7 @@ var _ = Describe("Workspace Event Loop Test", Ordered, func() {
 				applEventLoopFactory: tAELF,
 				applicationMap:       map[string]workspaceEventLoop_applicationEventLoopEntry{},
 				namespaceID:          "namespace-id",
+				namespaceName:        apiNamespace.Name,
 			}
 
 			By("calling the function beign tested")

--- a/backend/eventloop/workspace_resource_event_loop.go
+++ b/backend/eventloop/workspace_resource_event_loop.go
@@ -225,7 +225,7 @@ func handleResourceLoopRepositoryCredential(ctx context.Context, msg workspaceRe
 
 	req, ok := (msg.payload).(ctrl.Request)
 	if !ok {
-		return noRetry, fmt.Errorf("invalid payload in processWorkspaceResourceMessage")
+		return noRetry, fmt.Errorf("invalid RepositoryCredential payload in processWorkspaceResourceMessage")
 	}
 
 	// Retrieve the namespace that the repository credential is contained within
@@ -249,7 +249,7 @@ func handleResourceLoopRepositoryCredential(ctx context.Context, msg workspaceRe
 	// - If the GitOpsDeploymentRepositoryCredential does exist, but not in the DB, then create a RepositoryCredential DB entry
 	// - If the GitOpsDeploymentRepositoryCredential does exist, and also in the DB, then compare and change a RepositoryCredential DB entry
 	// Then, in all 3 cases, create an Operation to update the cluster-agent
-	_, err := sharedResourceLoop.ReconcileRepositoryCredential(ctx, msg.apiNamespaceClient, *namespace, req.Name, shared_resource_loop.DefaultK8sClientFactory{}, log)
+	_, err := sharedResourceLoop.ReconcileRepositoryCredential(ctx, msg.apiNamespaceClient, *namespace, req.Name, k8sClientFactory, log)
 
 	if err != nil {
 		return retry, fmt.Errorf("unable to reconcile repository credential. Error: %v", err)
@@ -262,7 +262,7 @@ func handleResourceLoopManagedEnvironment(ctx context.Context, msg workspaceReso
 
 	evlMessage, ok := (msg.payload).(eventlooptypes.EventLoopMessage)
 	if !ok {
-		return noRetry, fmt.Errorf("invalid payload in processWorkspaceResourceMessage")
+		return noRetry, fmt.Errorf("invalid ManagedEnvironment payload in processWorkspaceResourceMessage")
 	}
 
 	if evlMessage.Event == nil { // Sanity test the message
@@ -289,7 +289,7 @@ func handleResourceLoopManagedEnvironment(ctx context.Context, msg workspaceReso
 
 	// Ask the shared resource loop to ensure the managed environment is reconciled
 	_, err := sharedResourceLoop.ReconcileSharedManagedEnv(ctx, msg.apiNamespaceClient, *namespace, req.Name, req.Namespace,
-		false, shared_resource_loop.DefaultK8sClientFactory{}, log)
+		false, k8sClientFactory, log)
 
 	if err != nil {
 		return retry, fmt.Errorf("unable to reconcile shared managed env: %v", err)

--- a/backend/eventloop/workspace_resource_event_loop_test.go
+++ b/backend/eventloop/workspace_resource_event_loop_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Test Workspace Resource Loop", func() {
 
 			sharedResourceLoop := shared_resource_loop.NewSharedResourceLoop()
 			workspaceChan = make(chan workspaceEventLoopMessage)
-			wel := newWorkspaceResourceLoopWithFactory(sharedResourceLoop, workspaceChan, MockSRLK8sClientFactory{fakeClient: k8sClient})
+			wel := newWorkspaceResourceLoopWithFactory(sharedResourceLoop, workspaceChan, MockSRLK8sClientFactory{fakeClient: k8sClient}, apiNamespace.Name, string(apiNamespace.UID))
 			Expect(wel).ToNot(BeNil())
 
 			inputChan = wel.inputChannel

--- a/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache.go
+++ b/cluster-agent/controllers/argoproj.io/application_info_cache/application_info_cache.go
@@ -201,7 +201,7 @@ func applicationInfoCacheLoop(inputChan chan applicationInfoCacheRequest) {
 	})
 
 	log := log.FromContext(context.Background()).
-		WithName(logutil.LogLogger_managed_gitops)
+		WithName(logutil.LogLogger_managed_gitops).WithValues(logutil.Log_Component, logutil.Log_Component_Appstudio_Controller)
 
 	cacheAppState := map[string]applicationStateCacheEntry{}
 	cacheApp := map[string]applicationCacheEntry{}

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_cr_metrics.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_cr_metrics.go
@@ -32,7 +32,8 @@ func (r *OperationCRMetricUpdater) StartOperationCRMetricUpdater() {
 
 		ctx := context.Background()
 		log := log.FromContext(ctx).
-			WithName(logutil.LogLogger_managed_gitops)
+			WithName(logutil.LogLogger_managed_gitops).
+			WithValues(logutil.Log_Component, logutil.Log_Component_Appstudio_Controller)
 
 		_, _ = sharedutil.CatchPanic(func() error {
 			updateOperationCRMetrics(ctx, r.Client, log)

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop_test.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop_test.go
@@ -235,7 +235,7 @@ var _ = Describe("Operation Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("calling function to test")
-			err = ensureManagedEnvironmentExists(ctx, *applicationDB, opConfigVal)
+			err = ensureManagedEnvironmentExists(ctx, *applicationDB, opConfigVal, logger)
 			Expect(err).ToNot(HaveOccurred())
 
 			secretName := argosharedutil.GenerateArgoCDClusterSecretName(db.ManagedEnvironment{Managedenvironment_id: applicationDB.Managed_environment_id})
@@ -306,7 +306,7 @@ var _ = Describe("Operation Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("calling function to test")
-			err = ensureManagedEnvironmentExists(ctx, *applicationDB, opConfigVal)
+			err = ensureManagedEnvironmentExists(ctx, *applicationDB, opConfigVal, logger)
 			Expect(err).ToNot(HaveOccurred())
 
 			managedEnvironmentSecret := corev1.Secret{
@@ -353,7 +353,7 @@ var _ = Describe("Operation Controller", func() {
 			err := k8sClient.Create(ctx, &managedEnvironmentSecret)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = ensureManagedEnvironmentExists(ctx, *applicationDB, opConfigVal)
+			err = ensureManagedEnvironmentExists(ctx, *applicationDB, opConfigVal, logger)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&managedEnvironmentSecret), &managedEnvironmentSecret)

--- a/cluster-agent/controllers/util.go
+++ b/cluster-agent/controllers/util.go
@@ -38,7 +38,7 @@ const (
 // - If the Application is not deleted after X+2 minutes, return an error
 func DeleteArgoCDApplication(ctx context.Context, appFromList appv1.Application, eventClient client.Client, log logr.Logger) error {
 
-	log = log.WithValues("name", appFromList.Name, "namespace", appFromList.Namespace, "uid", string(appFromList.UID))
+	log = log.WithValues("argoCDApplicationName", appFromList.Name, "argoCDApplicationNamespace", appFromList.Namespace, "argoCDApplicationUID", string(appFromList.UID))
 
 	log.Info("Attempting to delete Argo CD Application CR")
 
@@ -188,9 +188,9 @@ func DeleteArgoCDApplication(ctx context.Context, appFromList appv1.Application,
 	}
 
 	if !success {
-		log.Info("Application was not successfully deleted")
+		log.Error(nil, "Argo CD Application was not successfully deleted")
 	} else {
-		log.Info("Application was successfully deleted")
+		log.Info("Argo CD Application was successfully deleted")
 	}
 
 	return nil

--- a/cluster-agent/controllers/util_test.go
+++ b/cluster-agent/controllers/util_test.go
@@ -197,6 +197,7 @@ var _ = Describe("Tests for the small number of utility functions in cluster-age
 			Expect(err).ToNot(HaveOccurred())
 
 			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&application), &application)
+
 			Expect(err).To(HaveOccurred(), "Application should not exist: it should have been deleted")
 
 		})
@@ -209,7 +210,7 @@ var _ = Describe("Tests for the small number of utility functions in cluster-age
 					Name:      "my-name",
 					Namespace: "my-namespace",
 					DeletionTimestamp: &metav1.Time{
-						Time: time.Now().Truncate(time.Hour * 3),
+						Time: time.Now().Add(-1 * time.Hour),
 					},
 					Labels: map[string]string{
 						ArgoCDApplicationDatabaseIDLabel: "test-my-database-id-label",

--- a/cluster-agent/controllers/utils_suite_test.go
+++ b/cluster-agent/controllers/utils_suite_test.go
@@ -5,7 +5,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(zapcore.DebugLevel)))
+})
 
 func TestUtils(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/cluster-agent/metrics/argocd/argocd_metrics.go
+++ b/cluster-agent/metrics/argocd/argocd_metrics.go
@@ -65,7 +65,8 @@ func (m *ReconciliationMetricsUpdater) poll(interval time.Duration) {
 
 	ctx := context.Background()
 	logger := log.FromContext(ctx).
-		WithName(logutil.LogLogger_managed_gitops)
+		WithName(logutil.LogLogger_managed_gitops).
+		WithValues(logutil.Log_Component, logutil.Log_Component_ClusterAgent)
 
 	updater := &reconciliationMetricsUpdater{
 		client:             m.Client,

--- a/cluster-agent/utils/argocd_login_credentials.go
+++ b/cluster-agent/utils/argocd_login_credentials.go
@@ -127,7 +127,8 @@ type credentialResponse struct {
 func (cs *CredentialService) credentialHandler(input chan credentialRequest) {
 
 	log := log.FromContext(context.Background()).
-		WithName(logutil.LogLogger_managed_gitops)
+		WithName(logutil.LogLogger_managed_gitops).
+		WithValues(logutil.Log_Component, logutil.Log_Component_ClusterAgent)
 
 	credentials := map[string]argoCDCredentials{}
 

--- a/cluster-agent/utils/argocd_terminate_app_command.go
+++ b/cluster-agent/utils/argocd_terminate_app_command.go
@@ -65,13 +65,16 @@ func terminateOperation(ctx context.Context, appName string, argocdNamespace cor
 				Namespace: argocdNamespace.Name,
 			},
 		}
+
+		log := log.WithValues("appName", appName, "appNamespace", argocdNamespace.Name)
+
 		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(application), application); err != nil {
 
 			if apierr.IsNotFound(err) {
-				log.Info("application '" + appName + "' no longer exists, so exiting terminate operation")
+				log.Info("application no longer exists, so exiting terminate operation")
 				return nil
 			}
-			log.Error(err, "unable to retrieve application '"+appName+"' from namespace "+argocdNamespace.Name)
+			log.Error(err, "unable to retrieve application from namespace")
 
 		} else {
 
@@ -79,7 +82,7 @@ func terminateOperation(ctx context.Context, appName string, argocdNamespace cor
 				operationPhase := application.Status.OperationState.Phase
 
 				if operationPhase != "" && operationPhase != common.OperationRunning && operationPhase != common.OperationTerminating {
-					log.Info("application '" + appName + "' operation is no longer running (or not running).")
+					log.Info("application operation is no longer running (or not running).")
 					return nil
 				}
 			}

--- a/tests-e2e/fixture/environment/fixture.go
+++ b/tests-e2e/fixture/environment/fixture.go
@@ -44,6 +44,9 @@ func expectedCondition(f func(env appstudiosharedv1.Environment) bool) matcher.G
 func HaveEmptyEnvironmentConditions() matcher.GomegaMatcher {
 
 	return expectedCondition(func(env appstudiosharedv1.Environment) bool {
+
+		fmt.Println("EmptyEnvironmentConditions, env.Status.Conditions is:", env.Status.Conditions)
+
 		return env.Status.Conditions == nil || len(env.Status.Conditions) == 0
 	})
 }


### PR DESCRIPTION
#### Description:
- Move some INFO-level log statements down to DEBUG, to reduce verbosity
- Move log text to constants to in log util package
- Remove spaces from log constant names
- Remove log context from log statements when that same log context is already being logged as part of the log object via `log.WithValues(...)`
- Change the param order of `deleteDbEntry`, to move the least specific params (dbqueries, log) to the end of the function signature

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
