### PR TITLE
GITOPSRVCE-787: wait X minutes before deleting orphaned SEB

### DIFF
--- a/tests-e2e/appstudio/snapshotenvironmentbinding_test.go
+++ b/tests-e2e/appstudio/snapshotenvironmentbinding_test.go
@@ -72,9 +72,15 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 			Expect(err).To(Succeed())
 			Eventually(&application, "1m", "1s").ShouldNot(k8s.ExistByName(k8sClient))
 
-			By("Checking that the binding gets deleted")
-			Eventually(&binding, "1m", "1s").ShouldNot(k8s.ExistByName(k8sClient))
-			Consistently(&binding, "1m", "5s").ShouldNot(k8s.ExistByName(k8sClient))
+			// The contents of this part of the test is based on 'allowDeletionOfOrphanedSnapshotEnvironmentBindingAfterXMinutes'.
+			// - When changing the value of allowDeletionOfOrphanedSnapshotEnvironmentBindingAfterXMinutes, you should also change this line.
+
+			Consistently(&binding, "2m", "10s").Should(k8s.ExistByName(k8sClient), "the binding should continue to exist for at least 2 minutes after the parent Application is deleted")
+
+			By("Checking that the binding gets deleted (this will take ~1 minutes)")
+			Eventually(&binding, "2m", "10s").ShouldNot(k8s.ExistByName(k8sClient), "binding should be deleted 3 minutes after the parent Application is deleted")
+
+			Consistently(&binding, "10s", "1s").ShouldNot(k8s.ExistByName(k8sClient), "binding should continue to not exist for several additional seconds")
 		})
 
 		// This test is to verify the scenario when a user creates an SnapshotEnvironmentBinding CR in Cluster.


### PR DESCRIPTION
#### Description:

There is a theoretical race condition (not seen in practice, to my knowledge) where a SnapshotEnvironmentBinding (SEB) is reconciled before the Application exists, which causes the SEB to be deleted by our orphaned SEB detection login.

For example:
1) SEB is created
2) SEB is reconciled. SEB `Reconcile()` logic detects that the parent Application doesn't exist, and thus the Reconcile logic will automatically delete the SEB.
3) Application is created.

You could imagine a case like this might happen if you were kubectl apply-ing a bunch of resources at once, and the SnapshotEnvironmentBinding was reconciled before the Application was created.

In any case, the fix is just to wait a few minutes (via requeue) before deletion.

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-787

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
