### PR TITLE
Restrict repo server parallelism and git/kustomize run time

### DIFF
--- a/manifests/base/gitops-service-argocd/base/argo-cd.yaml
+++ b/manifests/base/gitops-service-argocd/base/argo-cd.yaml
@@ -147,16 +147,19 @@ spec:
     extraRepoCommandArgs:
       - --max-combined-directory-manifests-size
       - 10M
+      - --parallelismlimit
+      - "20"
     resources:
       limits:
         cpu: "1"
-        memory: 1Gi
+        memory: 2Gi
       requests:
-        cpu: 250m
-        memory: 256Mi
+        cpu: 500m
+        memory: 512Mi
     env:
     - name: ARGOCD_RECONCILIATION_TIMEOUT
       value: "60s"
+    execTimeout: 30
   server:
     logLevel: "debug"
     autoscale:


### PR DESCRIPTION
#### Description:
- Limit the number of parallel `git clone`/`kustomize` calls that can be running at any given time, so as to avoid OOM
- Limit `git clone`/`kustomize` calls to 30 seconds
- Raise the memory limit as we are close in some scenarios


#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
