### PR TITLE
Move webhooks to GitOps-Service.

### DIFF
--- a/appstudio-controller/config/default-no-prometheus/kustomization.yaml
+++ b/appstudio-controller/config/default-no-prometheus/kustomization.yaml
@@ -42,7 +42,7 @@ patchesStrategicMerge:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:

--- a/appstudio-controller/config/default-no-prometheus/webhookcainjection_patch.yaml
+++ b/appstudio-controller/config/default-no-prometheus/webhookcainjection_patch.yaml
@@ -1,0 +1,15 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+#apiVersion: admissionregistration.k8s.io/v1
+#kind: MutatingWebhookConfiguration
+#metadata:
+#  name: mutating-webhook-configuration
+#  annotations:
+#    service.beta.openshift.io/inject-cabundle: "true"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/appstudio-controller/config/default/kustomization.yaml
+++ b/appstudio-controller/config/default/kustomization.yaml
@@ -42,7 +42,7 @@ patchesStrategicMerge:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:

--- a/appstudio-controller/config/webhook/manifests.yaml
+++ b/appstudio-controller/config/webhook/manifests.yaml
@@ -3,8 +3,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
 webhooks:
 - admissionReviewVersions:
   - v1

--- a/appstudio-controller/config/webhook/manifests.yaml
+++ b/appstudio-controller/config/webhook/manifests.yaml
@@ -2,11 +2,51 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
 webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-appstudio-redhat-com-v1alpha1-environment
+  failurePolicy: Fail
+  name: venvironment.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - environments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-appstudio-redhat-com-v1alpha1-promotionrun
+  failurePolicy: Fail
+  name: vpromotionrun.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - promotionruns
+  sideEffects: None
 - admissionReviewVersions:
   - v1
   clientConfig:
@@ -46,44 +86,4 @@ webhooks:
     - UPDATE
     resources:
     - snapshotenvironmentbindings
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-appstudio-redhat-com-v1alpha1-promotionrun
-  failurePolicy: Fail
-  name: vpromotionrun.kb.io
-  rules:
-  - apiGroups:
-    - appstudio.redhat.com
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - promotionruns
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-appstudio-redhat-com-v1alpha1-environment
-  failurePolicy: Fail
-  name: venvironment.kb.io
-  rules:
-  - apiGroups:
-    - appstudio.redhat.com
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - environments
   sideEffects: None

--- a/appstudio-controller/controllers/webhooks/environment_webhook.go
+++ b/appstudio-controller/controllers/webhooks/environment_webhook.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/go-logr/logr"
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Webhook describes the data structure for the release webhook
+type EnvironmentWebhook struct {
+	client client.Client
+	log    logr.Logger
+}
+
+// change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-environment,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=environments,verbs=create;update,versions=v1alpha1,name=venvironment.kb.io,admissionReviewVersions={v1,v1beta1}
+
+func (w *EnvironmentWebhook) Register(mgr ctrl.Manager, log *logr.Logger) error {
+
+	w.client = mgr.GetClient()
+	w.log = *log
+
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&appstudiov1alpha1.Environment{}).
+		WithValidator(w).
+		Complete()
+}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *EnvironmentWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+
+	app := obj.(*appstudiov1alpha1.Environment)
+
+	log := r.log.WithName("environment-webhook-create").
+		WithValues("controllerKind", "Environment").
+		WithValues("name", app.Name).
+		WithValues("namespace", app.Namespace)
+
+	log.Info("validating the create request")
+
+	// We use the DNS-1123 format for environment names, so ensure it conforms to that specification
+	if len(validation.IsDNS1123Label(app.Name)) != 0 {
+		return fmt.Errorf("invalid environment name: %s, an environment resource name must start with a lower case alphabetical character, be under 63 characters, and can only consist of lower case alphanumeric characters or ‘-’", app.Name)
+	}
+
+	return validateEnvironment(app)
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *EnvironmentWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+
+	newApp := newObj.(*appstudiov1alpha1.Environment)
+
+	log := r.log.WithName("environment-webhook-update").
+		WithValues("controllerKind", "Environment").
+		WithValues("name", newApp.Name).
+		WithValues("namespace", newApp.Namespace)
+
+	log.Info("validating the update request")
+
+	return validateEnvironment(newApp)
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *EnvironmentWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return nil
+}
+
+// validateEnvironment validates the ingress domain and API URL
+func validateEnvironment(r *appstudiov1alpha1.Environment) error {
+
+	unstableConfig := r.Spec.UnstableConfigurationFields
+	if unstableConfig != nil {
+		// if cluster type is Kubernetes, then Ingress Domain should be set
+		if unstableConfig.ClusterType == appstudiov1alpha1.ConfigurationClusterType_Kubernetes && unstableConfig.IngressDomain == "" {
+			return fmt.Errorf(appstudiov1alpha1.MissingIngressDomain)
+		}
+
+		// if Ingress Domain is provided, we use the DNS-1123 format for ingress domain, so ensure it conforms to that specification
+		if unstableConfig.IngressDomain != "" && len(validation.IsDNS1123Subdomain(unstableConfig.IngressDomain)) != 0 {
+			return fmt.Errorf(appstudiov1alpha1.InvalidDNS1123Subdomain, unstableConfig.IngressDomain)
+		}
+
+	}
+
+	if r.Spec.UnstableConfigurationFields != nil && r.Spec.UnstableConfigurationFields.KubernetesClusterCredentials.APIURL != "" {
+		if _, err := url.ParseRequestURI(r.Spec.UnstableConfigurationFields.KubernetesClusterCredentials.APIURL); err != nil {
+			return fmt.Errorf(err.Error() + appstudiov1alpha1.InvalidAPIURL)
+		}
+	}
+
+	return nil
+}

--- a/appstudio-controller/controllers/webhooks/environment_webhook_unit_test.go
+++ b/appstudio-controller/controllers/webhooks/environment_webhook_unit_test.go
@@ -1,0 +1,375 @@
+//
+// Copyright 2023 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestEnvironmentCreateValidatingWebhook(t *testing.T) {
+
+	badIngressDomain := "AbADIngr3ssDomaiN.CoM"
+
+	orgEnv := appstudiov1alpha1.Environment{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "kubernetes-environment",
+		},
+		Spec: appstudiov1alpha1.EnvironmentSpec{
+			UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+				ClusterType: appstudiov1alpha1.ConfigurationClusterType_Kubernetes,
+				KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{
+					IngressDomain: "domain",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		newEnv appstudiov1alpha1.Environment
+		err    string
+	}{
+		{
+			name: "environment ingress domain is empty when its Kubernetes",
+			err:  appstudiov1alpha1.MissingIngressDomain,
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "kubernetes-environment",
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+						ClusterType:                  appstudiov1alpha1.ConfigurationClusterType_Kubernetes,
+						KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{},
+					},
+				},
+			},
+		},
+		{
+			name: "environment ingress domain not DNS 1123 compliant",
+			err:  fmt.Sprintf(appstudiov1alpha1.InvalidDNS1123Subdomain, badIngressDomain),
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "kubernetes-environment",
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+						ClusterType: appstudiov1alpha1.ConfigurationClusterType_Kubernetes,
+						KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{
+							IngressDomain: badIngressDomain,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "environment ingress domain is good",
+			newEnv: orgEnv,
+		},
+		{
+			name: "environment unstable config is empty",
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "kubernetes-environment",
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: nil,
+				},
+			},
+		},
+		{
+			name: "environment's ingress domain is empty when its OpenShift",
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "kubernetes-environment",
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+						ClusterType: appstudiov1alpha1.ConfigurationClusterType_OpenShift,
+						KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{
+							TargetNamespace: "mynamespace",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "environment's ingress domain is provided when its OpenShift",
+			err:  fmt.Sprintf(appstudiov1alpha1.InvalidDNS1123Subdomain, badIngressDomain),
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "kubernetes-environment",
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+						ClusterType: appstudiov1alpha1.ConfigurationClusterType_OpenShift,
+						KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{
+							IngressDomain: badIngressDomain,
+						},
+					},
+				},
+			},
+		}, {
+			name: "environment name must have DNS-1123 format  (test 1)",
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "kubernetes-environment-1",
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+						ClusterType: appstudiov1alpha1.ConfigurationClusterType_OpenShift,
+						KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{
+							IngressDomain: "domain",
+						},
+					},
+				},
+			},
+		}, {
+			name: "environment name must have DNS-1123 format (test 2)",
+			err:  "invalid environment name: Kubernetes-environment, an environment resource name must start with a lower case alphabetical character, be under 63 characters, and can only consist of lower case alphanumeric characters or ‘-’",
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "Kubernetes-environment",
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+						ClusterType: appstudiov1alpha1.ConfigurationClusterType_OpenShift,
+						KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{
+							IngressDomain: "domain",
+						},
+					},
+				},
+			},
+		}, {
+			name: "environment name must have DNS-1123 format  (test 3)",
+			err:  "invalid environment name: kubernetesEnvironment, an environment resource name must start with a lower case alphabetical character, be under 63 characters, and can only consist of lower case alphanumeric characters or ‘-’",
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "kubernetesEnvironment",
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+						ClusterType: appstudiov1alpha1.ConfigurationClusterType_OpenShift,
+						KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{
+							IngressDomain: "domain",
+						},
+					},
+				},
+			},
+		}, {
+			name: "environment name must have DNS-1123 format  (test 4)",
+			err:  "invalid environment name: abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde, an environment resource name must start with a lower case alphabetical character, be under 63 characters, and can only consist of lower case alphanumeric characters or ‘-’",
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: strings.Repeat("abcde", 13),
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+						ClusterType: appstudiov1alpha1.ConfigurationClusterType_OpenShift,
+						KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{
+							IngressDomain: badIngressDomain,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "environment api url must start with https",
+			err:  "invalid URI for request" + appstudiov1alpha1.InvalidAPIURL,
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "kubernetes-environment-1",
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+						ClusterType: appstudiov1alpha1.ConfigurationClusterType_OpenShift,
+						KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{
+							IngressDomain: "domain",
+							APIURL:        "api.test.com",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			envWebhook := EnvironmentWebhook{
+				log: zap.New(zap.UseFlagOptions(&zap.Options{
+					Development: true,
+					TimeEncoder: zapcore.ISO8601TimeEncoder,
+				})),
+			}
+
+			err := envWebhook.ValidateCreate(context.Background(), &test.newEnv)
+
+			if test.err == "" {
+				assert.Nil(t, err)
+			} else {
+				assert.Contains(t, err.Error(), test.err)
+			}
+		})
+	}
+}
+
+func TestEnvironmentUpdateValidatingWebhook(t *testing.T) {
+
+	badIngressDomain := "AbADIngr3ssDomaiN.CoM"
+
+	orgEnv := appstudiov1alpha1.Environment{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "kubernetes-environment",
+		},
+		Spec: appstudiov1alpha1.EnvironmentSpec{
+			UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+				ClusterType: appstudiov1alpha1.ConfigurationClusterType_Kubernetes,
+				KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{
+					IngressDomain: "domain",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		newEnv appstudiov1alpha1.Environment
+		err    string
+	}{
+		{
+			name: "environment ingress domain is empty when its Kubernetes",
+			err:  appstudiov1alpha1.MissingIngressDomain,
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "kubernetes-environment",
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+						ClusterType:                  appstudiov1alpha1.ConfigurationClusterType_Kubernetes,
+						KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{},
+					},
+				},
+			},
+		},
+		{
+			name: "environment ingress domain not DNS 1123 compliant",
+			err:  fmt.Sprintf(appstudiov1alpha1.InvalidDNS1123Subdomain, badIngressDomain),
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "kubernetes-environment",
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+						ClusterType: appstudiov1alpha1.ConfigurationClusterType_Kubernetes,
+						KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{
+							IngressDomain: badIngressDomain,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "environment ingress domain is good",
+			newEnv: orgEnv,
+		},
+		{
+			name: "environment unstable config is empty",
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "kubernetes-environment",
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: nil,
+				},
+			},
+		},
+		{
+			name: "environment's ingress domain is empty when its OpenShift",
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "kubernetes-environment",
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+						ClusterType:                  appstudiov1alpha1.ConfigurationClusterType_OpenShift,
+						KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{},
+					},
+				},
+			},
+		},
+		{
+			name: "environment's ingress domain is provided when its OpenShift",
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "kubernetes-environment",
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+						ClusterType: appstudiov1alpha1.ConfigurationClusterType_OpenShift,
+						KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{
+							IngressDomain: "domain",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "environment api url must start with https",
+			err:  "invalid URI for request" + appstudiov1alpha1.InvalidAPIURL,
+			newEnv: appstudiov1alpha1.Environment{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "kubernetes-environment-1",
+				},
+				Spec: appstudiov1alpha1.EnvironmentSpec{
+					UnstableConfigurationFields: &appstudiov1alpha1.UnstableEnvironmentConfiguration{
+						ClusterType: appstudiov1alpha1.ConfigurationClusterType_OpenShift,
+						KubernetesClusterCredentials: appstudiov1alpha1.KubernetesClusterCredentials{
+							IngressDomain: "domain",
+							APIURL:        "api.test.com",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			envWebhook := EnvironmentWebhook{
+				log: zap.New(zap.UseFlagOptions(&zap.Options{
+					Development: true,
+					TimeEncoder: zapcore.ISO8601TimeEncoder,
+				})),
+			}
+
+			err := envWebhook.ValidateUpdate(context.Background(), &appstudiov1alpha1.Environment{}, &test.newEnv)
+
+			if test.err == "" {
+				assert.Nil(t, err)
+			} else {
+				assert.Contains(t, err.Error(), test.err)
+			}
+		})
+	}
+}

--- a/appstudio-controller/controllers/webhooks/promotionrun_webhook.go
+++ b/appstudio-controller/controllers/webhooks/promotionrun_webhook.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2021-2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Webhook describes the data structure for the release webhook
+type PromotionRunWebhook struct {
+	client client.Client
+	log    logr.Logger
+}
+
+// change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-promotionrun,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=promotionruns,verbs=create;update,versions=v1alpha1,name=vpromotionrun.kb.io,admissionReviewVersions=v1
+
+func (w *PromotionRunWebhook) Register(mgr ctrl.Manager, log *logr.Logger) error {
+
+	w.client = mgr.GetClient()
+	w.log = *log
+
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&appstudiov1alpha1.PromotionRun{}).
+		WithValidator(w).
+		Complete()
+}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *PromotionRunWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+
+	app := obj.(*appstudiov1alpha1.PromotionRun)
+
+	log := r.log.WithName("promotionrun-webhook-create").
+		WithValues("controllerKind", "PromotionRun").
+		WithValues("name", app.Name).
+		WithValues("namespace", app.Namespace)
+
+	log.Info("validating the create request")
+
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *PromotionRunWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+
+	oldApp := oldObj.(*appstudiov1alpha1.PromotionRun)
+	newApp := newObj.(*appstudiov1alpha1.PromotionRun)
+
+	log := r.log.WithName("promotionrun-webhook-update").
+		WithValues("controllerKind", "PromotionRun").
+		WithValues("name", newApp.Name).
+		WithValues("namespace", newApp.Namespace)
+
+	log.Info("validating the update request")
+
+	if !reflect.DeepEqual(newApp.Spec, oldApp.Spec) {
+		return fmt.Errorf("spec cannot be updated to %+v", newApp.Spec)
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *PromotionRunWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return nil
+}

--- a/appstudio-controller/controllers/webhooks/promotionrun_webhook_test.go
+++ b/appstudio-controller/controllers/webhooks/promotionrun_webhook_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2021-2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"testing"
+
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestPromotionRunValidatingWebhook(t *testing.T) {
+
+	originalPromotionRun := appstudiov1alpha1.PromotionRun{
+		Spec: appstudiov1alpha1.PromotionRunSpec{
+			Snapshot:    "test-snapshot-a",
+			Application: "test-app-a",
+			ManualPromotion: appstudiov1alpha1.ManualPromotionConfiguration{
+				TargetEnvironment: "test-env-a",
+			},
+		},
+	}
+
+	tests := []struct {
+		testName      string                         // Name of test
+		testData      appstudiov1alpha1.PromotionRun // Test data to be passed to webhook function
+		expectedError string                         // Expected error message from webhook function
+	}{
+		{
+			testName: "No error when Spec is same.",
+			testData: appstudiov1alpha1.PromotionRun{
+				Spec: appstudiov1alpha1.PromotionRunSpec{
+					Snapshot:    "test-snapshot-a",
+					Application: "test-app-a",
+					ManualPromotion: appstudiov1alpha1.ManualPromotionConfiguration{
+						TargetEnvironment: "test-env-a",
+					},
+				},
+			},
+			expectedError: "",
+		},
+
+		{
+			testName: "Error occurs when Spec.Snapshot is changed.",
+			testData: appstudiov1alpha1.PromotionRun{
+				Spec: appstudiov1alpha1.PromotionRunSpec{
+					Snapshot:    "test-snapshot-a-changed",
+					Application: "test-app-a",
+					ManualPromotion: appstudiov1alpha1.ManualPromotionConfiguration{
+						TargetEnvironment: "test-env-a",
+					},
+				},
+			},
+			expectedError: "spec cannot be updated to {Snapshot:test-snapshot-a-changed Application:test-app-a ManualPromotion:{TargetEnvironment:test-env-a} AutomatedPromotion:{InitialEnvironment:}}",
+		},
+
+		{
+			testName: "Error occurs when Spec.Application is changed.",
+			testData: appstudiov1alpha1.PromotionRun{
+				Spec: appstudiov1alpha1.PromotionRunSpec{
+					Snapshot:    "test-snapshot-a",
+					Application: "test-app-a-changed",
+					ManualPromotion: appstudiov1alpha1.ManualPromotionConfiguration{
+						TargetEnvironment: "test-env-a",
+					},
+				},
+			},
+			expectedError: "spec cannot be updated to {Snapshot:test-snapshot-a Application:test-app-a-changed ManualPromotion:{TargetEnvironment:test-env-a} AutomatedPromotion:{InitialEnvironment:}}",
+		},
+
+		{
+			testName: "Error occurs when Spec.Application is changed.",
+			testData: appstudiov1alpha1.PromotionRun{
+				Spec: appstudiov1alpha1.PromotionRunSpec{
+					Snapshot:    "test-snapshot-a",
+					Application: "test-app-a-changed",
+					ManualPromotion: appstudiov1alpha1.ManualPromotionConfiguration{
+						TargetEnvironment: "test-env-a-changed",
+					},
+				},
+			},
+			expectedError: "spec cannot be updated to {Snapshot:test-snapshot-a Application:test-app-a-changed ManualPromotion:{TargetEnvironment:test-env-a-changed} AutomatedPromotion:{InitialEnvironment:}}",
+		},
+
+		{
+			testName: "Error occurs when Spec.AutomatedPromotion is added.",
+			testData: appstudiov1alpha1.PromotionRun{
+				Spec: appstudiov1alpha1.PromotionRunSpec{
+					Snapshot:    "test-snapshot-a",
+					Application: "test-app-a-changed",
+					AutomatedPromotion: appstudiov1alpha1.AutomatedPromotionConfiguration{
+						InitialEnvironment: "test-env-a",
+					},
+				},
+			},
+			expectedError: "spec cannot be updated to {Snapshot:test-snapshot-a Application:test-app-a-changed ManualPromotion:{TargetEnvironment:} AutomatedPromotion:{InitialEnvironment:test-env-a}}",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			promotionRunWebhook := PromotionRunWebhook{
+				log: zap.New(zap.UseFlagOptions(&zap.Options{
+					Development: true,
+					TimeEncoder: zapcore.ISO8601TimeEncoder,
+				})),
+			}
+
+			err := promotionRunWebhook.ValidateUpdate(context.Background(), &originalPromotionRun, &test.testData)
+
+			if test.expectedError == "" {
+				assert.Nil(t, err)
+			} else {
+				assert.Contains(t, err.Error(), test.expectedError)
+			}
+		})
+	}
+}

--- a/appstudio-controller/controllers/webhooks/snapshot_webhook unit_test.go
+++ b/appstudio-controller/controllers/webhooks/snapshot_webhook unit_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2021-2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"testing"
+
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestSnapshotValidatingWebhook(t *testing.T) {
+
+	// Create initial Snapshot CR.
+	originalSnapshot := appstudiov1alpha1.Snapshot{
+		Spec: appstudiov1alpha1.SnapshotSpec{
+			Application: "test-app-a",
+			Components: []appstudiov1alpha1.SnapshotComponent{
+				{
+					Name:           "test-component-a",
+					ContainerImage: "test-container-image-a",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		testName      string                     // Name of test
+		testData      appstudiov1alpha1.Snapshot // Test data to be passed to webhook function
+		expectedError string                     // Expected error message from webhook function
+	}{
+		{
+			testName: "No error when Spec is same.",
+			testData: appstudiov1alpha1.Snapshot{
+				Spec: appstudiov1alpha1.SnapshotSpec{
+					Application: "test-app-a",
+					Components: []appstudiov1alpha1.SnapshotComponent{
+						{
+							Name:           "test-component-a",
+							ContainerImage: "test-container-image-a",
+						},
+					},
+				},
+			},
+			expectedError: "",
+		}, {
+			testName: "Error occurs when Spec.Application name is changed.",
+			testData: appstudiov1alpha1.Snapshot{
+				Spec: appstudiov1alpha1.SnapshotSpec{
+					Application: "test-app-a-changed",
+					Components:  originalSnapshot.Spec.Components,
+				},
+			},
+			expectedError: "application field cannot be updated to test-app-a-changed",
+		},
+
+		{
+			testName: "Error occurs when Spec.Components.Name is changed.",
+			testData: appstudiov1alpha1.Snapshot{
+				Spec: appstudiov1alpha1.SnapshotSpec{
+					Application: originalSnapshot.Spec.Application,
+					Components: []appstudiov1alpha1.SnapshotComponent{
+						{
+							Name:           "test-component-a-changed",
+							ContainerImage: "test-container-image-a",
+						},
+					},
+				},
+			},
+			expectedError: "components cannot be updated to [{Name:test-component-a-changed ContainerImage:test-container-image-a Source:{ComponentSourceUnion:{GitSource:<nil>}}}]",
+		},
+
+		{
+			testName: "Error occurs when Spec.Components.ContainerImage is changed.",
+			testData: appstudiov1alpha1.Snapshot{
+				Spec: appstudiov1alpha1.SnapshotSpec{
+					Application: "test-app-a",
+					Components: []appstudiov1alpha1.SnapshotComponent{
+						{
+							Name:           "test-component-a",
+							ContainerImage: "test-container-image-a-changed",
+						},
+					},
+				},
+			},
+			expectedError: "components cannot be updated to [{Name:test-component-a ContainerImage:test-container-image-a-changed Source:{ComponentSourceUnion:{GitSource:<nil>}}}]",
+		},
+
+		{
+			testName: "Error when adding Source",
+			testData: appstudiov1alpha1.Snapshot{
+				Spec: appstudiov1alpha1.SnapshotSpec{
+					Application: "test-app-a",
+					Components: []appstudiov1alpha1.SnapshotComponent{
+						{
+							Name:           "test-component-a",
+							ContainerImage: "test-container-image-a",
+							Source: appstudiov1alpha1.ComponentSource{
+								ComponentSourceUnion: appstudiov1alpha1.ComponentSourceUnion{
+									GitSource: &appstudiov1alpha1.GitSource{
+										URL: "https://github.com/dummy/repo",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: "components cannot be updated to [{Name:test-component-a ContainerImage:test-container-image-a Source:{ComponentSourceUnion:{GitSource:",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+
+			snapshotWebhook := SnapshotWebhook{
+				log: zap.New(zap.UseFlagOptions(&zap.Options{
+					Development: true,
+					TimeEncoder: zapcore.ISO8601TimeEncoder,
+				})),
+			}
+
+			err := snapshotWebhook.ValidateUpdate(context.Background(), &originalSnapshot, &test.testData)
+
+			if test.expectedError == "" {
+				assert.Nil(t, err)
+			} else {
+				assert.Contains(t, err.Error(), test.expectedError)
+			}
+		})
+	}
+}

--- a/appstudio-controller/controllers/webhooks/snapshot_webhook.go
+++ b/appstudio-controller/controllers/webhooks/snapshot_webhook.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2021-2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Webhook describes the data structure for the release webhook
+type SnapshotWebhook struct {
+	client client.Client
+	log    logr.Logger
+}
+
+// change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-snapshot,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=snapshots,verbs=create;update,versions=v1alpha1,name=vsnapshot.kb.io,admissionReviewVersions=v1
+
+func (w *SnapshotWebhook) Register(mgr ctrl.Manager, log *logr.Logger) error {
+
+	w.client = mgr.GetClient()
+	w.log = *log
+
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&appstudiov1alpha1.Snapshot{}).
+		WithValidator(w).
+		Complete()
+}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *SnapshotWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+
+	app := obj.(*appstudiov1alpha1.Snapshot)
+
+	log := r.log.WithName("snapshot-webhook-create").
+		WithValues("controllerKind", "Snapshot").
+		WithValues("name", app.Name).
+		WithValues("namespace", app.Namespace)
+
+	log.Info("validating the create request")
+
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *SnapshotWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+
+	oldApp := oldObj.(*appstudiov1alpha1.Snapshot)
+	newApp := newObj.(*appstudiov1alpha1.Snapshot)
+
+	log := r.log.WithName("snapshot-webhook-update").
+		WithValues("controllerKind", "Snapshot").
+		WithValues("name", newApp.Name).
+		WithValues("namespace", newApp.Namespace)
+
+	log.Info("validating the update request")
+
+	if !reflect.DeepEqual(newApp.Spec.Application, oldApp.Spec.Application) {
+		return fmt.Errorf("application field cannot be updated to %+v", newApp.Spec.Application)
+	}
+
+	if !reflect.DeepEqual(newApp.Spec.Components, oldApp.Spec.Components) {
+		return fmt.Errorf("components cannot be updated to %+v", newApp.Spec.Components)
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *SnapshotWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return nil
+}

--- a/appstudio-controller/controllers/webhooks/snapshotenvironmentbinding_webhook.go
+++ b/appstudio-controller/controllers/webhooks/snapshotenvironmentbinding_webhook.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2021-2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Webhook describes the data structure for the release webhook
+type SnapshotEnvironmentBindingWebhook struct {
+	client client.Client
+	log    logr.Logger
+}
+
+var snapshotEnvironmentBindingClientFromManager client.Client
+
+// change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-snapshotenvironmentbinding,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=snapshotenvironmentbindings,verbs=create;update,versions=v1alpha1,name=vsnapshotenvironmentbinding.kb.io,admissionReviewVersions=v1
+
+func (w *SnapshotEnvironmentBindingWebhook) Register(mgr ctrl.Manager, log *logr.Logger) error {
+
+	w.client = mgr.GetClient()
+	w.log = *log
+
+	snapshotEnvironmentBindingClientFromManager = w.client
+
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&appstudiov1alpha1.SnapshotEnvironmentBinding{}).
+		WithValidator(w).
+		Complete()
+}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *SnapshotEnvironmentBindingWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+
+	app := obj.(*appstudiov1alpha1.SnapshotEnvironmentBinding)
+
+	log := r.log.WithName("snapshotenvironmentbinding-webhook-create").
+		WithValues("controllerKind", "SnapshotEnvironmentBinding").
+		WithValues("name", app.Name).
+		WithValues("namespace", app.Namespace)
+
+	log.Info("validating the create request")
+
+	if err := validateSEB(app); err != nil {
+		return fmt.Errorf("invalid SnapshotEnvironmentBinding: %v", err)
+	}
+
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *SnapshotEnvironmentBindingWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+
+	oldApp := oldObj.(*appstudiov1alpha1.SnapshotEnvironmentBinding)
+	newApp := newObj.(*appstudiov1alpha1.SnapshotEnvironmentBinding)
+
+	log := r.log.WithName("snapshotenvironmentbinding-webhook-update").
+		WithValues("controllerKind", "SnapshotEnvironmentBinding").
+		WithValues("name", newApp.Name).
+		WithValues("namespace", newApp.Namespace)
+
+	log.Info("validating the update request")
+
+	if !reflect.DeepEqual(oldApp.Spec.Application, newApp.Spec.Application) {
+		return fmt.Errorf("application field cannot be updated to %+v", newApp.Spec.Application)
+	}
+
+	if !reflect.DeepEqual(oldApp.Spec.Environment, newApp.Spec.Environment) {
+		return fmt.Errorf("environment field cannot be updated to %+v", newApp.Spec.Environment)
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *SnapshotEnvironmentBindingWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return nil
+}
+
+func validateSEB(newBinding *appstudiov1alpha1.SnapshotEnvironmentBinding) error {
+
+	if snapshotEnvironmentBindingClientFromManager == nil {
+		return fmt.Errorf("webhook not initialized")
+	}
+
+	// Retrieve the list of existing SnapshotEnvironmentBindings from the namespace
+	existingSEBs := appstudiov1alpha1.SnapshotEnvironmentBindingList{}
+
+	if err := snapshotEnvironmentBindingClientFromManager.List(context.Background(), &existingSEBs, &client.ListOptions{Namespace: newBinding.Namespace}); err != nil {
+		return fmt.Errorf("failed to list existing SnapshotEnvironmentBindings: %v", err)
+	}
+
+	// Check if any existing SEB has the same Application/Environment combination
+	for _, existingSEB := range existingSEBs.Items {
+
+		// Don't match the SEB on itself
+		if existingSEB.Name == newBinding.Name && existingSEB.Namespace == newBinding.Namespace {
+			continue
+		}
+
+		if existingSEB.Spec.Application == newBinding.Spec.Application && existingSEB.Spec.Environment == newBinding.Spec.Environment {
+			return fmt.Errorf("duplicate combination of Application (%s) and Environment (%s). Duplicated by: %s", newBinding.Spec.Application, newBinding.Spec.Environment, existingSEB.Name)
+		}
+	}
+
+	return nil
+}

--- a/appstudio-controller/controllers/webhooks/snapshotenvironmentbinding_webhook_test.go
+++ b/appstudio-controller/controllers/webhooks/snapshotenvironmentbinding_webhook_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2021-2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"testing"
+
+	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestSnapshotEnvironmentBindingValidateCreateWebhook(t *testing.T) {
+	tests := []struct {
+		testName      string                                         // Name of test
+		testData      appstudiov1alpha1.SnapshotEnvironmentBinding   // Test data to be passed to ValidateCreate function
+		existingSEBs  []appstudiov1alpha1.SnapshotEnvironmentBinding // Existing SnapshotEnvironmentBindings for the namespace
+		expectedError string                                         // Expected error message from ValidateCreate function
+		warnings      []string
+	}{
+		{
+			testName: "No error when no existing SnapshotEnvironmentBindings with the same combination",
+			testData: appstudiov1alpha1.SnapshotEnvironmentBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"test-key-b": "test-value-b"},
+					Name:   "seb1",
+				},
+				Spec: appstudiov1alpha1.SnapshotEnvironmentBindingSpec{
+					Application: "test-app-b",
+					Environment: "test-env-b",
+				},
+			},
+			existingSEBs:  []appstudiov1alpha1.SnapshotEnvironmentBinding{},
+			expectedError: "",
+		},
+
+		{
+			testName: "Error occurs when an existing SnapshotEnvironmentBinding has the same combination",
+			testData: appstudiov1alpha1.SnapshotEnvironmentBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"test-key-c": "test-value-c"},
+					Name:   "seb2",
+				},
+				Spec: appstudiov1alpha1.SnapshotEnvironmentBindingSpec{
+					Application: "test-app-c",
+					Environment: "test-env-c",
+				},
+			},
+			existingSEBs: []appstudiov1alpha1.SnapshotEnvironmentBinding{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{"test-key-d": "test-value-d"},
+						Name:   "seb1",
+					},
+					Spec: appstudiov1alpha1.SnapshotEnvironmentBindingSpec{
+						Application: "test-app-c",
+						Environment: "test-env-c",
+					},
+				},
+			},
+			expectedError: "duplicate combination of Application (test-app-c) and Environment (test-env-c)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+
+			objects := make([]runtime.Object, len(test.existingSEBs))
+			for i, seb := range test.existingSEBs {
+				objects[i] = &seb
+			}
+
+			scheme := runtime.NewScheme()
+
+			err := appstudiov1alpha1.AddToScheme(scheme)
+			if err != nil {
+				t.Fatalf("failed to setup scheme: %v", err)
+			}
+
+			snapshotEnvironmentBindingClientFromManager = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(objects...).
+				Build()
+
+			sebWebhook := SnapshotEnvironmentBindingWebhook{
+				log: zap.New(zap.UseFlagOptions(&zap.Options{
+					Development: true,
+					TimeEncoder: zapcore.ISO8601TimeEncoder,
+				})),
+			}
+
+			err = sebWebhook.ValidateCreate(context.Background(), &test.testData)
+
+			if test.expectedError == "" {
+				assert.Nil(t, err)
+			} else {
+				if assert.NotNil(t, err) {
+					assert.Contains(t, err.Error(), test.expectedError)
+				}
+			}
+		})
+	}
+}
+
+func TestSnapshotEnvironmentBindingValidateUpdateWebhook(t *testing.T) {
+
+	originalBinding := appstudiov1alpha1.SnapshotEnvironmentBinding{
+		ObjectMeta: v1.ObjectMeta{
+			Labels: map[string]string{"test-key-a": "test-value-a"},
+		},
+		Spec: appstudiov1alpha1.SnapshotEnvironmentBindingSpec{
+			Application: "test-app-a",
+			Environment: "test-env-a",
+		},
+	}
+
+	tests := []struct {
+		testName      string                                         // Name of test
+		testData      appstudiov1alpha1.SnapshotEnvironmentBinding   // Test data to be passed to webhook function
+		existingSEBs  []appstudiov1alpha1.SnapshotEnvironmentBinding // Existing SnapshotEnvironmentBindings for the namespace
+		expectedError string                                         // Expected error message from webhook function
+		warnings      []string
+	}{
+		{
+			testName: "No error when Spec is same.",
+			testData: appstudiov1alpha1.SnapshotEnvironmentBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"test-key-a": "test-value-a"},
+				},
+				Spec: appstudiov1alpha1.SnapshotEnvironmentBindingSpec{
+					Application: "test-app-a",
+					Environment: "test-env-a",
+				},
+			},
+			expectedError: "",
+		},
+
+		{
+			testName: "Error occurs when Spec.Application name is changed.",
+			testData: appstudiov1alpha1.SnapshotEnvironmentBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"test-key-a": "test-value-a"},
+				},
+				Spec: appstudiov1alpha1.SnapshotEnvironmentBindingSpec{
+					Application: "test-app-a-changed",
+					Environment: "test-env-a",
+				},
+			},
+			expectedError: "application field cannot be updated to test-app-a-changed",
+		},
+
+		{
+			testName: "Error occurs when Spec.Environment name is changed.",
+			testData: appstudiov1alpha1.SnapshotEnvironmentBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"test-key-a": "test-value-a"},
+				},
+				Spec: appstudiov1alpha1.SnapshotEnvironmentBindingSpec{
+					Application: "test-app-a",
+					Environment: "test-env-a-changed",
+				},
+			},
+			expectedError: "environment field cannot be updated to test-env-a-changed",
+		},
+		{
+			testName: "Error does not occur when an existing SnapshotEnvironmentBinding is updated",
+			testData: appstudiov1alpha1.SnapshotEnvironmentBinding{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"test-key-a": "test-value-a"},
+					Name:   "seb1",
+				},
+				Spec: appstudiov1alpha1.SnapshotEnvironmentBindingSpec{
+					Application: "test-app-a",
+					Environment: "test-env-a",
+				},
+			},
+			existingSEBs: []appstudiov1alpha1.SnapshotEnvironmentBinding{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{"test-key-a": "test-value-a"},
+						Name:   "seb1",
+					},
+					Spec: appstudiov1alpha1.SnapshotEnvironmentBindingSpec{
+						Application: "test-app-a",
+						Environment: "test-env-a",
+					},
+				},
+			},
+			expectedError: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+
+			sebWebhook := SnapshotEnvironmentBindingWebhook{
+				log: zap.New(zap.UseFlagOptions(&zap.Options{
+					Development: true,
+					TimeEncoder: zapcore.ISO8601TimeEncoder,
+				})),
+			}
+
+			err := sebWebhook.ValidateUpdate(context.Background(), &originalBinding, &test.testData)
+
+			if test.expectedError == "" {
+				assert.Nil(t, err)
+			} else {
+				assert.Contains(t, err.Error(), test.expectedError)
+			}
+		})
+	}
+}

--- a/appstudio-controller/controllers/webhooks/webhooks.go
+++ b/appstudio-controller/controllers/webhooks/webhooks.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// Webhook is an interface that should be implemented by operator webhooks and that allows to have a cohesive way
+// of defining them and register them.
+type Webhook interface {
+	Register(mgr ctrl.Manager, log *logr.Logger) error
+}
+
+// SetupWebhooks invoke the Register function of every webhook passed as an argument to this function.
+func SetupWebhooks(mgr manager.Manager, webhooks ...Webhook) error {
+	log := ctrl.Log.WithName("webhooks")
+
+	for _, webhook := range webhooks {
+		err := webhook.Register(mgr, &log)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// EnabledWebhooks is a slice containing references to all the webhooks that have to be registered
+var EnabledWebhooks = []Webhook{
+	&EnvironmentWebhook{},
+	&PromotionRunWebhook{},
+	&SnapshotWebhook{},
+	&SnapshotEnvironmentBindingWebhook{},
+}

--- a/appstudio-controller/go.mod
+++ b/appstudio-controller/go.mod
@@ -7,8 +7,9 @@ require (
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20230417235430-8258a3281250
 	github.com/onsi/ginkgo/v2 v2.6.0
 	github.com/onsi/gomega v1.24.1
-	github.com/redhat-appstudio/application-api v0.0.0-20230906075853-8d1126322971
+	github.com/redhat-appstudio/application-api v0.0.0-20231025105224-2790bb451725
 	github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0
+	github.com/stretchr/testify v1.8.0
 	k8s.io/apimachinery v0.25.0
 	k8s.io/client-go v0.25.0
 	sigs.k8s.io/controller-runtime v0.13.0
@@ -39,6 +40,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/openshift/api v0.0.0-20230213134911-7ba313770556 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.6.2 // indirect
 	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc // indirect
 	github.com/vmihailenco/bufpool v0.1.11 // indirect

--- a/appstudio-controller/go.sum
+++ b/appstudio-controller/go.sum
@@ -343,8 +343,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
-github.com/redhat-appstudio/application-api v0.0.0-20230906075853-8d1126322971 h1:5fZaG1iVebcLWeJsVpWxSNmd0qhH1x9rLXWP+jVOSZo=
-github.com/redhat-appstudio/application-api v0.0.0-20230906075853-8d1126322971/go.mod h1:E277KEEjL6rEXUHIhc0FQd6jyf3CzCQ7MOkauqF3gt4=
+github.com/redhat-appstudio/application-api v0.0.0-20231025105224-2790bb451725 h1:9808yVdQmzCLGrbedW6h4brggYqdnMpyMwKhFpx9/pE=
+github.com/redhat-appstudio/application-api v0.0.0-20231025105224-2790bb451725/go.mod h1:OvmeiVOItG2OSX/QE+vQwzOYfbOMBhBy43ZFxkWZJyc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
@@ -360,13 +360,16 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc h1:9lRDQMhESg+zvGYmW5DyG0UqvY96Bu5QYsTLvCHdrgo=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc/go.mod h1:bciPuU6GHm1iF1pBvUfxfsH0Wmnc2VbpgvbI9ZWuIRs=
 github.com/vmihailenco/bufpool v0.1.11 h1:gOq2WmBrq0i2yW5QJ16ykccQ4wH9UyEsgLm6czKAd94=

--- a/tests-e2e/appstudio/dt_dtc_dtclass_test.go
+++ b/tests-e2e/appstudio/dt_dtc_dtclass_test.go
@@ -86,7 +86,9 @@ var _ = Describe("DeploymentTarget DeploymentTargetClaim and Class tests", func(
 					DisplayName:        "my environment",
 					DeploymentStrategy: appstudiosharedv1.DeploymentStrategy_AppStudioAutomated,
 					Configuration: appstudiosharedv1.EnvironmentConfiguration{
-						Env: []appstudiosharedv1.EnvVarPair{},
+						Env: []appstudiosharedv1.EnvVarPair{
+							{Name: "e1", Value: "v1"},
+						},
 						Target: appstudiosharedv1.EnvironmentTarget{
 							DeploymentTargetClaim: appstudiosharedv1.DeploymentTargetClaimConfig{
 								ClaimName: dtc.Name,

--- a/tests-e2e/appstudio/environment_test.go
+++ b/tests-e2e/appstudio/environment_test.go
@@ -66,7 +66,9 @@ var _ = Describe("Environment Status.Conditions tests", func() {
 				},
 				Spec: appstudioshared.EnvironmentSpec{
 					Configuration: appstudioshared.EnvironmentConfiguration{
-						Env: []appstudioshared.EnvVarPair{},
+						Env: []appstudioshared.EnvVarPair{
+							{Name: "e1", Value: "v1"},
+						},
 						Target: appstudioshared.EnvironmentTarget{
 							DeploymentTargetClaim: appstudioshared.DeploymentTargetClaimConfig{
 								ClaimName: "test",
@@ -114,7 +116,9 @@ var _ = Describe("Environment Status.Conditions tests", func() {
 						},
 					},
 					Configuration: appstudioshared.EnvironmentConfiguration{
-						Env: []appstudioshared.EnvVarPair{},
+						Env: []appstudioshared.EnvVarPair{
+							{Name: "e1", Value: "v1"},
+						},
 						Target: appstudioshared.EnvironmentTarget{
 							DeploymentTargetClaim: appstudioshared.DeploymentTargetClaimConfig{
 								ClaimName: "testdtc",
@@ -195,7 +199,9 @@ var _ = Describe("Environment E2E tests", func() {
 					ParentEnvironment:  "",
 					Tags:               []string{},
 					Configuration: appstudioshared.EnvironmentConfiguration{
-						Env: []appstudioshared.EnvVarPair{},
+						Env: []appstudioshared.EnvVarPair{
+							{Name: "e1", Value: "v1"},
+						},
 					},
 					UnstableConfigurationFields: &appstudioshared.UnstableEnvironmentConfiguration{
 						KubernetesClusterCredentials: appstudioshared.KubernetesClusterCredentials{
@@ -268,7 +274,9 @@ var _ = Describe("Environment E2E tests", func() {
 					ParentEnvironment:  "",
 					Tags:               []string{},
 					Configuration: appstudioshared.EnvironmentConfiguration{
-						Env: []appstudioshared.EnvVarPair{},
+						Env: []appstudioshared.EnvVarPair{
+							{Name: "e1", Value: "v1"},
+						},
 					},
 					UnstableConfigurationFields: &appstudioshared.UnstableEnvironmentConfiguration{
 						KubernetesClusterCredentials: appstudioshared.KubernetesClusterCredentials{
@@ -388,7 +396,9 @@ var _ = Describe("Environment E2E tests", func() {
 					ParentEnvironment:  "",
 					Tags:               []string{},
 					Configuration: appstudioshared.EnvironmentConfiguration{
-						Env: []appstudioshared.EnvVarPair{},
+						Env: []appstudioshared.EnvVarPair{
+							{Name: "e1", Value: "v1"},
+						},
 						Target: appstudioshared.EnvironmentTarget{
 							DeploymentTargetClaim: appstudioshared.DeploymentTargetClaimConfig{
 								ClaimName: dtc.Name,
@@ -472,7 +482,9 @@ var _ = Describe("Environment E2E tests", func() {
 					ParentEnvironment:  "",
 					Tags:               []string{},
 					Configuration: appstudioshared.EnvironmentConfiguration{
-						Env: []appstudioshared.EnvVarPair{},
+						Env: []appstudioshared.EnvVarPair{
+							{Name: "e1", Value: "v1"},
+						},
 						Target: appstudioshared.EnvironmentTarget{
 							DeploymentTargetClaim: appstudioshared.DeploymentTargetClaimConfig{
 								ClaimName: dtc.Name,
@@ -566,7 +578,9 @@ var _ = Describe("Environment E2E tests", func() {
 					ParentEnvironment:  "",
 					Tags:               []string{},
 					Configuration: appstudioshared.EnvironmentConfiguration{
-						Env: []appstudioshared.EnvVarPair{},
+						Env: []appstudioshared.EnvVarPair{
+							{Name: "e1", Value: "v1"},
+						},
 						Target: appstudioshared.EnvironmentTarget{
 							DeploymentTargetClaim: appstudioshared.DeploymentTargetClaimConfig{
 								ClaimName: dtc.Name,

--- a/tests-e2e/appstudio/promotionrun_controller_test.go
+++ b/tests-e2e/appstudio/promotionrun_controller_test.go
@@ -289,7 +289,9 @@ func buildEnvironmentResource(name, displayName, parentEnvironment string, envTy
 			ParentEnvironment:  parentEnvironment,
 			Tags:               []string{name},
 			Configuration: appstudiosharedv1.EnvironmentConfiguration{
-				Env: []appstudiosharedv1.EnvVarPair{},
+				Env: []appstudiosharedv1.EnvVarPair{
+					{Name: "e1", Value: "v1"},
+				},
 			},
 		},
 	}

--- a/tests-e2e/appstudio/snapshotenvironmentbinding_test.go
+++ b/tests-e2e/appstudio/snapshotenvironmentbinding_test.go
@@ -573,7 +573,9 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 					ParentEnvironment:  "",
 					Tags:               []string{},
 					Configuration: appstudiosharedv1.EnvironmentConfiguration{
-						Env: []appstudiosharedv1.EnvVarPair{},
+						Env: []appstudiosharedv1.EnvVarPair{
+							{Name: "e1", Value: "v1"},
+						},
 					},
 					// The cluster doesn't need to be real for this test
 					UnstableConfigurationFields: &appstudiosharedv1.UnstableEnvironmentConfiguration{
@@ -664,7 +666,9 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 				Expect(ok).To(BeTrue())
 				envObj.Spec.UnstableConfigurationFields = nil
 				envObj.Spec.Configuration = appstudiosharedv1.EnvironmentConfiguration{
-					Env: []appstudiosharedv1.EnvVarPair{},
+					Env: []appstudiosharedv1.EnvVarPair{
+						{Name: "e1", Value: "v1"},
+					},
 					Target: appstudiosharedv1.EnvironmentTarget{
 						DeploymentTargetClaim: appstudiosharedv1.DeploymentTargetClaimConfig{
 							ClaimName: dtc.Name,
@@ -698,7 +702,9 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 				Expect(ok).To(BeTrue())
 
 				envObj.Spec.Configuration = appstudiosharedv1.EnvironmentConfiguration{
-					Env: []appstudiosharedv1.EnvVarPair{},
+					Env: []appstudiosharedv1.EnvVarPair{
+						{Name: "e1", Value: "v1"},
+					},
 				}
 				envObj.Spec.UnstableConfigurationFields = &appstudiosharedv1.UnstableEnvironmentConfiguration{
 					KubernetesClusterCredentials: appstudiosharedv1.KubernetesClusterCredentials{

--- a/tests-e2e/appstudio/webhook_test.go
+++ b/tests-e2e/appstudio/webhook_test.go
@@ -90,9 +90,16 @@ var _ = Describe("Webhook E2E tests", func() {
 
 		It("Should validate SnapshotEnvironmentBinding CR Webhooks.", func() {
 
+			k8sClient, err = fixture.GetE2ETestUserWorkspaceKubeClient()
+			Expect(err).To(Succeed())
+
 			if !isWebhookInstalled("snapshotenvironmentbindings", k8sClient) {
 				Skip("skipping as snapshotenvironmentbindings webhook is not installed")
 			}
+
+			Expect(fixture.EnsureCleanSlate()).To(Succeed())
+
+			ctx = context.Background()
 
 			By("Create Application.")
 

--- a/tests-e2e/go.mod
+++ b/tests-e2e/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/codeready-toolchain/api v0.0.0-20230417183849-f62ccbf3bd40
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20230417235430-8258a3281250
 	github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible
-	github.com/redhat-appstudio/application-api v0.0.0-20230906075853-8d1126322971
+	github.com/redhat-appstudio/application-api v0.0.0-20231025105224-2790bb451725
 	github.com/redhat-appstudio/managed-gitops/appstudio-controller v0.0.0
 	github.com/redhat-appstudio/managed-gitops/backend v0.0.0-00010101000000-000000000000
 	github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0

--- a/tests-e2e/go.sum
+++ b/tests-e2e/go.sum
@@ -675,8 +675,8 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/r3labs/diff v1.1.0 h1:V53xhrbTHrWFWq3gI4b94AjgEJOerO1+1l0xyHOBi8M=
 github.com/r3labs/diff v1.1.0/go.mod h1:7WjXasNzi0vJetRcB/RqNl5dlIsmXcTTLmF5IoH6Xig=
-github.com/redhat-appstudio/application-api v0.0.0-20230906075853-8d1126322971 h1:5fZaG1iVebcLWeJsVpWxSNmd0qhH1x9rLXWP+jVOSZo=
-github.com/redhat-appstudio/application-api v0.0.0-20230906075853-8d1126322971/go.mod h1:E277KEEjL6rEXUHIhc0FQd6jyf3CzCQ7MOkauqF3gt4=
+github.com/redhat-appstudio/application-api v0.0.0-20231025105224-2790bb451725 h1:9808yVdQmzCLGrbedW6h4brggYqdnMpyMwKhFpx9/pE=
+github.com/redhat-appstudio/application-api v0.0.0-20231025105224-2790bb451725/go.mod h1:OvmeiVOItG2OSX/QE+vQwzOYfbOMBhBy43ZFxkWZJyc=
 github.com/redis/go-redis/v9 v9.0.0-rc.4/go.mod h1:Vo3EsyWnicKnSKCA7HhgnvnyA74wOA69Cd2Meli5mmA=
 github.com/redis/go-redis/v9 v9.0.2 h1:BA426Zqe/7r56kCcvxYLWe1mkaz71LKF77GwgFzSxfE=
 github.com/redis/go-redis/v9 v9.0.2/go.mod h1:/xDTe9EF1LM61hek62Poq2nzQSGj0xSrEtEHbBQevps=

--- a/utilities/load-test/go.mod
+++ b/utilities/load-test/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	github.com/redhat-appstudio/application-api v0.0.0-20230906075853-8d1126322971 // indirect
+	github.com/redhat-appstudio/application-api v0.0.0-20231025105224-2790bb451725 // indirect
 	github.com/redis/go-redis/v9 v9.0.2 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect

--- a/utilities/load-test/go.sum
+++ b/utilities/load-test/go.sum
@@ -584,8 +584,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-appstudio/application-api v0.0.0-20230906075853-8d1126322971 h1:5fZaG1iVebcLWeJsVpWxSNmd0qhH1x9rLXWP+jVOSZo=
-github.com/redhat-appstudio/application-api v0.0.0-20230906075853-8d1126322971/go.mod h1:E277KEEjL6rEXUHIhc0FQd6jyf3CzCQ7MOkauqF3gt4=
+github.com/redhat-appstudio/application-api v0.0.0-20231025105224-2790bb451725 h1:9808yVdQmzCLGrbedW6h4brggYqdnMpyMwKhFpx9/pE=
+github.com/redhat-appstudio/application-api v0.0.0-20231025105224-2790bb451725/go.mod h1:OvmeiVOItG2OSX/QE+vQwzOYfbOMBhBy43ZFxkWZJyc=
 github.com/redis/go-redis/v9 v9.0.0-rc.4/go.mod h1:Vo3EsyWnicKnSKCA7HhgnvnyA74wOA69Cd2Meli5mmA=
 github.com/redis/go-redis/v9 v9.0.2 h1:BA426Zqe/7r56kCcvxYLWe1mkaz71LKF77GwgFzSxfE=
 github.com/redis/go-redis/v9 v9.0.2/go.mod h1:/xDTe9EF1LM61hek62Poq2nzQSGj0xSrEtEHbBQevps=


### PR DESCRIPTION
## Description
This PR is to move GitOps Service related webhooks to managed-gitops repo from application.
[An application-api PR](https://github.com/redhat-appstudio/application-api/pull/76) was merged which removed GitOps-Service related webhooks from there and in this PR all those webhooks are added with few modifications.

## Jira Ticket
https://issues.redhat.com/browse/GITOPSRVCE-762