### PR TITLE
GITOPSRVCE-704: Improve test coverage of 'application_event_runner.go' in backend component

### DIFF
--- a/backend/eventloop/application_event_loop/application_event_loop_test.go
+++ b/backend/eventloop/application_event_loop/application_event_loop_test.go
@@ -25,7 +25,7 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 		It("should forward messages received on the input channel, to the runner, without a response channel", func() {
 
 			mockApplicationEventLoopRunnerFactory := mockApplicationEventLoopRunnerFactory{
-				mockChannel: make(chan *eventlooptypes.EventLoopEvent),
+				mockChannel: make(chan eventlooptypes.EventLoopEvent),
 			}
 
 			aeqlParam := ApplicationEventQueueLoop{
@@ -94,10 +94,10 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 				activeSyncOperationEvent:   nil,
 				waitingSyncOperationEvents: []*RequestMessage{},
 
-				deploymentEventRunner:         make(chan *eventlooptypes.EventLoopEvent, 5),
+				deploymentEventRunner:         make(chan eventlooptypes.EventLoopEvent, 5),
 				deploymentEventRunnerShutdown: false,
 
-				syncOperationEventRunner:         make(chan *eventlooptypes.EventLoopEvent, 5),
+				syncOperationEventRunner:         make(chan eventlooptypes.EventLoopEvent, 5),
 				syncOperationEventRunnerShutdown: false,
 			}
 
@@ -128,7 +128,7 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 					Expect(shouldTerminate).To(BeFalse())
 
 					event := <-state.syncOperationEventRunner
-					Expect(event).To(Equal(newEvent.Message.Event))
+					Expect(event).To(Equal(*newEvent.Message.Event))
 					Expect(state.waitingSyncOperationEvents).To(BeEmpty())
 					Expect(state.activeSyncOperationEvent.Message).To(Equal(newEvent.Message))
 				})
@@ -191,7 +191,7 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 					Expect(shouldTerminate).To(BeFalse())
 
 					event := <-state.syncOperationEventRunner
-					Expect(event).To(Equal(newEvent.Message.Event))
+					Expect(event).To(Equal(*newEvent.Message.Event))
 					Expect(state.waitingSyncOperationEvents).To(BeEmpty())
 					Expect(state.activeSyncOperationEvent.Message).To(Equal(newEvent.Message))
 
@@ -236,7 +236,7 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 					Expect(shouldTerminate).To(BeFalse())
 
 					event := <-state.deploymentEventRunner
-					Expect(event).To(Equal(newEvent.Message.Event))
+					Expect(event).To(Equal(*newEvent.Message.Event))
 					Expect(state.waitingDeploymentEvents).To(BeEmpty())
 					Expect(state.activeDeploymentEvent.Message).To(Equal(newEvent.Message))
 				})
@@ -299,7 +299,7 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 					Expect(shouldTerminate).To(BeFalse())
 
 					event := <-state.deploymentEventRunner
-					Expect(event).To(Equal(newEvent.Message.Event))
+					Expect(event).To(Equal(*newEvent.Message.Event))
 					Expect(state.waitingDeploymentEvents).To(BeEmpty())
 					Expect(state.activeDeploymentEvent.Message).To(Equal(newEvent.Message))
 
@@ -346,7 +346,7 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 					Expect(shouldTerminate).To(BeFalse())
 
 					event := <-state.deploymentEventRunner
-					Expect(event).To(Equal(newEvent.Message.Event))
+					Expect(event).To(Equal(*newEvent.Message.Event))
 					Expect(state.waitingDeploymentEvents).To(BeEmpty())
 					Expect(state.activeDeploymentEvent.Message).To(Equal(newEvent.Message))
 
@@ -393,7 +393,7 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 					Expect(shouldTerminate).To(BeFalse())
 
 					event := <-state.deploymentEventRunner
-					Expect(event).To(Equal(newEvent.Message.Event))
+					Expect(event).To(Equal(*newEvent.Message.Event))
 					Expect(state.waitingDeploymentEvents).To(BeEmpty())
 					Expect(state.activeDeploymentEvent.Message).To(Equal(newEvent.Message))
 
@@ -497,7 +497,7 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 
 		It("should start a runner based on incoming GitOpsDeployment request ", func() {
 			mockApplicationEventLoopRunnerFactory := mockApplicationEventLoopRunnerFactory{
-				mockChannel: make(chan *eventlooptypes.EventLoopEvent),
+				mockChannel: make(chan eventlooptypes.EventLoopEvent),
 			}
 
 			startApplicationEventQueueLoopWithFactory(context.Background(), aeqlParam, &mockApplicationEventLoopRunnerFactory)
@@ -585,14 +585,14 @@ var _ = Describe("ApplicationEventLoop Tests", func() {
 
 // mockApplicationEventLoopRunnerFactory which returns a pre-provided channel, rather than starting a new goroutine.
 type mockApplicationEventLoopRunnerFactory struct {
-	mockChannel chan *eventlooptypes.EventLoopEvent
+	mockChannel chan eventlooptypes.EventLoopEvent
 }
 
 var _ applicationEventRunnerFactory = &mockApplicationEventLoopRunnerFactory{}
 
-func (fact *mockApplicationEventLoopRunnerFactory) createNewApplicationEventLoopRunner(informWorkCompleteChan chan RequestMessage,
+func (fact *mockApplicationEventLoopRunnerFactory) createNewApplicationEventLoopRunner(ctx context.Context, informWorkCompleteChan chan RequestMessage,
 	sharedResourceEventLoop *shared_resource_loop.SharedResourceEventLoop, gitopsDeplName string, gitopsDeplNamespace string,
-	workspaceID string, debugContext string) chan *eventlooptypes.EventLoopEvent {
+	workspaceID string, debugContext string, k8sFactory shared_resource_loop.SRLK8sClientFactory) chan eventlooptypes.EventLoopEvent {
 
 	return fact.mockChannel
 

--- a/backend/eventloop/application_event_loop/application_event_runner_deployments.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_deployments.go
@@ -247,7 +247,7 @@ func (a applicationEventLoopRunner_Action) handleNewGitOpsDeplEvent(ctx context.
 	if err != nil {
 
 		userError := "Unable to reconcile the ManagedEnvironment. Verify that the ManagedEnvironment and Secret are correctly defined, and have valid credentials"
-		devError := fmt.Errorf("unable to get or create managed environment, isworkspacetarget:%v: %v", isWorkspaceTarget, err)
+		devError := fmt.Errorf("unable to get or create managed environment, isworkspacetarget:%v: %w", isWorkspaceTarget, err)
 
 		return nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewUserDevError(userError, devError)
 
@@ -527,7 +527,7 @@ func (a applicationEventLoopRunner_Action) reconcileManagedEnvironmentOfGitOpsDe
 		a.k8sClientFactory, a.log)
 
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("unable to get or create managed environment when reconciling for GitOpsDeployment: %v", err)
+		return nil, nil, "", fmt.Errorf("unable to get or create managed environment when reconciling for GitOpsDeployment: %w", err)
 	}
 
 	var destinationName string
@@ -760,6 +760,7 @@ func (a applicationEventLoopRunner_Action) handleUpdatedGitOpsDeplEvent(ctx cont
 		err = fmt.Errorf("gitopsengineinstance namespace is nil, expected non-nil:  %s", engineInstance.Gitopsengineinstance_id)
 		return nil, nil, deploymentModifiedResult_Failed, gitopserrors.NewDevOnlyError(err)
 	}
+
 	k8sOperation, dbOperation, err := operations.CreateOperation(ctx, waitForOperation, dbOperationInput, clusterUser.Clusteruser_id,
 		engineInstance.Namespace_name, dbQueries, gitopsEngineClient, log)
 	if err != nil {

--- a/backend/eventloop/application_event_loop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_test.go
@@ -1412,7 +1412,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 
 			It("verifies the event is processed", func() {
 
-				By("creating a generic GitOpsDeployment of type manual sy=nc")
+				By("creating a generic GitOpsDeployment of type manual sync")
 
 				gitopsDepl := &managedgitopsv1alpha1.GitOpsDeployment{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1461,7 +1461,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 
 						applId := findDBApplicationIDforGitOpsDeployment(ctx, gitopsDeploymentName, gitopsDeploymentNamespace, *namespace)
 						if applId == "" {
-							fmt.Println("waitin for application for gitopsdepl")
+							fmt.Println("waiting for application for gitopsdepl")
 							time.Sleep(500 * time.Millisecond)
 							continue
 						}
@@ -1687,7 +1687,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 						// wait for Applicaton row to exist for GitopsDeployment
 						applId := findDBApplicationIDforGitOpsDeployment(ctx, gitopsDeploymentName, gitopsDeploymentNamespace, *namespace)
 						if applId == "" {
-							fmt.Println("waitin for application for gitopsdepl")
+							fmt.Println("waiting for application for gitopsdepl")
 							time.Sleep(250 * time.Millisecond)
 							continue
 						}
@@ -1839,7 +1839,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 
 						applId := findDBApplicationIDforGitOpsDeployment(ctx, gitopsDeploymentName, gitopsDeploymentNamespace, *namespace)
 						if applId == "" {
-							fmt.Println("waitin for application for gitopsdepl")
+							fmt.Println("waiting for application for gitopsdepl")
 							time.Sleep(500 * time.Millisecond)
 							continue
 						}

--- a/backend/eventloop/application_event_loop/metrics_test.go
+++ b/backend/eventloop/application_event_loop/metrics_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Test for Gitopsdeployment metrics counter", func() {
 				WorkspaceID: workspaceID,
 			}
 
-			shutdownSignalled, err := handleDeploymentModified(ctx, &eventLoopEvent, appEventLoopRunnerAction, dbQueries, log.FromContext(context.Background()))
+			shutdownSignalled, err := handleDeploymentModified(ctx, eventLoopEvent, appEventLoopRunnerAction, dbQueries, log.FromContext(context.Background()))
 			Expect(shutdownSignalled).To(BeFalse())
 
 			Expect(err).To(HaveOccurred())
@@ -130,7 +130,7 @@ var _ = Describe("Test for Gitopsdeployment metrics counter", func() {
 
 			err = k8sClient.Delete(ctx, gitopsDepl)
 			Expect(err).ToNot(HaveOccurred())
-			shutdownSignalled, err = handleDeploymentModified(ctx, &eventLoopEvent, appEventLoopRunnerAction, dbQueries, log.FromContext(context.Background()))
+			shutdownSignalled, err = handleDeploymentModified(ctx, eventLoopEvent, appEventLoopRunnerAction, dbQueries, log.FromContext(context.Background()))
 			Expect(shutdownSignalled).To(BeFalse())
 			Expect(err).ToNot(HaveOccurred())
 
@@ -216,7 +216,7 @@ var _ = Describe("Test for Gitopsdeployment metrics counter", func() {
 				WorkspaceID: workspaceID,
 			}
 
-			shutdownSignalled, err := handleDeploymentModified(ctx, &eventLoopEvent, appEventLoopRunnerAction, dbQueries, log.FromContext(context.Background()))
+			shutdownSignalled, err := handleDeploymentModified(ctx, eventLoopEvent, appEventLoopRunnerAction, dbQueries, log.FromContext(context.Background()))
 			Expect(shutdownSignalled).To(BeFalse())
 
 			Expect(err).ToNot(HaveOccurred())
@@ -229,7 +229,7 @@ var _ = Describe("Test for Gitopsdeployment metrics counter", func() {
 
 			err = k8sClient.Delete(ctx, gitopsDepl)
 			Expect(err).ToNot(HaveOccurred())
-			shutdownSignalled, err = handleDeploymentModified(ctx, &eventLoopEvent, appEventLoopRunnerAction, dbQueries, log.FromContext(context.Background()))
+			shutdownSignalled, err = handleDeploymentModified(ctx, eventLoopEvent, appEventLoopRunnerAction, dbQueries, log.FromContext(context.Background()))
 			Expect(shutdownSignalled).To(BeFalse())
 			Expect(err).ToNot(HaveOccurred())
 

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -764,13 +764,13 @@ func internalProcessMessage_GetOrCreateSharedResources(ctx context.Context, gito
 	clusterUser, isNewUser, err := internalProcessMessage_GetOrCreateClusterUserByNamespaceUID(ctx, workspaceNamespace, dbQueries, l)
 	if err != nil {
 		return SharedResourceManagedEnvContainer{}, createUnknownErrorEnvInitCondition(),
-			fmt.Errorf("unable to retrieve cluster user in processMessage, '%s': %v", string(workspaceNamespace.UID), err)
+			fmt.Errorf("unable to retrieve cluster user in processMessage, '%s': %w", string(workspaceNamespace.UID), err)
 	}
 
 	managedEnv, isNewManagedEnv, err := dbutil.GetOrCreateManagedEnvironmentByNamespaceUID(ctx, workspaceNamespace, dbQueries, l)
 	if err != nil {
 		return SharedResourceManagedEnvContainer{}, createUnknownErrorEnvInitCondition(),
-			fmt.Errorf("unable to get or created managed env on deployment modified event: %v", err)
+			fmt.Errorf("unable to get or created managed env on deployment modified event: %w", err)
 	}
 
 	engineInstance, isNewInstance, gitopsEngineCluster, uerr := internalDetermineGitOpsEngineInstance(ctx, *clusterUser, gitopsEngineClient, dbQueries, l)
@@ -821,14 +821,14 @@ func internalDetermineGitOpsEngineInstance(ctx context.Context, user db.ClusterU
 	// TODO: GITOPSRVCE-73 - Once we have a way to distribute work between Argo CD instances, update this function.
 	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: dbutil.GetGitOpsEngineSingleInstanceNamespace()}}
 	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
-		devError := fmt.Errorf("unable to retrieve gitopsengine namespace in determineGitOpsEngineInstanceForNewApplication: %w", err)
+		devError := fmt.Errorf("unable to retrieve gitopsengine namespace in internalDetermineGitOpsEngineInstanceForNewApplication: %w", err)
 		userMsg := gitopserrors.UnknownError
 		return nil, false, nil, gitopserrors.NewUserConditionError(userMsg, devError, string(managedgitopsv1alpha1.ConditionReasonKubeError))
 	}
 
 	kubeSystemNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}}
 	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(kubeSystemNamespace), kubeSystemNamespace); err != nil {
-		devError := fmt.Errorf("unable to retrieve kube-system namespace in determineGitOpsEngineInstanceForNewApplication: %w", err)
+		devError := fmt.Errorf("unable to retrieve kube-system namespace in internalDetermineGitOpsEngineInstanceForNewApplication: %w", err)
 		userMsg := gitopserrors.UnknownError
 		return nil, false, nil, gitopserrors.NewUserConditionError(userMsg, devError, string(managedgitopsv1alpha1.ConditionReasonKubeError))
 	}

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv.go
@@ -67,6 +67,8 @@ func internalProcessMessage_internalReconcileSharedManagedEnv(ctx context.Contex
 
 	log = log.WithValues("managedEnvCRName", managedEnvironmentCRName)
 
+	log.Info("reconciling reference to Managed Environment")
+
 	gitopsEngineClient, err := k8sClientFactory.GetK8sClientForGitOpsEngineInstance(ctx, nil)
 	if err != nil {
 		return newSharedResourceManagedEnvContainer(), createUnknownErrorEnvInitCondition(), err


### PR DESCRIPTION
#### Description:
- Vast majority of new work in this PR is in 'Generic Application Event Loop Runner tests' in `application_event_runner_test.go`
- The rest of the PR is just some misc refactoring:
    - In a couple cases, I changed `chan *eventlooptypes.EventLoopEvent` to `chan eventlooptypes.EventLoopEvent`, as it didn't make sense for these to be pointers.
    - Added context and factory parameters to ApplicationEventLoopRunner interface

#### Link to JIRA Story (if applicable): [GITOPSRVCE-704](https://issues.redhat.com/browse/GITOPSRVCE-704)
