### PR TITLE
GITOPSRVCE-731: Add Amazon CA root certs, re-enable TLS verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,11 @@ WORKDIR /
 RUN mkdir -p /migrations
 RUN mkdir -p /init-container
 
+# Add Amazon public CA certs to system root CA, to allow us to validate Amazon RDS TLS connections.
+# - More information on Amazon TLS certs is available here: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html
+RUN curl -o /etc/pki/ca-trust/source/anchors/global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
+	&& update-ca-trust
+
 # Copy both the controller binaries into the $PATH so they can be invoked
 COPY --from=builder workspace/backend/bin/manager /usr/local/bin/gitops-service-backend
 COPY --from=builder workspace/cluster-agent/bin/manager /usr/local/bin/gitops-service-cluster-agent

--- a/backend-shared/db/postgres-integration.go
+++ b/backend-shared/db/postgres-integration.go
@@ -60,8 +60,6 @@ func ConnectToDatabaseWithPort(verbose bool, port int) (*pg.DB, error) {
 			MinVersion: tls.VersionTLS12,
 			ServerName: addr,
 		}
-
-		opts.TLSConfig.InsecureSkipVerify = true /* #nosec G402 */
 	}
 
 	db := pg.Connect(opts)


### PR DESCRIPTION
#### Description:
- Automatically acquire the latest Amazon CA root certs, and add them to the system store within the container
- Re-enable TLS verification, to valid RDS instances using those certificates

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-731

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
