### PR TITLE
GITOPSRVCE-767: fix interimittent failure in workspace_resource_event_loop_test.go

### DIFF
--- a/backend/eventloop/workspace_resource_event_loop_test.go
+++ b/backend/eventloop/workspace_resource_event_loop_test.go
@@ -317,8 +317,11 @@ var _ = Describe("Test Workspace Resource Loop", func() {
 
 				Expect(shouldRetry).To(BeTrue())
 				Expect(err).To(HaveOccurred())
-				expectedErr := "unable to reconcile shared managed env: context cancelled in GetOrCreateSharedManagedEnv"
-				Expect(err).To(Equal(resourceLoopErr(expectedErr)))
+
+				Expect(err.Error()).To(SatisfyAny(
+					Equal(resourceLoopErr("unable to reconcile shared managed env: context cancelled in GetOrCreateSharedManagedEnv").Error()),
+					ContainSubstring("error on retrieving GetClusterUserByUsername: context deadline exceeded")))
+
 			})
 		})
 
@@ -371,8 +374,11 @@ var _ = Describe("Test Workspace Resource Loop", func() {
 
 				Expect(shouldRetry).To(BeTrue())
 				Expect(err).To(HaveOccurred())
-				expectedErr := "unable to reconcile repository credential. Error: context cancelled in ReconcileRepositoryCredential"
-				Expect(err).To(Equal(resourceLoopErr(expectedErr)))
+
+				Expect(err.Error()).To(SatisfyAny(
+					Equal(resourceLoopErr("unable to reconcile repository credential. Error: context cancelled in ReconcileRepositoryCredential").Error()),
+					ContainSubstring("error on retrieving GetClusterUserByUsername: context deadline exceeded")))
+
 			})
 		})
 	})


### PR DESCRIPTION
#### Description:
- Intermittent, a different a error string is returned, due to where the context cancelled is recognized. 
- This PR updates the error string to handle both cases.

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-767

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
