### PR TITLE
GITOPSRVCE-778: only create operations for missing external cluster secrets

### DIFF
--- a/backend-shared/db/clusteraccess_test.go
+++ b/backend-shared/db/clusteraccess_test.go
@@ -42,7 +42,7 @@ var _ = Describe("ClusterAccess Tests", func() {
 			Host:                        "host",
 			Kube_config:                 "kube-config",
 			Kube_config_context:         "kube-config-context",
-			Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+			Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 			Serviceaccount_ns:           "Serviceaccount_ns",
 		}
 
@@ -137,7 +137,7 @@ var _ = Describe("ClusterAccess Tests", func() {
 				Host:                        "host",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 			err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)

--- a/backend-shared/db/clustercredentials.go
+++ b/backend-shared/db/clustercredentials.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 )
 
+const (
+	DefaultServiceaccount_bearer_token = "serviceaccount_bearer_token"
+)
+
 func (dbq *PostgreSQLDatabaseQueries) UnsafeListAllClusterCredentials(ctx context.Context, clusterCredentials *[]ClusterCredentials) error {
 	if dbq.dbConnection == nil {
 		return fmt.Errorf("database connection is nil")

--- a/backend-shared/db/gitopsenginecluster_test.go
+++ b/backend-shared/db/gitopsenginecluster_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Gitopsenginecluster Test", func() {
 			Host:                        "host",
 			Kube_config:                 "kube-config",
 			Kube_config_context:         "kube-config-context",
-			Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+			Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 			Serviceaccount_ns:           "Serviceaccount_ns",
 		}
 
@@ -92,7 +92,7 @@ var _ = Describe("Gitopsenginecluster Test", func() {
 			Host:                        "host",
 			Kube_config:                 "kube-config",
 			Kube_config_context:         "kube-config-context",
-			Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+			Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 			Serviceaccount_ns:           "Serviceaccount_ns",
 		}
 		err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)

--- a/backend-shared/db/gitopsengineinstance_test.go
+++ b/backend-shared/db/gitopsengineinstance_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Gitopsengineinstance Test", func() {
 			Host:                        "host",
 			Kube_config:                 "kube-config",
 			Kube_config_context:         "kube-config-context",
-			Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+			Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 			Serviceaccount_ns:           "Serviceaccount_ns",
 		}
 

--- a/backend-shared/db/guardrow_test.go
+++ b/backend-shared/db/guardrow_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Test to verify update/delete operations are not globally scope
 				Host:                        "host",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 
@@ -256,7 +256,7 @@ var _ = Describe("Test to verify update/delete operations are not globally scope
 				Host:                        "host",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 
@@ -436,7 +436,7 @@ var _ = Describe("Test to verify update/delete operations are not globally scope
 				Host:                        "host",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 
@@ -456,7 +456,7 @@ var _ = Describe("Test to verify update/delete operations are not globally scope
 				Host:                        "host",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 
@@ -488,7 +488,7 @@ var _ = Describe("Test to verify update/delete operations are not globally scope
 				Host:                        "host",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 
@@ -517,7 +517,7 @@ var _ = Describe("Test to verify update/delete operations are not globally scope
 				Host:                        "host",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 
@@ -596,7 +596,7 @@ var _ = Describe("Test to verify update/delete operations are not globally scope
 				Host:                        "host",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 
@@ -617,7 +617,7 @@ var _ = Describe("Test to verify update/delete operations are not globally scope
 				Host:                        "host",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 

--- a/backend-shared/db/injection_test.go
+++ b/backend-shared/db/injection_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Injection Test", func() {
 			Host:                        "host",
 			Kube_config:                 "kube-config",
 			Kube_config_context:         "kube-config-context",
-			Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+			Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 			Serviceaccount_ns:           "Serviceaccount_ns",
 		}
 
@@ -124,7 +124,7 @@ var _ = Describe("Injection Test", func() {
 			Host:                        "host",
 			Kube_config:                 "kube-config",
 			Kube_config_context:         "kube-config-context",
-			Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+			Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 			Serviceaccount_ns:           "Serviceaccount_ns",
 		}
 
@@ -178,7 +178,7 @@ var _ = Describe("Injection Test", func() {
 			Host:                        "host",
 			Kube_config:                 "kube-config",
 			Kube_config_context:         "kube-config-context",
-			Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+			Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 			Serviceaccount_ns:           "Serviceaccount_ns",
 		}
 

--- a/backend-shared/db/managedenvironment_test.go
+++ b/backend-shared/db/managedenvironment_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Managedenvironment Test", func() {
 			Host:                        "host",
 			Kube_config:                 "kube-config",
 			Kube_config_context:         "kube-config-context",
-			Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+			Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 			Serviceaccount_ns:           "Serviceaccount_ns",
 		}
 
@@ -138,7 +138,7 @@ var _ = Describe("Managedenvironment Test", func() {
 			Host:                        "host",
 			Kube_config:                 "kube-config",
 			Kube_config_context:         "kube-config-context",
-			Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+			Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 			Serviceaccount_ns:           "Serviceaccount_ns",
 		}
 		err = dbq.CreateClusterCredentials(ctx, &clusterCredentials)

--- a/backend-shared/db/test_utils.go
+++ b/backend-shared/db/test_utils.go
@@ -54,7 +54,7 @@ func generateSampleData() (ClusterCredentials, ManagedEnvironment, GitopsEngineC
 		Host:                        "host",
 		Kube_config:                 "kube-config",
 		Kube_config_context:         "kube-config-context",
-		Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+		Serviceaccount_bearer_token: DefaultServiceaccount_bearer_token,
 		Serviceaccount_ns:           "Serviceaccount_ns",
 	}
 

--- a/backend-shared/db/types_test.go
+++ b/backend-shared/db/types_test.go
@@ -317,7 +317,7 @@ var _ = Describe("Types Test", func() {
 				Host:                        "host",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 

--- a/backend-shared/db/util/utils.go
+++ b/backend-shared/db/util/utils.go
@@ -110,7 +110,7 @@ func GetOrCreateManagedEnvironmentByNamespaceUID(ctx context.Context, namespace 
 		Host:                        "host",
 		Kube_config:                 "kube_config",
 		Kube_config_context:         "kube_config_context",
-		Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+		Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 		Serviceaccount_ns:           "serviceaccount_ns",
 	}
 
@@ -395,7 +395,7 @@ func GetOrCreateGitopsEngineClusterByKubeSystemNamespaceUID(ctx context.Context,
 		Host:                        "host",
 		Kube_config:                 "kube_config",
 		Kube_config_context:         "kube_config_context",
-		Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+		Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 		Serviceaccount_ns:           "serviceaccount_ns",
 	}
 	if err := dbq.CreateClusterCredentials(ctx, &clusterCreds); err != nil {

--- a/backend-shared/db/util/utils_test.go
+++ b/backend-shared/db/util/utils_test.go
@@ -245,7 +245,7 @@ var _ = Describe("Test utility functions.", func() {
 				Host:                        "host",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 			err = dbQueries.CreateClusterCredentials(ctx, &clusterCredentials)
@@ -921,7 +921,7 @@ var _ = Describe("Test utility functions.", func() {
 				Host:                        "host",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 

--- a/backend/eventloop/application_event_loop/application_event_runner_test.go
+++ b/backend/eventloop/application_event_loop/application_event_runner_test.go
@@ -633,7 +633,7 @@ var _ = Describe("ApplicationEventLoop Test", func() {
 				Host:                        "host",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 

--- a/backend/eventloop/db_reconciler_test.go
+++ b/backend/eventloop/db_reconciler_test.go
@@ -316,7 +316,7 @@ var _ = Describe("DB Clean-up Function Tests", func() {
 					Host:                        "host",
 					Kube_config:                 "kube-config",
 					Kube_config_context:         "kube-config-context",
-					Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+					Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 					Serviceaccount_ns:           "Serviceaccount_ns",
 				}
 				err = dbq.CreateClusterCredentials(ctx, &clusterCredentialsDb)
@@ -1638,7 +1638,7 @@ var _ = Describe("DB Clean-up Function Tests", func() {
 				Host:                        "host",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 			err = dbq.CreateClusterCredentials(ctx, &clusterCredentialsDb)

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv_test.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop_managedenv_test.go
@@ -1471,7 +1471,7 @@ var _ = Describe("SharedResourceEventLoop ManagedEnvironment-related Test", func
 				Host:                        "host",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 			err = dbQueries.CreateClusterCredentials(ctx, &clusterCredentialsDb)

--- a/cluster-agent/controllers/argoproj.io/application_controller_test.go
+++ b/cluster-agent/controllers/argoproj.io/application_controller_test.go
@@ -924,7 +924,7 @@ func generateSampleData() (db.ClusterCredentials, db.ManagedEnvironment, db.Gito
 		Host:                        "host",
 		Kube_config:                 "kube-config",
 		Kube_config_context:         "kube-config-context",
-		Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+		Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 		Serviceaccount_ns:           "Serviceaccount_ns",
 	}
 

--- a/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop_test.go
+++ b/cluster-agent/controllers/managed-gitops/eventloop/operation_event_loop_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Operation Controller", func() {
 				Host:                        "https://my-cluster-url.com",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 			err := dbQueries.CreateClusterCredentials(ctx, &clusterCredentials)
@@ -153,7 +153,7 @@ var _ = Describe("Operation Controller", func() {
 				Host:                        "https://my-cluster-url.com?queryParameter=hello",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 			err := dbQueries.CreateClusterCredentials(ctx, &clusterCredentials)
@@ -210,7 +210,7 @@ var _ = Describe("Operation Controller", func() {
 				Host:                        "https://my-cluster-url.com",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 			err := dbQueries.CreateClusterCredentials(ctx, &clusterCredentials)
@@ -262,7 +262,7 @@ var _ = Describe("Operation Controller", func() {
 				Host:                        "https://my-cluster-url.com",
 				Kube_config:                 "kube-config",
 				Kube_config_context:         "kube-config-context",
-				Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+				Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 				Serviceaccount_ns:           "Serviceaccount_ns",
 			}
 			err := dbQueries.CreateClusterCredentials(ctx, &clusterCredentials)
@@ -2878,7 +2878,7 @@ var _ = Describe("Operation Controller", func() {
 					Host:                        "host",
 					Kube_config:                 "kube_config",
 					Kube_config_context:         "kube_config_context",
-					Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+					Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 					Serviceaccount_ns:           "serviceaccount_ns",
 				}
 

--- a/utilities/db-migration/migration_test/add_test_values/add_db_values.go
+++ b/utilities/db-migration/migration_test/add_test_values/add_db_values.go
@@ -16,7 +16,7 @@ var (
 		Host:                        "host",
 		Kube_config:                 "kube-config",
 		Kube_config_context:         "kube-config-context",
-		Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+		Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 		Serviceaccount_ns:           "Serviceaccount_ns",
 		Namespaces:                  "namespaceA",
 		ClusterResources:            true,
@@ -39,7 +39,7 @@ var (
 		Host:                        "host",
 		Kube_config:                 "kube-config",
 		Kube_config_context:         "kube-config-context",
-		Serviceaccount_bearer_token: "serviceaccount_bearer_token",
+		Serviceaccount_bearer_token: db.DefaultServiceaccount_bearer_token,
 		Serviceaccount_ns:           "Serviceaccount_ns",
 	}
 


### PR DESCRIPTION
#### Description:
- At present, in cluster-agent's namespace_reconciler.go, in recreateClusterSecrets, we are iterating through the list of ManagedEnvironments looking for those that do not have a corresponding Argo CD Cluster Secret.
- However, there exist many ManagedEnvironment rows that do not require a cluster secret: any managed environment that corresponds to a '*_tenant' Namespace on the cluster does not require an Argo CD cluster secret. Why? Because Argo CD by default already has the credentials needed to read/write from any namespace on the that it is deployed to.
- We can thus update logic in 'recreateClusterSecrets' to avoid creating Operations for ManagedEnvironments/Applications that target the same cluster as Argo CD.

This PR:
- moves `"serviceaccount_bearer_token"` to a string constant
- skips creating Argo CD Cluster secret in `recreateClusterSecrets` for ManagedEnvironents that have a default serviceaccount_bearer_token 
- adds a new test case to verify this case
 
#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-778

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
