### PR TITLE
GITOPSRVCE-731: add server name to DB TLS conn info

### DIFF
--- a/backend-shared/db/postgres-integration.go
+++ b/backend-shared/db/postgres-integration.go
@@ -57,6 +57,7 @@ func ConnectToDatabaseWithPort(verbose bool, port int) (*pg.DB, error) {
 	if value, isSet := os.LookupEnv("DEV_ONLY_ALLOW_NON_TLS_CONNECTION_TO_POSTGRESQL"); !isSet || strings.ToLower(value) != "true" {
 		opts.TLSConfig = &tls.Config{
 			MinVersion: tls.VersionTLS12,
+			ServerName: addr,
 		}
 	}
 


### PR DESCRIPTION
#### Description:

When I merged GITOSRVCE-731 to staging, I got this error, so this PR should address that:

```
{
  "level": "error",
  "ts": "2023-10-17T09:26:46.991188015Z",
  "caller": "util/util.go:117",
  "msg": "NewProductionPostgresDBQueries: tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config, unable to connect to database: Host:'multi-tenant-staging-gitopsvc.cksigd96yuso.us-east-1.rds.amazonaws.com:5432' User:'postgres' DB:'postgres' ",
  "error": "tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config, unable to connect to database: Host:'multi-tenant-staging-gitopsvc.cksigd96yuso.us-east-1.rds.amazonaws.com:5432' User:'postgres' DB:'postgres' ",
  "stacktrace": "github.com/redhat-appstudio/managed-gitops/backend-shared/util.RunTaskUntilTrue\n /workspace/backend-shared/util/util.go:117\ngithub.com/redhat-appstudio/managed-gitops/backend-shared/db.internalNewProductionPostgresDBQueriesWithPort\n /workspace/backend-shared/db/queries.go:425\ngithub.com/redhat-appstudio/managed-gitops/backend-shared/db.NewSharedProductionPostgresDBQueries\n /workspace/backend-shared/db/queries.go:400\nmain.startDBReconciler\n /workspace/backend/main.go:221\nmain.main\n /workspace/backend/main.go:191\nruntime.main\n /usr/local/go/src/runtime/proc.go:267"
}
```


#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-731

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
