### PR TITLE
GITOPSRVCE-769: Switch to namespace-scoped gitops-service-argocd

### DIFF
--- a/manifests/base/gitops-service-argocd/base/argo-cd-application-controller-clusterrole.yaml
+++ b/manifests/base/gitops-service-argocd/base/argo-cd-application-controller-clusterrole.yaml
@@ -1,964 +1,966 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: appstudio-gitops-service-argocd-argocd-application-controller
-rules:
-  - apiGroups:
-      - '*'
-    resources:
-      - '*'
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - monitoring.coreos.com
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - operators.coreos.com
-    resources:
-      - subscriptions
-    verbs:
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - operators.coreos.com
-    resources:
-      - clusterserviceversions
-      - catalogsources
-      - installplans
-      - subscriptions
-    verbs:
-      - delete
-  - apiGroups:
-      - operators.coreos.com
-    resources:
-      - clusterserviceversions
-      - catalogsources
-      - installplans
-      - subscriptions
-      - operatorgroups
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - packages.operators.coreos.com
-    resources:
-      - packagemanifests
-      - packagemanifests/icon
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - argoproj.io
-    resources:
-      - applications
-      - applicationsets
-      - appprojects
-      - argocds
-    verbs:
-      - '*'
-  - apiGroups:
-      - argoproj.io
-    resources:
-      - applications
-      - applicationsets
-      - appprojects
-      - argocds
-    verbs:
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - pipelines.openshift.io
-    resources:
-      - gitopsservices
-    verbs:
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - packages.operators.coreos.com
-    resources:
-      - packagemanifests
-    verbs:
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - helm.openshift.io
-    resources:
-      - projecthelmchartrepositories
-    verbs:
-      - get
-      - list
-      - update
-      - create
-      - watch
-      - patch
-      - delete
-  - apiGroups:
-      - ''
-    resources:
-      - secrets
-      - serviceaccounts
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ''
-      - image.openshift.io
-    resources:
-      - imagestreamimages
-      - imagestreammappings
-      - imagestreams
-      - imagestreams/secrets
-      - imagestreamtags
-      - imagetags
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ''
-      - image.openshift.io
-    resources:
-      - imagestreamimports
-    verbs:
-      - create
-  - apiGroups:
-      - ''
-      - image.openshift.io
-    resources:
-      - imagestreams/layers
-    verbs:
-      - get
-      - update
-  - apiGroups:
-      - ''
-    resources:
-      - namespaces
-    verbs:
-      - get
-  - apiGroups:
-      - ''
-      - project.openshift.io
-    resources:
-      - projects
-    verbs:
-      - get
-  - apiGroups:
-      - ''
-    resources:
-      - pods/attach
-      - pods/exec
-      - pods/portforward
-      - pods/proxy
-      - secrets
-      - services/proxy
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-    resources:
-      - serviceaccounts
-    verbs:
-      - impersonate
-  - apiGroups:
-      - ''
-    resources:
-      - pods
-      - pods/attach
-      - pods/exec
-      - pods/portforward
-      - pods/proxy
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - patch
-      - update
-  - apiGroups:
-      - ''
-    resources:
-      - pods/eviction
-    verbs:
-      - create
-  - apiGroups:
-      - ''
-    resources:
-      - configmaps
-      - endpoints
-      - events
-      - persistentvolumeclaims
-      - replicationcontrollers
-      - replicationcontrollers/scale
-      - secrets
-      - serviceaccounts
-      - services
-      - services/proxy
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - patch
-      - update
-  - apiGroups:
-      - ''
-    resources:
-      - serviceaccounts/token
-    verbs:
-      - create
-  - apiGroups:
-      - apps
-    resources:
-      - daemonsets
-      - deployments
-      - deployments/rollback
-      - deployments/scale
-      - replicasets
-      - replicasets/scale
-      - statefulsets
-      - statefulsets/scale
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - patch
-      - update
-  - apiGroups:
-      - autoscaling
-    resources:
-      - horizontalpodautoscalers
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - patch
-      - update
-  - apiGroups:
-      - batch
-    resources:
-      - cronjobs
-      - jobs
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - patch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - daemonsets
-      - deployments
-      - deployments/rollback
-      - deployments/scale
-      - ingresses
-      - networkpolicies
-      - replicasets
-      - replicasets/scale
-      - replicationcontrollers/scale
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - patch
-      - update
-  - apiGroups:
-      - policy
-    resources:
-      - poddisruptionbudgets
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - patch
-      - update
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-      - networkpolicies
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - patch
-      - update
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - metrics.k8s.io
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-      - image.openshift.io
-    resources:
-      - imagestreams
-    verbs:
-      - create
-  - apiGroups:
-      - ''
-      - build.openshift.io
-    resources:
-      - builds/details
-    verbs:
-      - update
-  - apiGroups:
-      - ''
-      - build.openshift.io
-    resources:
-      - builds
-    verbs:
-      - get
-  - apiGroups:
-      - snapshot.storage.k8s.io
-    resources:
-      - volumesnapshots
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-      - deletecollection
-  - apiGroups:
-      - ''
-      - build.openshift.io
-    resources:
-      - buildconfigs
-      - buildconfigs/webhooks
-      - builds
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ''
-      - build.openshift.io
-    resources:
-      - builds/log
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-      - build.openshift.io
-    resources:
-      - buildconfigs/instantiate
-      - buildconfigs/instantiatebinary
-      - builds/clone
-    verbs:
-      - create
-  - apiGroups:
-      - build.openshift.io
-    resources:
-      - jenkins
-    verbs:
-      - edit
-      - view
-  - apiGroups:
-      - ''
-      - apps.openshift.io
-    resources:
-      - deploymentconfigs
-      - deploymentconfigs/scale
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ''
-      - apps.openshift.io
-    resources:
-      - deploymentconfigrollbacks
-      - deploymentconfigs/instantiate
-      - deploymentconfigs/rollback
-    verbs:
-      - create
-  - apiGroups:
-      - ''
-      - apps.openshift.io
-    resources:
-      - deploymentconfigs/log
-      - deploymentconfigs/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-      - image.openshift.io
-    resources:
-      - imagestreams/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-      - quota.openshift.io
-    resources:
-      - appliedclusterresourcequotas
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-      - route.openshift.io
-    resources:
-      - routes
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ''
-      - route.openshift.io
-    resources:
-      - routes/custom-host
-    verbs:
-      - create
-  - apiGroups:
-      - ''
-      - route.openshift.io
-    resources:
-      - routes/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-      - template.openshift.io
-    resources:
-      - processedtemplates
-      - templateconfigs
-      - templateinstances
-      - templates
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - networkpolicies
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ''
-      - build.openshift.io
-    resources:
-      - buildlogs
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ''
-    resources:
-      - resourcequotausages
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    resourceNames:
-      - applications.argoproj.io
-    verbs:
-      - get
-  - apiGroups:
-      - argoproj.io
-    resources:
-      - applications
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    resourceNames:
-      - applicationsets.argoproj.io
-    verbs:
-      - get
-  - apiGroups:
-      - argoproj.io
-    resources:
-      - applicationsets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    resourceNames:
-      - appprojects.argoproj.io
-    verbs:
-      - get
-  - apiGroups:
-      - argoproj.io
-    resources:
-      - appprojects
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    resourceNames:
-      - argocds.argoproj.io
-    verbs:
-      - get
-  - apiGroups:
-      - argoproj.io
-    resources:
-      - argocds
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    resourceNames:
-      - gitopsservices.pipelines.openshift.io
-    verbs:
-      - get
-  - apiGroups:
-      - pipelines.openshift.io
-    resources:
-      - gitopsservices
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - packages.operators.coreos.com
-    resources:
-      - packagemanifests
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-      - image.openshift.io
-    resources:
-      - imagestreamimages
-      - imagestreammappings
-      - imagestreams
-      - imagestreamtags
-      - imagetags
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-      - image.openshift.io
-    resources:
-      - imagestreams/layers
-    verbs:
-      - get
-  - apiGroups:
-      - ''
-    resources:
-      - configmaps
-      - endpoints
-      - persistentvolumeclaims
-      - persistentvolumeclaims/status
-      - pods
-      - replicationcontrollers
-      - replicationcontrollers/scale
-      - serviceaccounts
-      - services
-      - services/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-    resources:
-      - bindings
-      - events
-      - limitranges
-      - namespaces/status
-      - pods/log
-      - pods/status
-      - replicationcontrollers/status
-      - resourcequotas
-      - resourcequotas/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-    resources:
-      - namespaces
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apps
-    resources:
-      - controllerrevisions
-      - daemonsets
-      - daemonsets/status
-      - deployments
-      - deployments/scale
-      - deployments/status
-      - replicasets
-      - replicasets/scale
-      - replicasets/status
-      - statefulsets
-      - statefulsets/scale
-      - statefulsets/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - autoscaling
-    resources:
-      - horizontalpodautoscalers
-      - horizontalpodautoscalers/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - batch
-    resources:
-      - cronjobs
-      - cronjobs/status
-      - jobs
-      - jobs/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - extensions
-    resources:
-      - daemonsets
-      - daemonsets/status
-      - deployments
-      - deployments/scale
-      - deployments/status
-      - ingresses
-      - ingresses/status
-      - networkpolicies
-      - replicasets
-      - replicasets/scale
-      - replicasets/status
-      - replicationcontrollers/scale
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - policy
-    resources:
-      - poddisruptionbudgets
-      - poddisruptionbudgets/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-      - ingresses/status
-      - networkpolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - snapshot.storage.k8s.io
-    resources:
-      - volumesnapshots
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-      - build.openshift.io
-    resources:
-      - buildconfigs
-      - buildconfigs/webhooks
-      - builds
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - build.openshift.io
-    resources:
-      - jenkins
-    verbs:
-      - view
-  - apiGroups:
-      - ''
-      - apps.openshift.io
-    resources:
-      - deploymentconfigs
-      - deploymentconfigs/scale
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-      - route.openshift.io
-    resources:
-      - routes
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-      - template.openshift.io
-    resources:
-      - processedtemplates
-      - templateconfigs
-      - templateinstances
-      - templates
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-      - build.openshift.io
-    resources:
-      - buildlogs
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - pipelines.openshift.io
-    resources:
-      - gitopsservices
-    verbs:
-      - '*'
-  - apiGroups:
-      - k8s.cni.cncf.io
-    resources:
-      - network-attachment-definitions
-    verbs:
-      - watch
-      - list
-      - get
-  - apiGroups:
-      - packages.operators.coreos.com
-    resources:
-      - packagemanifests
-    verbs:
-      - '*'
-  - apiGroups:
-      - ''
-      - authorization.openshift.io
-    resources:
-      - rolebindings
-      - roles
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - rolebindings
-      - roles
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ''
-      - authorization.openshift.io
-    resources:
-      - localresourceaccessreviews
-      - localsubjectaccessreviews
-      - subjectrulesreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - localsubjectaccessreviews
-    verbs:
-      - create
-  - apiGroups:
-      - ''
-      - project.openshift.io
-    resources:
-      - projects
-    verbs:
-      - delete
-      - get
-  - apiGroups:
-      - ''
-      - authorization.openshift.io
-    resources:
-      - resourceaccessreviews
-      - subjectaccessreviews
-    verbs:
-      - create
-  - apiGroups:
-      - ''
-      - security.openshift.io
-    resources:
-      - podsecuritypolicyreviews
-      - podsecuritypolicyselfsubjectreviews
-      - podsecuritypolicysubjectreviews
-    verbs:
-      - create
-  - apiGroups:
-      - ''
-      - authorization.openshift.io
-    resources:
-      - rolebindingrestrictions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - build.openshift.io
-    resources:
-      - jenkins
-    verbs:
-      - admin
-      - edit
-      - view
-  - apiGroups:
-      - ''
-      - project.openshift.io
-    resources:
-      - projects
-    verbs:
-      - delete
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - ''
-      - route.openshift.io
-    resources:
-      - routes/status
-    verbs:
-      - update
+# To enable 'gitops-service-argocd' instance as cluster-scoped Argo CD, uncomment the lines below.
+
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: ClusterRole
+# metadata:
+#   name: appstudio-gitops-service-argocd-argocd-application-controller
+# rules:
+#   - apiGroups:
+#       - '*'
+#     resources:
+#       - '*'
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - monitoring.coreos.com
+#     resources:
+#       - '*'
+#     verbs:
+#       - '*'
+#   - apiGroups:
+#       - operators.coreos.com
+#     resources:
+#       - subscriptions
+#     verbs:
+#       - create
+#       - update
+#       - patch
+#       - delete
+#   - apiGroups:
+#       - operators.coreos.com
+#     resources:
+#       - clusterserviceversions
+#       - catalogsources
+#       - installplans
+#       - subscriptions
+#     verbs:
+#       - delete
+#   - apiGroups:
+#       - operators.coreos.com
+#     resources:
+#       - clusterserviceversions
+#       - catalogsources
+#       - installplans
+#       - subscriptions
+#       - operatorgroups
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - packages.operators.coreos.com
+#     resources:
+#       - packagemanifests
+#       - packagemanifests/icon
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - argoproj.io
+#     resources:
+#       - applications
+#       - applicationsets
+#       - appprojects
+#       - argocds
+#     verbs:
+#       - '*'
+#   - apiGroups:
+#       - argoproj.io
+#     resources:
+#       - applications
+#       - applicationsets
+#       - appprojects
+#       - argocds
+#     verbs:
+#       - create
+#       - update
+#       - patch
+#       - delete
+#   - apiGroups:
+#       - pipelines.openshift.io
+#     resources:
+#       - gitopsservices
+#     verbs:
+#       - create
+#       - update
+#       - patch
+#       - delete
+#   - apiGroups:
+#       - packages.operators.coreos.com
+#     resources:
+#       - packagemanifests
+#     verbs:
+#       - create
+#       - update
+#       - patch
+#       - delete
+#   - apiGroups:
+#       - helm.openshift.io
+#     resources:
+#       - projecthelmchartrepositories
+#     verbs:
+#       - get
+#       - list
+#       - update
+#       - create
+#       - watch
+#       - patch
+#       - delete
+#   - apiGroups:
+#       - ''
+#     resources:
+#       - secrets
+#       - serviceaccounts
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - get
+#       - list
+#       - patch
+#       - update
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - image.openshift.io
+#     resources:
+#       - imagestreamimages
+#       - imagestreammappings
+#       - imagestreams
+#       - imagestreams/secrets
+#       - imagestreamtags
+#       - imagetags
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - get
+#       - list
+#       - patch
+#       - update
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - image.openshift.io
+#     resources:
+#       - imagestreamimports
+#     verbs:
+#       - create
+#   - apiGroups:
+#       - ''
+#       - image.openshift.io
+#     resources:
+#       - imagestreams/layers
+#     verbs:
+#       - get
+#       - update
+#   - apiGroups:
+#       - ''
+#     resources:
+#       - namespaces
+#     verbs:
+#       - get
+#   - apiGroups:
+#       - ''
+#       - project.openshift.io
+#     resources:
+#       - projects
+#     verbs:
+#       - get
+#   - apiGroups:
+#       - ''
+#     resources:
+#       - pods/attach
+#       - pods/exec
+#       - pods/portforward
+#       - pods/proxy
+#       - secrets
+#       - services/proxy
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - ''
+#     resources:
+#       - serviceaccounts
+#     verbs:
+#       - impersonate
+#   - apiGroups:
+#       - ''
+#     resources:
+#       - pods
+#       - pods/attach
+#       - pods/exec
+#       - pods/portforward
+#       - pods/proxy
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - patch
+#       - update
+#   - apiGroups:
+#       - ''
+#     resources:
+#       - pods/eviction
+#     verbs:
+#       - create
+#   - apiGroups:
+#       - ''
+#     resources:
+#       - configmaps
+#       - endpoints
+#       - events
+#       - persistentvolumeclaims
+#       - replicationcontrollers
+#       - replicationcontrollers/scale
+#       - secrets
+#       - serviceaccounts
+#       - services
+#       - services/proxy
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - patch
+#       - update
+#   - apiGroups:
+#       - ''
+#     resources:
+#       - serviceaccounts/token
+#     verbs:
+#       - create
+#   - apiGroups:
+#       - apps
+#     resources:
+#       - daemonsets
+#       - deployments
+#       - deployments/rollback
+#       - deployments/scale
+#       - replicasets
+#       - replicasets/scale
+#       - statefulsets
+#       - statefulsets/scale
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - patch
+#       - update
+#   - apiGroups:
+#       - autoscaling
+#     resources:
+#       - horizontalpodautoscalers
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - patch
+#       - update
+#   - apiGroups:
+#       - batch
+#     resources:
+#       - cronjobs
+#       - jobs
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - patch
+#       - update
+#   - apiGroups:
+#       - extensions
+#     resources:
+#       - daemonsets
+#       - deployments
+#       - deployments/rollback
+#       - deployments/scale
+#       - ingresses
+#       - networkpolicies
+#       - replicasets
+#       - replicasets/scale
+#       - replicationcontrollers/scale
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - patch
+#       - update
+#   - apiGroups:
+#       - policy
+#     resources:
+#       - poddisruptionbudgets
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - patch
+#       - update
+#   - apiGroups:
+#       - networking.k8s.io
+#     resources:
+#       - ingresses
+#       - networkpolicies
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - patch
+#       - update
+#   - apiGroups:
+#       - coordination.k8s.io
+#     resources:
+#       - leases
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - get
+#       - list
+#       - patch
+#       - update
+#       - watch
+#   - apiGroups:
+#       - metrics.k8s.io
+#     resources:
+#       - pods
+#       - nodes
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - image.openshift.io
+#     resources:
+#       - imagestreams
+#     verbs:
+#       - create
+#   - apiGroups:
+#       - ''
+#       - build.openshift.io
+#     resources:
+#       - builds/details
+#     verbs:
+#       - update
+#   - apiGroups:
+#       - ''
+#       - build.openshift.io
+#     resources:
+#       - builds
+#     verbs:
+#       - get
+#   - apiGroups:
+#       - snapshot.storage.k8s.io
+#     resources:
+#       - volumesnapshots
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#       - create
+#       - update
+#       - patch
+#       - delete
+#       - deletecollection
+#   - apiGroups:
+#       - ''
+#       - build.openshift.io
+#     resources:
+#       - buildconfigs
+#       - buildconfigs/webhooks
+#       - builds
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - get
+#       - list
+#       - patch
+#       - update
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - build.openshift.io
+#     resources:
+#       - builds/log
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - build.openshift.io
+#     resources:
+#       - buildconfigs/instantiate
+#       - buildconfigs/instantiatebinary
+#       - builds/clone
+#     verbs:
+#       - create
+#   - apiGroups:
+#       - build.openshift.io
+#     resources:
+#       - jenkins
+#     verbs:
+#       - edit
+#       - view
+#   - apiGroups:
+#       - ''
+#       - apps.openshift.io
+#     resources:
+#       - deploymentconfigs
+#       - deploymentconfigs/scale
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - get
+#       - list
+#       - patch
+#       - update
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - apps.openshift.io
+#     resources:
+#       - deploymentconfigrollbacks
+#       - deploymentconfigs/instantiate
+#       - deploymentconfigs/rollback
+#     verbs:
+#       - create
+#   - apiGroups:
+#       - ''
+#       - apps.openshift.io
+#     resources:
+#       - deploymentconfigs/log
+#       - deploymentconfigs/status
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - image.openshift.io
+#     resources:
+#       - imagestreams/status
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - quota.openshift.io
+#     resources:
+#       - appliedclusterresourcequotas
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - route.openshift.io
+#     resources:
+#       - routes
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - get
+#       - list
+#       - patch
+#       - update
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - route.openshift.io
+#     resources:
+#       - routes/custom-host
+#     verbs:
+#       - create
+#   - apiGroups:
+#       - ''
+#       - route.openshift.io
+#     resources:
+#       - routes/status
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - template.openshift.io
+#     resources:
+#       - processedtemplates
+#       - templateconfigs
+#       - templateinstances
+#       - templates
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - get
+#       - list
+#       - patch
+#       - update
+#       - watch
+#   - apiGroups:
+#       - networking.k8s.io
+#     resources:
+#       - networkpolicies
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - get
+#       - list
+#       - patch
+#       - update
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - build.openshift.io
+#     resources:
+#       - buildlogs
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - get
+#       - list
+#       - patch
+#       - update
+#       - watch
+#   - apiGroups:
+#       - ''
+#     resources:
+#       - resourcequotausages
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - apiextensions.k8s.io
+#     resources:
+#       - customresourcedefinitions
+#     resourceNames:
+#       - applications.argoproj.io
+#     verbs:
+#       - get
+#   - apiGroups:
+#       - argoproj.io
+#     resources:
+#       - applications
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - apiextensions.k8s.io
+#     resources:
+#       - customresourcedefinitions
+#     resourceNames:
+#       - applicationsets.argoproj.io
+#     verbs:
+#       - get
+#   - apiGroups:
+#       - argoproj.io
+#     resources:
+#       - applicationsets
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - apiextensions.k8s.io
+#     resources:
+#       - customresourcedefinitions
+#     resourceNames:
+#       - appprojects.argoproj.io
+#     verbs:
+#       - get
+#   - apiGroups:
+#       - argoproj.io
+#     resources:
+#       - appprojects
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - apiextensions.k8s.io
+#     resources:
+#       - customresourcedefinitions
+#     resourceNames:
+#       - argocds.argoproj.io
+#     verbs:
+#       - get
+#   - apiGroups:
+#       - argoproj.io
+#     resources:
+#       - argocds
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - apiextensions.k8s.io
+#     resources:
+#       - customresourcedefinitions
+#     resourceNames:
+#       - gitopsservices.pipelines.openshift.io
+#     verbs:
+#       - get
+#   - apiGroups:
+#       - pipelines.openshift.io
+#     resources:
+#       - gitopsservices
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - packages.operators.coreos.com
+#     resources:
+#       - packagemanifests
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - image.openshift.io
+#     resources:
+#       - imagestreamimages
+#       - imagestreammappings
+#       - imagestreams
+#       - imagestreamtags
+#       - imagetags
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - image.openshift.io
+#     resources:
+#       - imagestreams/layers
+#     verbs:
+#       - get
+#   - apiGroups:
+#       - ''
+#     resources:
+#       - configmaps
+#       - endpoints
+#       - persistentvolumeclaims
+#       - persistentvolumeclaims/status
+#       - pods
+#       - replicationcontrollers
+#       - replicationcontrollers/scale
+#       - serviceaccounts
+#       - services
+#       - services/status
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - ''
+#     resources:
+#       - bindings
+#       - events
+#       - limitranges
+#       - namespaces/status
+#       - pods/log
+#       - pods/status
+#       - replicationcontrollers/status
+#       - resourcequotas
+#       - resourcequotas/status
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - ''
+#     resources:
+#       - namespaces
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - discovery.k8s.io
+#     resources:
+#       - endpointslices
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - apps
+#     resources:
+#       - controllerrevisions
+#       - daemonsets
+#       - daemonsets/status
+#       - deployments
+#       - deployments/scale
+#       - deployments/status
+#       - replicasets
+#       - replicasets/scale
+#       - replicasets/status
+#       - statefulsets
+#       - statefulsets/scale
+#       - statefulsets/status
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - autoscaling
+#     resources:
+#       - horizontalpodautoscalers
+#       - horizontalpodautoscalers/status
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - batch
+#     resources:
+#       - cronjobs
+#       - cronjobs/status
+#       - jobs
+#       - jobs/status
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - extensions
+#     resources:
+#       - daemonsets
+#       - daemonsets/status
+#       - deployments
+#       - deployments/scale
+#       - deployments/status
+#       - ingresses
+#       - ingresses/status
+#       - networkpolicies
+#       - replicasets
+#       - replicasets/scale
+#       - replicasets/status
+#       - replicationcontrollers/scale
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - policy
+#     resources:
+#       - poddisruptionbudgets
+#       - poddisruptionbudgets/status
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - networking.k8s.io
+#     resources:
+#       - ingresses
+#       - ingresses/status
+#       - networkpolicies
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - snapshot.storage.k8s.io
+#     resources:
+#       - volumesnapshots
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - build.openshift.io
+#     resources:
+#       - buildconfigs
+#       - buildconfigs/webhooks
+#       - builds
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - build.openshift.io
+#     resources:
+#       - jenkins
+#     verbs:
+#       - view
+#   - apiGroups:
+#       - ''
+#       - apps.openshift.io
+#     resources:
+#       - deploymentconfigs
+#       - deploymentconfigs/scale
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - route.openshift.io
+#     resources:
+#       - routes
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - template.openshift.io
+#     resources:
+#       - processedtemplates
+#       - templateconfigs
+#       - templateinstances
+#       - templates
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - build.openshift.io
+#     resources:
+#       - buildlogs
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - pipelines.openshift.io
+#     resources:
+#       - gitopsservices
+#     verbs:
+#       - '*'
+#   - apiGroups:
+#       - k8s.cni.cncf.io
+#     resources:
+#       - network-attachment-definitions
+#     verbs:
+#       - watch
+#       - list
+#       - get
+#   - apiGroups:
+#       - packages.operators.coreos.com
+#     resources:
+#       - packagemanifests
+#     verbs:
+#       - '*'
+#   - apiGroups:
+#       - ''
+#       - authorization.openshift.io
+#     resources:
+#       - rolebindings
+#       - roles
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - get
+#       - list
+#       - patch
+#       - update
+#       - watch
+#   - apiGroups:
+#       - rbac.authorization.k8s.io
+#     resources:
+#       - rolebindings
+#       - roles
+#     verbs:
+#       - create
+#       - delete
+#       - deletecollection
+#       - get
+#       - list
+#       - patch
+#       - update
+#       - watch
+#   - apiGroups:
+#       - ''
+#       - authorization.openshift.io
+#     resources:
+#       - localresourceaccessreviews
+#       - localsubjectaccessreviews
+#       - subjectrulesreviews
+#     verbs:
+#       - create
+#   - apiGroups:
+#       - authorization.k8s.io
+#     resources:
+#       - localsubjectaccessreviews
+#     verbs:
+#       - create
+#   - apiGroups:
+#       - ''
+#       - project.openshift.io
+#     resources:
+#       - projects
+#     verbs:
+#       - delete
+#       - get
+#   - apiGroups:
+#       - ''
+#       - authorization.openshift.io
+#     resources:
+#       - resourceaccessreviews
+#       - subjectaccessreviews
+#     verbs:
+#       - create
+#   - apiGroups:
+#       - ''
+#       - security.openshift.io
+#     resources:
+#       - podsecuritypolicyreviews
+#       - podsecuritypolicyselfsubjectreviews
+#       - podsecuritypolicysubjectreviews
+#     verbs:
+#       - create
+#   - apiGroups:
+#       - ''
+#       - authorization.openshift.io
+#     resources:
+#       - rolebindingrestrictions
+#     verbs:
+#       - get
+#       - list
+#       - watch
+#   - apiGroups:
+#       - build.openshift.io
+#     resources:
+#       - jenkins
+#     verbs:
+#       - admin
+#       - edit
+#       - view
+#   - apiGroups:
+#       - ''
+#       - project.openshift.io
+#     resources:
+#       - projects
+#     verbs:
+#       - delete
+#       - get
+#       - patch
+#       - update
+#   - apiGroups:
+#       - ''
+#       - route.openshift.io
+#     resources:
+#       - routes/status
+#     verbs:
+#       - update

--- a/manifests/base/gitops-service-argocd/base/argo-cd-application-controller-clusterrolebinding.yaml
+++ b/manifests/base/gitops-service-argocd/base/argo-cd-application-controller-clusterrolebinding.yaml
@@ -1,12 +1,15 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: appstudio-gitops-service-argocd-argocd-application-controller
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: appstudio-gitops-service-argocd-argocd-application-controller
-subjects:
-  - kind: ServiceAccount
-    name: gitops-service-argocd-argocd-application-controller
-    namespace: gitops-service-argocd
+
+# To enable 'gitops-service-argocd' instance as cluster-scoped Argo CD, uncomment the lines below.
+
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: ClusterRoleBinding
+# metadata:
+#   name: appstudio-gitops-service-argocd-argocd-application-controller
+# roleRef:
+#   apiGroup: rbac.authorization.k8s.io
+#   kind: ClusterRole
+#   name: appstudio-gitops-service-argocd-argocd-application-controller
+# subjects:
+#   - kind: ServiceAccount
+#     name: gitops-service-argocd-argocd-application-controller
+#     namespace: gitops-service-argocd

--- a/manifests/base/gitops-service-argocd/base/argo-cd-server-clusterrole.yaml
+++ b/manifests/base/gitops-service-argocd/base/argo-cd-server-clusterrole.yaml
@@ -1,46 +1,48 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: appstudio-gitops-service-argocd-argocd-server
-rules:
-  - apiGroups:
-      - '*'
-    resources:
-      - '*'
-    verbs:
-      - get
-      - patch
-      - delete
-  - apiGroups:
-      - ''
-    resources:
-      - secrets
-      - configmaps
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - argoproj.io
-    resources:
-      - applications
-      - appprojects
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-      - delete
-      - patch
-  - apiGroups:
-      - ''
-    resources:
-      - events
-    verbs:
-      - create
-      - list
+# To enable 'gitops-service-argocd' instance as cluster-scoped Argo CD, uncomment the lines below.
+
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: ClusterRole
+# metadata:
+#   name: appstudio-gitops-service-argocd-argocd-server
+# rules:
+#   - apiGroups:
+#       - '*'
+#     resources:
+#       - '*'
+#     verbs:
+#       - get
+#       - patch
+#       - delete
+#   - apiGroups:
+#       - ''
+#     resources:
+#       - secrets
+#       - configmaps
+#     verbs:
+#       - create
+#       - get
+#       - list
+#       - watch
+#       - update
+#       - patch
+#       - delete
+#   - apiGroups:
+#       - argoproj.io
+#     resources:
+#       - applications
+#       - appprojects
+#     verbs:
+#       - create
+#       - get
+#       - list
+#       - watch
+#       - update
+#       - delete
+#       - patch
+#   - apiGroups:
+#       - ''
+#     resources:
+#       - events
+#     verbs:
+#       - create
+#       - list

--- a/manifests/base/gitops-service-argocd/base/argo-cd-server-clusterrolebinding.yaml
+++ b/manifests/base/gitops-service-argocd/base/argo-cd-server-clusterrolebinding.yaml
@@ -1,12 +1,15 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: appstudio-gitops-service-argocd-argocd-server
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: appstudio-gitops-service-argocd-argocd-server
-subjects:
-  - kind: ServiceAccount
-    name: gitops-service-argocd-argocd-server
-    namespace: gitops-service-argocd
+
+# To enable 'gitops-service-argocd' instance as cluster-scoped Argo CD, uncomment the lines below.
+
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: ClusterRoleBinding
+# metadata:
+#   name: appstudio-gitops-service-argocd-argocd-server
+# roleRef:
+#   apiGroup: rbac.authorization.k8s.io
+#   kind: ClusterRole
+#   name: appstudio-gitops-service-argocd-argocd-server
+# subjects:
+#   - kind: ServiceAccount
+#     name: gitops-service-argocd-argocd-server
+#     namespace: gitops-service-argocd

--- a/manifests/scripts/openshift-argo-deploy/openshift-gitops-subscription.yaml
+++ b/manifests/scripts/openshift-argo-deploy/openshift-gitops-subscription.yaml
@@ -13,5 +13,6 @@ spec:
     env:
       - name: DISABLE_DEFAULT_ARGOCD_INSTANCE
         value: "true"
-      - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
-        value: "gitops-service-argocd"
+      # re-enable this to enable cluster-scoped Argo CD:
+      # - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
+      #   value: "gitops-service-argocd"

--- a/tests-e2e/fixture/fixture.go
+++ b/tests-e2e/fixture/fixture.go
@@ -57,9 +57,10 @@ const (
 )
 
 const (
-	// EnableNamespaceBackedArgoCD is currently disabled, due to concerns with performance issues when Argo CD is running in namespace-scoped mode.
-	// When enabled, this will ensure that certain tests/fixtures add the managed by label to Namespace.
-	EnableNamespaceBackedArgoCD = false
+	// EnableNamespaceBackedArgoCD: When enabled, this will ensure that certain tests/fixtures add the managed-by label to Namespace. This allows the gitops-service-argocd instance to manage them.
+	//
+	// When Argo CD is running in cluster-scoped mode (i.e. due to concerns with performance issues when Argo CD is running in namespace-scoped mode), this field should be set to false.
+	EnableNamespaceBackedArgoCD = true
 )
 
 // EnsureCleanSlateNonKCPVirtualWorkspace should be called before every E2E tests:


### PR DESCRIPTION
#### Description:
- Platform team would like use to avoid using very permissive cluster roles in our `gitops-service-argocd` instance, so the easiest way to do that is to move GitOps Service' Argo CD instance to be strictly namespace-scoped.
 
#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-769

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
