### PR TITLE
Fix invalid SEVERE log entry by only checking field (rather than pointer) of event.Message.Event in app event loop

### DIFF
--- a/backend/eventloop/application_event_loop/application_event_loop.go
+++ b/backend/eventloop/application_event_loop/application_event_loop.go
@@ -306,10 +306,11 @@ func processApplicationEventQueueLoopMessage(ctx context.Context, newEvent Reque
 		} else if eventLoopMessage.ReqResource == eventlooptypes.GitOpsDeploymentTypeName ||
 			eventLoopMessage.ReqResource == eventlooptypes.GitOpsDeploymentManagedEnvironmentTypeName {
 
-			if state.activeDeploymentEvent.Message.Event != newEvent.Message.Event {
+			if mismatchingField := eventlooptypes.EventsMatch(state.activeDeploymentEvent.Message.Event, newEvent.Message.Event); mismatchingField != "" {
 				log.Error(nil, "SEVERE: unmatched deployment event work item",
-					"activeDeploymentEvent", eventlooptypes.StringEventLoopEvent(state.activeDeploymentEvent.Message.Event))
+					"activeDeploymentEvent", eventlooptypes.StringEventLoopEvent(state.activeDeploymentEvent.Message.Event), "newEvent", "activeDeploymentEvent", eventlooptypes.StringEventLoopEvent(newEvent.Message.Event), "mismatchingField", mismatchingField)
 			}
+
 			state.activeDeploymentEvent = nil
 
 			state.deploymentEventRunnerShutdown = newEvent.Message.ShutdownSignalled
@@ -319,10 +320,12 @@ func processApplicationEventQueueLoopMessage(ctx context.Context, newEvent Reque
 
 		} else if eventLoopMessage.ReqResource == eventlooptypes.GitOpsDeploymentSyncRunTypeName {
 
-			if state.activeSyncOperationEvent.Message.Event != newEvent.Message.Event {
+			if mismatchingField := eventlooptypes.EventsMatch(state.activeSyncOperationEvent.Message.Event, newEvent.Message.Event); mismatchingField != "" {
 				log.Error(nil, "SEVERE: unmatched sync operation event work item",
-					"activeSyncOperationEvent", eventlooptypes.StringEventLoopEvent(state.activeSyncOperationEvent.Message.Event))
+					"activeSyncOperationEvent", eventlooptypes.StringEventLoopEvent(state.activeSyncOperationEvent.Message.Event),
+					"newEvent", eventlooptypes.StringEventLoopEvent(newEvent.Message.Event), "mismatchingField", mismatchingField)
 			}
+
 			state.activeSyncOperationEvent = nil
 			state.syncOperationEventRunnerShutdown = newEvent.Message.ShutdownSignalled
 			if state.syncOperationEventRunnerShutdown {

--- a/backend/eventloop/eventlooptypes/types.go
+++ b/backend/eventloop/eventlooptypes/types.go
@@ -46,6 +46,40 @@ type EventLoopEvent struct {
 	WorkspaceID string
 }
 
+// EventsMatch returns "" if the events match, otherwise returns a string indicating which field did not match
+func EventsMatch(one *EventLoopEvent, two *EventLoopEvent) string {
+	if one == nil && two == nil {
+		return ""
+	}
+
+	if (one == nil && two != nil) || (one != nil && two == nil) {
+		return "nil mismatch"
+	}
+
+	if one.EventType != two.EventType {
+		return "eventtype mismatch"
+	}
+
+	if one.ReqResource != two.ReqResource {
+		return "reqresource mismatch"
+	}
+
+	if one.Request.Name != two.Request.Name {
+		return "request name mismatch"
+	}
+
+	if one.Request.Namespace != two.Request.Namespace {
+		return "request namespace mismatch"
+	}
+
+	if one.WorkspaceID != two.WorkspaceID {
+		return "workspaceid mismatch"
+	}
+
+	return ""
+
+}
+
 // Packages an EventLoopEvent as a message between event loop channels.
 // - The type of messages depends on the MessageType
 type EventLoopMessage struct {

--- a/backend/eventloop/eventlooptypes/types_test.go
+++ b/backend/eventloop/eventlooptypes/types_test.go
@@ -1,0 +1,97 @@
+package eventlooptypes
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("eventlooptypes test", func() {
+	Context("eventsMatch", func() {
+
+		DescribeTable("eventsMatch unit tests", func(one *EventLoopEvent, two *EventLoopEvent, expectedResult string) {
+			res := EventsMatch(one, two)
+			Expect(res).To(Equal(expectedResult))
+		},
+			Entry("both params are nil", nil, nil, ""),
+			Entry("first param is nil", nil, &EventLoopEvent{}, "nil mismatch"),
+			Entry("second param is nil", &EventLoopEvent{}, nil, "nil mismatch"),
+
+			Entry("mismatching event type", &EventLoopEvent{
+				EventType: DeploymentModified,
+			}, &EventLoopEvent{
+				EventType: ManagedEnvironmentModified,
+			}, "eventtype mismatch"),
+
+			Entry("mismatching reqresource", &EventLoopEvent{
+				EventType:   DeploymentModified,
+				ReqResource: GitOpsDeploymentManagedEnvironmentTypeName,
+			}, &EventLoopEvent{
+				EventType:   DeploymentModified,
+				ReqResource: GitOpsDeploymentRepositoryCredentialTypeName,
+			}, "reqresource mismatch"),
+
+			Entry("mismatching request name", &EventLoopEvent{
+				EventType:   DeploymentModified,
+				ReqResource: GitOpsDeploymentManagedEnvironmentTypeName,
+				Request: ctrl.Request{
+					NamespacedName: types.NamespacedName{Namespace: "namespace", Name: "name"},
+				},
+			}, &EventLoopEvent{
+				EventType:   DeploymentModified,
+				ReqResource: GitOpsDeploymentManagedEnvironmentTypeName,
+				Request: ctrl.Request{
+					NamespacedName: types.NamespacedName{Namespace: "namespace", Name: "name2"},
+				},
+			}, "request name mismatch"),
+
+			Entry("mismatching request namespace", &EventLoopEvent{
+				EventType:   DeploymentModified,
+				ReqResource: GitOpsDeploymentManagedEnvironmentTypeName,
+				Request: ctrl.Request{
+					NamespacedName: types.NamespacedName{Namespace: "namespace2", Name: "name"},
+				},
+			}, &EventLoopEvent{
+				EventType:   DeploymentModified,
+				ReqResource: GitOpsDeploymentManagedEnvironmentTypeName,
+				Request: ctrl.Request{
+					NamespacedName: types.NamespacedName{Namespace: "namespace", Name: "name"},
+				},
+			}, "request namespace mismatch"),
+
+			Entry("mismatching workspace", &EventLoopEvent{
+				EventType:   DeploymentModified,
+				ReqResource: GitOpsDeploymentManagedEnvironmentTypeName,
+				Request: ctrl.Request{
+					NamespacedName: types.NamespacedName{Namespace: "namespace", Name: "name"},
+				},
+				WorkspaceID: "one",
+			}, &EventLoopEvent{
+				EventType:   DeploymentModified,
+				ReqResource: GitOpsDeploymentManagedEnvironmentTypeName,
+				Request: ctrl.Request{
+					NamespacedName: types.NamespacedName{Namespace: "namespace", Name: "name"},
+				},
+				WorkspaceID: "two",
+			}, "workspaceid mismatch"),
+
+			Entry("should match", &EventLoopEvent{
+				EventType:   DeploymentModified,
+				ReqResource: GitOpsDeploymentManagedEnvironmentTypeName,
+				Request: ctrl.Request{
+					NamespacedName: types.NamespacedName{Namespace: "namespace", Name: "name"},
+				},
+				WorkspaceID: "one",
+			}, &EventLoopEvent{
+				EventType:   DeploymentModified,
+				ReqResource: GitOpsDeploymentManagedEnvironmentTypeName,
+				Request: ctrl.Request{
+					NamespacedName: types.NamespacedName{Namespace: "namespace", Name: "name"},
+				},
+				WorkspaceID: "one",
+			}, ""),
+		)
+
+	})
+})

--- a/cluster-agent/controllers/managed-gitops/operation_controller.go
+++ b/cluster-agent/controllers/managed-gitops/operation_controller.go
@@ -121,7 +121,9 @@ func (g *garbageCollector) startGarbageCollectionCycle() {
 				return nil
 			})
 
-			log.Error(err, "error in garbage collector")
+			if err != nil {
+				log.Error(err, "error in garbage collector")
+			}
 
 		}
 	}()


### PR DESCRIPTION
#### Description:
- As part of [GITOPSRVCE-704](https://issues.redhat.com//browse/GITOPSRVCE-704) I converted some pointer fields to objects, however there were a couple SEVERE error logs that were checking the pointer.
- Fix invalid SEVERE log entry by only checking field (rather than pointer) of event.Message.Event in app event loop

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-704

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
