### PR TITLE
Add kubectl command to check  controller deployments are ready

### DIFF
--- a/scripts/openshiftci-presubmit-e2e-tests.sh
+++ b/scripts/openshiftci-presubmit-e2e-tests.sh
@@ -44,5 +44,8 @@ export DB_PASS=$(kubectl get -n gitops secret gitops-postgresql-staging -o jsonp
 # Show commands in logs
 set -x
 
+# Wait for our controller Deployments to be Ready
+kubectl get deployments --no-headers -o custom-columns="DEPLOYMENT:.metadata.name" | xargs -I {} kubectl rollout status deploy/{}
+
 # Run E2E tests
 make test-e2e


### PR DESCRIPTION
#### Description:
- Added kubectl command in `openshiftci-presubmit-e2e-tests.sh` file
- Command description:
    - kubectl get deployments --no-headers -o custom-columns="DEPLOYMENT:.metadata.name : retrieves a list of deployment names in your cluster.
    - xargs -I {} : is used to iterate through each deployment name.
    - kubectl rollout status deploy/{} - s run for each deployment, where {} is replaced with the deployment name. This checks the rollout status for each deployment.

#### Link to JIRA Story (if applicable):
https://issues.redhat.com/browse/GITOPSRVCE-754
