### PR TITLE
Delete SEB when associated Application is deleted

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
@@ -126,12 +126,14 @@ func (r *SnapshotEnvironmentBindingReconciler) Reconcile(ctx context.Context, re
 		},
 	}
 	if err := rClient.Get(ctx, client.ObjectKeyFromObject(&application), &application); apierr.IsNotFound(err) {
-		err = rClient.Delete(ctx, binding)
-		if err != nil {
+
+		if err := rClient.Delete(ctx, &binding); err != nil {
 			return ctrl.Result{}, fmt.Errorf("unable to delete Binding %s in Namespace %s: %w", binding.Name, binding.Namespace, err)
 		}
+		log.Info("deleting SnapshotEnvironmentBinding because referenced Application no longer exists", "applicationName", application.Name)
 		logutil.LogAPIResourceChangeEvent(binding.Namespace, binding.Name, binding, logutil.ResourceDeleted, log)
 		return ctrl.Result{}, nil
+
 	} else if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error getting Application %s associated with Binding %s in Namespace %s: %w", binding.Spec.Application, binding.Name, binding.Namespace, err)
 	}

--- a/tests-e2e/appstudio/promotionrun_controller_seb_test.go
+++ b/tests-e2e/appstudio/promotionrun_controller_seb_test.go
@@ -17,6 +17,7 @@ var _ = Describe("Promotion Run Creation of SnapshotEnvironmentBinding E2E Tests
 	Context("Testing Promotion Run Creation of SnapshotEnvironmentBinding.", func() {
 		var environmentProd appstudiosharedv1.Environment
 		var promotionRun appstudiosharedv1.PromotionRun
+		var application appstudiosharedv1.Application
 		var k8sClient client.Client
 		var err error
 
@@ -34,6 +35,11 @@ var _ = Describe("Promotion Run Creation of SnapshotEnvironmentBinding E2E Tests
 			By("Create Production Environment.")
 			environmentProd = buildEnvironmentResource("prod", "Production Environment", "prod", appstudiosharedv1.EnvironmentType_POC)
 			err = k8s.Create(&environmentProd, k8sClient)
+			Expect(err).To(Succeed())
+
+			By("Create Application")
+			application = buildApplication("new-demo-app", fixture.GitOpsServiceE2ENamespace, fixture.RepoURL)
+			err = k8s.Create(&application, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Create Snapshot.")
@@ -89,7 +95,10 @@ var _ = Describe("Promotion Run Creation of SnapshotEnvironmentBinding E2E Tests
 
 		It("Creates a SnapshotEnvironmentBinding if one exists that targets the environment, but NOT the application.", func() {
 			By("Create binding targeting the environment but not the application.")
-			bindingApp := buildSnapshotEnvironmentBindingResource("appx-prod-binding", "app-x", "prod", "my-snapshot", 3, []string{"component-a"})
+			appx := buildApplication("app-x", fixture.GitOpsServiceE2ENamespace, fixture.RepoURL)
+			err = k8s.Create(&appx, k8sClient)
+			Expect(err).To(Succeed())
+			bindingApp := buildSnapshotEnvironmentBindingResource("appx-prod-binding", appx.Name, "prod", "my-snapshot", 3, []string{"component-a"})
 			err = k8s.Create(&bindingApp, k8sClient)
 			Expect(err).To(Succeed())
 

--- a/tests-e2e/appstudio/promotionrun_controller_test.go
+++ b/tests-e2e/appstudio/promotionrun_controller_test.go
@@ -22,6 +22,7 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 		var environmentProd appstudiosharedv1.Environment
 		var bindingStage appstudiosharedv1.SnapshotEnvironmentBinding
 		var bindingProd appstudiosharedv1.SnapshotEnvironmentBinding
+		var application appstudiosharedv1.Application
 		var promotionRun appstudiosharedv1.PromotionRun
 
 		BeforeEach(func() {
@@ -99,6 +100,11 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 			By("Create Production Environment.")
 			environmentProd = buildEnvironmentResource("prod", "Production Environment", "prod", appstudiosharedv1.EnvironmentType_POC)
 			err = k8s.Create(&environmentProd, k8sClient)
+			Expect(err).To(Succeed())
+
+			By("Create Application.")
+			application = buildApplication("new-demo-app", fixture.GitOpsServiceE2ENamespace, fixture.RepoURL)
+			err = k8s.Create(&application, k8sClient)
 			Expect(err).To(Succeed())
 
 			By("Create Snapshot.")

--- a/tests-e2e/appstudio/webhook_test.go
+++ b/tests-e2e/appstudio/webhook_test.go
@@ -145,6 +145,11 @@ var _ = Describe("Webhook E2E tests", func() {
 
 			ctx = context.Background()
 
+			By("Create Application.")
+			application := buildApplication("new-demo-app", fixture.GitOpsServiceE2ENamespace, fixture.RepoURL)
+			err = k8s.Create(&application, k8sClient)
+			Expect(err).To(Succeed())
+
 			By("Create SnapshotEnvironmentBindingResource.")
 			binding = buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})
 			err = k8s.Create(&binding, k8sClient)

--- a/tests-e2e/appstudio/webhook_test.go
+++ b/tests-e2e/appstudio/webhook_test.go
@@ -94,6 +94,12 @@ var _ = Describe("Webhook E2E tests", func() {
 				Skip("skipping as snapshotenvironmentbindings webhook is not installed")
 			}
 
+			By("Create Application.")
+
+			application := buildApplication("new-demo-app", fixture.GitOpsServiceE2ENamespace, fixture.RepoURL)
+			err = k8s.Create(&application, k8sClient)
+			Expect(err).To(Succeed())
+
 			By("Create SnapshotEnvironmentBindings")
 
 			binding = buildSnapshotEnvironmentBindingResource("appa-staging-binding", "new-demo-app", "staging", "my-snapshot", 3, []string{"component-a"})


### PR DESCRIPTION
#### Description:
- Delete the SnapshotEnvironmentBinding when the associated application is deleted.  Add unit and e2e tests for this.  Update existing tests which used to set the .spec.application field in the SEB without creating an application.

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-716

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
