### PR TITLE
Only call k8s client to update SnapshotEnvironmentBinding status when .status field has changed

### DIFF
--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller_test.go
@@ -487,7 +487,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			_, err = bindingReconciler.Reconcile(ctx, request)
 			Expect(err).ToNot(HaveOccurred())
 
-			checkStatusConditionOfEnvironmentBinding(ctx, bindingReconciler.Client, binding, "Can not Reconcile Binding 'appa-staging-binding', since GitOps Repo Conditions status is false.", metav1.ConditionFalse, SnapshotEnvironmentBindingReasonGitOpsRepoNotReady)
+			checkStatusConditionOfEnvironmentBinding(ctx, bindingReconciler.Client, binding, "Cannot Reconcile Binding 'appa-staging-binding', since GitOps Repo Conditions status is false.", metav1.ConditionFalse, SnapshotEnvironmentBindingReasonGitOpsRepoNotReady)
 		})
 
 		It("should update the previous binding condition status if there is no longer a repo condition error", func() {
@@ -506,7 +506,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler Tests", func() {
 			_, err = bindingReconciler.Reconcile(ctx, request)
 			Expect(err).ToNot(HaveOccurred())
 
-			checkStatusConditionOfEnvironmentBinding(ctx, bindingReconciler.Client, binding, "Can not Reconcile Binding 'appa-staging-binding', since GitOps Repo Conditions status is false.", metav1.ConditionFalse, SnapshotEnvironmentBindingReasonGitOpsRepoNotReady)
+			checkStatusConditionOfEnvironmentBinding(ctx, bindingReconciler.Client, binding, "Cannot Reconcile Binding 'appa-staging-binding', since GitOps Repo Conditions status is false.", metav1.ConditionFalse, SnapshotEnvironmentBindingReasonGitOpsRepoNotReady)
 
 			By("update the repo condition and verify if the binding condition is updated")
 			binding.Status.GitOpsRepoConditions = []metav1.Condition{


### PR DESCRIPTION
#### Description:
- I happened to notice that on RHTAP cluster we were making way too many status updates to `SnapshotEnvironmentBinding` CR, despite no obvious changes. 
    - This code change should help reduce that, by only updating the status when it has changed, and using a more deterministic generation algorithm that does not rely on Go map key ordering
- Only call `k8sClient.Update` to update the `SnapshotEnvironmentBinding` status IF the contents of the .status field actually changed (otherwise skip)
- Process the component names in alphabetical order, so that the generated status is consistent (deterministic) from run to run
- Misc tweaks:
    - Tweak the pointer usage on `SnapshotEnvironmentBinding`
    - `Can not` -> `Cannot`

#### Link to JIRA Story (if applicable):

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
