### PR TITLE
Enable AppProject isolation for Makefile run targets

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -59,28 +59,28 @@ build: generate fmt vet ## Build manager binary.
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	DISABLE_APPSTUDIO_WEBHOOK=true go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
+	ENABLE_APPPROJECT_ISOLATION=true DISABLE_APPSTUDIO_WEBHOOK=true go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
 
 run-no-self-heal: manifests generate fmt vet ## Run a controller from your host.
-	SELF_HEAL_INTERVAL=0 DISABLE_APPSTUDIO_WEBHOOK=true go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
+	ENABLE_APPPROJECT_ISOLATION=true SELF_HEAL_INTERVAL=0 DISABLE_APPSTUDIO_WEBHOOK=true go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
 
 runexec: ## Run a controller from your host using exe in current folder
 ifeq (,$(wildcard ./main))
 runexec: manifests generate fmt vet
 	@echo Building and running backend
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build main.go
-	DISABLE_APPSTUDIO_WEBHOOK=true ./main --zap-log-level info --zap-time-encoding=rfc3339nano
+	ENABLE_APPPROJECT_ISOLATION=true DISABLE_APPSTUDIO_WEBHOOK=true ./main --zap-log-level info --zap-time-encoding=rfc3339nano
 else
 runexec:
 	@echo Running backend using existing main executable.
-	DISABLE_APPSTUDIO_WEBHOOK=true ./main --zap-log-level info --zap-time-encoding=rfc3339nano
+	ENABLE_APPPROJECT_ISOLATION=true DISABLE_APPSTUDIO_WEBHOOK=true ./main --zap-log-level info --zap-time-encoding=rfc3339nano
 endif
 
 # more on controller log level configuration: https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/
 
 chaos-run: manifests generate fmt vet ## Chaos Engineering: Simulate a controller that restarts every ~33 seconds.
 	go build -o /tmp/backend-manager-chaos  main.go
-	DISABLE_APPSTUDIO_WEBHOOK=true KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/backend-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
+	ENABLE_APPPROJECT_ISOLATION=true DISABLE_APPSTUDIO_WEBHOOK=true KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/backend-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
 	rm /tmp/backend-manager-chaos
 
 ##@ Deployment

--- a/cluster-agent/Makefile
+++ b/cluster-agent/Makefile
@@ -111,27 +111,27 @@ build: generate fmt vet ## Build manager binary.
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
+	ENABLE_APPPROJECT_ISOLATION=true go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
 # more on controller log level configuration: https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/
 
 run-no-self-heal: manifests generate fmt vet ## Run a controller from your host.
-	SELF_HEAL_INTERVAL=0 KUBECONFIG=${WORKLOAD_KUBECONFIG} go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
+	ENABLE_APPPROJECT_ISOLATION=true SELF_HEAL_INTERVAL=0 KUBECONFIG=${WORKLOAD_KUBECONFIG} go run ./main.go --zap-log-level info --zap-time-encoding=rfc3339nano
 
 runexec: ## Run a controller from your host using exe in current folder
 ifeq (,$(wildcard ./main))
 runexec: manifests generate fmt vet
 	@echo Building and running cluster-agent
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build ./main.go
-	main --zap-log-level info --zap-time-encoding=rfc3339nano
+	ENABLE_APPPROJECT_ISOLATION=true main --zap-log-level info --zap-time-encoding=rfc3339nano
 else
 runexec:
 	@echo Running cluster-agent using existing main executable.
-	 main --zap-log-level info --zap-time-encoding=rfc3339nano
+	 ENABLE_APPPROJECT_ISOLATION=true main --zap-log-level info --zap-time-encoding=rfc3339nano
 endif
 
 chaos-run: manifests generate fmt vet ## Chaos Engineering: Simulate a controller that restarts every ~33 seconds.
 	go build -o /tmp/cluster-agent-manager-chaos main.go
-	KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/cluster-agent-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
+	ENABLE_APPPROJECT_ISOLATION=true KILL_INTERVAL="45" KILL_INITIAL="10" ../utilities/random-kill.sh /tmp/cluster-agent-manager-chaos --zap-log-level info --zap-time-encoding=rfc3339nano
 	rm /tmp/cluster-agent-manager-chaos
 
 # docker-build: test ## Build docker image with the manager.


### PR DESCRIPTION
#### Description:
- A change was made recently (PR #643) to enable AppProject isolation for `make test-e2e`.  But it was not enabled for the run targets in the various Makefiles, so running locally using `make start-e2e` would cause some of the tests to fail

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
