### PR TITLE
GITOPSRVCE-723: Better secure dev postgresql instance

### DIFF
--- a/manifests/base/postgresql-staging/postgresql-staging.yaml
+++ b/manifests/base/postgresql-staging/postgresql-staging.yaml
@@ -105,6 +105,13 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           env:
             - name: POSTGRESQL_DATABASE
               value: postgres
@@ -140,13 +147,21 @@ spec:
             failureThreshold: 6
           volumeMounts:
             - name: data
-              mountPath: /var/lib/pgsql/data
+              mountPath: /var/lib/pgsql
             - name: dshm
               mountPath: /dev/shm
+            - name: tmp
+              mountPath: /tmp
+            - name: runpostgresql
+              mountPath: /run/postgresql
       volumes:
         - name: dshm
           emptyDir:
             medium: Memory
+        - name: tmp
+          emptyDir: {}
+        - name: runpostgresql
+          emptyDir: {}
   volumeClaimTemplates:
     - metadata:
         name: data


### PR DESCRIPTION
#### Description:
- Postgresql dev container should not run as root, and should use a readonly FS

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-723
