### PR TITLE
GITOPSRVCE-771: re-enable environment webhook

### DIFF
--- a/appstudio-controller/config/webhook/manifests.yaml
+++ b/appstudio-controller/config/webhook/manifests.yaml
@@ -67,23 +67,23 @@ webhooks:
     resources:
     - promotionruns
   sideEffects: None
-# - admissionReviewVersions:
-#   - v1
-#   clientConfig:
-#     service:
-#       name: webhook-service
-#       namespace: system
-#       path: /validate-appstudio-redhat-com-v1alpha1-environment
-#   failurePolicy: Fail
-#   name: venvironment.kb.io
-#   rules:
-#   - apiGroups:
-#     - appstudio.redhat.com
-#     apiVersions:
-#     - v1alpha1
-#     operations:
-#     - CREATE
-#     - UPDATE
-#     resources:
-#     - environments
-#   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-appstudio-redhat-com-v1alpha1-environment
+  failurePolicy: Fail
+  name: venvironment.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - environments
+  sideEffects: None


### PR DESCRIPTION
#### Description:
- Re-enable environment webhook after it was previously disabled, see 771 for details.

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-771

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
