### PR TITLE
GITOPSRVCE-788: reconcile changes to repository Secrets

### DIFF
--- a/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentrepositorycredential_types.go
+++ b/backend-shared/apis/managed-gitops/v1alpha1/gitopsdeploymentrepositorycredential_types.go
@@ -81,8 +81,9 @@ const (
 	RepositoryCredentialReasonCredentialsUpToDate  = "RepositoryCredentialUpToDate"
 	RepositoryCredentialReasonSecretNotSpecified   = "SecretNotSpecified"
 	RepositoryCredentialReasonSecretNotFound       = "SecretNotFound"
+	RepositoryCredentialReasonSecretInvalidType    = "SecretInvalidType"
 	RepositoryCredentialReasonInvalidCredentials   = "InvalidCredentials"
-	RepositoryCredentialReasonInValidRepositoryUrl = "InvalidRepositoryUrl"
+	RepositoryCredentialReasonInvalidRepositoryUrl = "InvalidRepositoryUrl"
 	RepositoryCredentialReasonValidRepositoryUrl   = "ValidRepositoryUrl"
 )
 

--- a/backend-shared/util/util.go
+++ b/backend-shared/util/util.go
@@ -33,6 +33,8 @@ const (
 
 	ManagedEnvironmentSecretType = "managed-gitops.redhat.com/managed-environment"
 
+	RepositoryCredentialSecretType = "managed-gitops.redhat.com/repository-credential"
+
 	Log_JobKey      = "job"                    // Clean up job key
 	Log_JobKeyValue = "managed-gitops-cleanup" // Clean up job value
 	Log_JobTypeKey  = "jobType"                // Key to identify clean up job type

--- a/backend/controllers/managed-gitops/gitopsdeploymentmanagedenvironment_controller.go
+++ b/backend/controllers/managed-gitops/gitopsdeploymentmanagedenvironment_controller.go
@@ -19,6 +19,7 @@ package managedgitops
 import (
 	"context"
 	"fmt"
+
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -108,7 +109,7 @@ func (r *GitOpsDeploymentManagedEnvironmentReconciler) SetupWithManager(mgr ctrl
 		Watches(
 			&source.Kind{Type: &corev1.Secret{}},
 			handler.EnqueueRequestsFromMapFunc(r.findSecretsForManagedEnvironment),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
 		Complete(r)
 }
 

--- a/backend/controllers/managed-gitops/gitopsdeploymentrepositorycredential_controller_test.go
+++ b/backend/controllers/managed-gitops/gitopsdeploymentrepositorycredential_controller_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package managedgitops
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
+	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
+	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/tests"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("GitOpsDeploymentRepositoryCredential Controller Test", func() {
+
+	Context("Generic tests", func() {
+
+		var k8sClient client.Client
+		var namespace corev1.Namespace
+
+		var reconciler GitOpsDeploymentRepositoryCredentialReconciler
+		// var mockProcessor mockPreprocessEventLoopProcessor
+
+		var secretName = "test-secret"
+
+		BeforeEach(func() {
+			scheme, argocdNamespace, kubesystemNamespace, _, err := tests.GenericTestSetup()
+			Expect(err).ToNot(HaveOccurred())
+
+			k8sClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(argocdNamespace, kubesystemNamespace).Build()
+
+			namespace = corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-user",
+					UID:  uuid.NewUUID(),
+				},
+				Spec: corev1.NamespaceSpec{},
+			}
+
+			err = k8sClient.Create(context.Background(), &namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			// mockProcessor = mockPreprocessEventLoopProcessor{}
+			reconciler = GitOpsDeploymentRepositoryCredentialReconciler{
+				Client: k8sClient,
+				Scheme: scheme,
+			}
+
+		})
+
+		Context("Test findSecretsForRepositoryCredential function", func() {
+
+			When("GitOpsDeploymentRepositoryCredential references a secret in the same namespace", func() {
+
+				It("should return a repository credential", func() {
+					By("create a valid repository credential secret")
+					secret := createSecretForRepositoryCredential(secretName, true, namespace, k8sClient)
+
+					By("create a repository credential that references the secret")
+
+					repoCred := createRepositoryCredentialTargetingSecret("testRepoCred", secret, namespace, k8sClient)
+
+					Expect(reconciler.findSecretsForRepositoryCredential(&secret)).To(Equal([]reconcile.Request{{NamespacedName: client.ObjectKeyFromObject(&repoCred)}}))
+				})
+			})
+
+			When("findSecretsForRepositoryCredential is called with an invalid object", func() {
+
+				It("should return an empty request slice", func() {
+
+					invalidObj := corev1.Namespace{}
+					Expect(reconciler.findSecretsForRepositoryCredential(&invalidObj)).To(BeEmpty())
+				})
+			})
+
+			When("findSecretsForRepositoryCredential is called on a non-repo-cred Secret", func() {
+
+				It("should return an empty request slice", func() {
+
+					By("create a INVALID repository credential secret")
+					secret := createSecretForRepositoryCredential(secretName, false, namespace, k8sClient)
+
+					By("create a repository credential that references the secret")
+
+					_ = createRepositoryCredentialTargetingSecret("testRepoCred", secret, namespace, k8sClient)
+
+					Expect(reconciler.findSecretsForRepositoryCredential(&secret)).To(BeEmpty())
+
+				})
+			})
+
+			When("findSecretsForRepositoryCredential is called on a valid repo-cred Secret, but the Secret in a different namespace than the RepositoryCredential", func() {
+
+				It("should return an empty request slice", func() {
+
+					By("create a valid repository credential secret, but in a different Namespace than the repo cred")
+					secret := corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      secretName,
+							Namespace: "a-different-namespace",
+						},
+						Type: sharedutil.RepositoryCredentialSecretType,
+					}
+
+					Expect(k8sClient.Create(context.Background(), &secret)).To(Succeed())
+
+					By("create a repository credential that references the secret")
+
+					_ = createRepositoryCredentialTargetingSecret("testRepoCred", secret, namespace, k8sClient)
+
+					Expect(reconciler.findSecretsForRepositoryCredential(&secret)).To(BeEmpty())
+
+				})
+			})
+
+		})
+	})
+})
+
+func createRepositoryCredentialTargetingSecret(name string, secret corev1.Secret, namespace corev1.Namespace, k8sClient client.Client) managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredential {
+
+	repoCred := managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace.Name,
+		},
+		Spec: managedgitopsv1alpha1.GitOpsDeploymentRepositoryCredentialSpec{
+			Secret: secret.Name,
+		},
+	}
+	Expect(k8sClient.Create(context.Background(), &repoCred)).To(Succeed())
+
+	return repoCred
+
+}
+
+func createSecretForRepositoryCredential(name string, validSecret bool, namespace corev1.Namespace, k8sClient client.Client) corev1.Secret {
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace.Name,
+		},
+		Type: sharedutil.RepositoryCredentialSecretType,
+	}
+
+	if !validSecret {
+		secret.Type = ""
+	}
+
+	Expect(k8sClient.Create(context.Background(), &secret)).To(Succeed())
+
+	return secret
+}

--- a/backend/eventloop/db_reconciler_test.go
+++ b/backend/eventloop/db_reconciler_test.go
@@ -19,6 +19,7 @@ import (
 
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	db "github.com/redhat-appstudio/managed-gitops/backend-shared/db"
+	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	sharedoperations "github.com/redhat-appstudio/managed-gitops/backend-shared/util/operations"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -286,7 +287,7 @@ var _ = Describe("DB Clean-up Function Tests", func() {
 						Name:      "my-managed-env-secret",
 						Namespace: "test-k8s-namespace",
 					},
-					Type:       "managed-gitops.redhat.com/managed-environment",
+					Type:       sharedutil.ManagedEnvironmentSecretType,
 					StringData: map[string]string{shared_resource_loop.KubeconfigKey: "abc"},
 				}
 				err = k8sClient.Create(context.Background(), secretCr)
@@ -545,7 +546,7 @@ var _ = Describe("DB Clean-up Function Tests", func() {
 						Name:      "test-secret",
 						Namespace: "test-k8s-namespace",
 					},
-					Type: "managed-gitops.redhat.com/managed-environment",
+					Type: sharedutil.ManagedEnvironmentSecretType,
 					StringData: map[string]string{
 						"username": "test-user",
 						"password": "test@123",

--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -44,6 +44,9 @@ import (
 //     concurrently create API-namespace-scoped database resources at the same time.
 type SharedResourceEventLoop struct {
 	inputChannel chan sharedResourceLoopMessage
+
+	// For use by unit tests only: If this function is non-nil, it will be used instead of the default repository credentials validation function.
+	validateRepoURLAndCredentialsFunction ValidateRepoURLAndCredentialsFunction
 }
 
 // ReconcileAppProjectRepositories ensures that the necessary AppProjectRepository database rows exists in the database, and that they are consistent with the GitOpsDeployment/GitOpsDeploymentRepositoryCredentials defined in the given Namespace.
@@ -254,13 +257,29 @@ func (srEventLoop *SharedResourceEventLoop) ReconcileRepositoryCredential(ctx co
 
 }
 
+// NewSharedResourceLoop creates a new SharedResourceLoop, and starts the goroutine responsible for processing channel messages.
+// See documentation at top of this file for details.
 func NewSharedResourceLoop() *SharedResourceEventLoop {
 
 	sharedResourceEventLoop := &SharedResourceEventLoop{
 		inputChannel: make(chan sharedResourceLoopMessage),
 	}
 
-	go internalSharedResourceEventLoop(sharedResourceEventLoop.inputChannel)
+	go sharedResourceEventLoop.internalSharedResourceEventLoop(sharedResourceEventLoop.inputChannel)
+
+	return sharedResourceEventLoop
+}
+
+// NewSharedResourceLoopWithCustomFuncs allows override of validation functions from NewSharedResourceLoop
+// Note: This should only be called from unit tests
+func NewSharedResourceLoopWithCustomFuncs(validateRepoURLFunction ValidateRepoURLAndCredentialsFunction) *SharedResourceEventLoop {
+
+	sharedResourceEventLoop := &SharedResourceEventLoop{
+		inputChannel:                          make(chan sharedResourceLoopMessage),
+		validateRepoURLAndCredentialsFunction: validateRepoURLFunction,
+	}
+
+	go sharedResourceEventLoop.internalSharedResourceEventLoop(sharedResourceEventLoop.inputChannel)
 
 	return sharedResourceEventLoop
 }
@@ -367,7 +386,7 @@ type sharedResourceLoopMessage_reconcileAppProjectRepositoryResponse struct {
 	err error
 }
 
-func internalSharedResourceEventLoop(inputChan chan sharedResourceLoopMessage) {
+func (srel *SharedResourceEventLoop) internalSharedResourceEventLoop(inputChan chan sharedResourceLoopMessage) {
 
 	ctx := context.Background()
 	l := log.FromContext(ctx).
@@ -382,7 +401,7 @@ func internalSharedResourceEventLoop(inputChan chan sharedResourceLoopMessage) {
 		msg := <-inputChan
 
 		_, err = sharedutil.CatchPanic(func() error {
-			processSharedResourceMessage(msg.ctx, msg, dbQueries, msg.log)
+			srel.processSharedResourceMessage(msg.ctx, msg, dbQueries, msg.log)
 			return nil
 		})
 		if err != nil {
@@ -391,7 +410,7 @@ func internalSharedResourceEventLoop(inputChan chan sharedResourceLoopMessage) {
 	}
 }
 
-func processSharedResourceMessage(ctx context.Context, msg sharedResourceLoopMessage, dbQueries db.DatabaseQueries, log logr.Logger) {
+func (srel *SharedResourceEventLoop) processSharedResourceMessage(ctx context.Context, msg sharedResourceLoopMessage, dbQueries db.DatabaseQueries, log logr.Logger) {
 
 	log.V(logutil.LogLevel_Debug).Info("sharedResourceEventLoop received message: " + string(msg.messageType))
 
@@ -470,8 +489,14 @@ func processSharedResourceMessage(ctx context.Context, msg sharedResourceLoopMes
 		payload, ok := (msg.payload).(sharedResourceLoopMessage_reconcileRepositoryCredentialRequest)
 		if ok {
 
+			repoCredValidationFunction := DefaultValidateRepositoryCredentials
+
+			if srel.validateRepoURLAndCredentialsFunction != nil {
+				repoCredValidationFunction = srel.validateRepoURLAndCredentialsFunction
+			}
+
 			repositoryCredential, err = internalProcessMessage_ReconcileRepositoryCredential(ctx,
-				payload.repositoryCredentialCRName, msg.workspaceNamespace, msg.workspaceClient, dbQueries, true, log)
+				payload.repositoryCredentialCRName, msg.workspaceNamespace, repoCredValidationFunction, msg.workspaceClient, dbQueries, true, log)
 
 		} else {
 			err = fmt.Errorf("SEVERE - unexpected cast in internalSharedResourceEventLoop")

--- a/backend/eventloop/workspace_resource_event_loop.go
+++ b/backend/eventloop/workspace_resource_event_loop.go
@@ -229,12 +229,12 @@ func handleResourceLoopRepositoryCredential(ctx context.Context, msg workspaceRe
 	}
 
 	// Retrieve the namespace that the repository credential is contained within
-	namespace := &corev1.Namespace{
+	namespace := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: req.Namespace,
 		},
 	}
-	if err := msg.apiNamespaceClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
+	if err := msg.apiNamespaceClient.Get(ctx, client.ObjectKeyFromObject(&namespace), &namespace); err != nil {
 
 		if !apierr.IsNotFound(err) {
 			return retry, fmt.Errorf("unexpected error in retrieving repo credentials: %v", err)
@@ -249,7 +249,7 @@ func handleResourceLoopRepositoryCredential(ctx context.Context, msg workspaceRe
 	// - If the GitOpsDeploymentRepositoryCredential does exist, but not in the DB, then create a RepositoryCredential DB entry
 	// - If the GitOpsDeploymentRepositoryCredential does exist, and also in the DB, then compare and change a RepositoryCredential DB entry
 	// Then, in all 3 cases, create an Operation to update the cluster-agent
-	_, err := sharedResourceLoop.ReconcileRepositoryCredential(ctx, msg.apiNamespaceClient, *namespace, req.Name, k8sClientFactory, log)
+	_, err := sharedResourceLoop.ReconcileRepositoryCredential(ctx, msg.apiNamespaceClient, namespace, req.Name, k8sClientFactory, log)
 
 	if err != nil {
 		return retry, fmt.Errorf("unable to reconcile repository credential. Error: %v", err)

--- a/tests-e2e/appstudio/environment_test.go
+++ b/tests-e2e/appstudio/environment_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Environment Status.Conditions tests", func() {
 					Name:      "my-managed-env-secret",
 					Namespace: fixture.GitOpsServiceE2ENamespace,
 				},
-				Type:       "managed-gitops.redhat.com/managed-environment",
+				Type:       sharedutil.ManagedEnvironmentSecretType,
 				StringData: map[string]string{"kubeconfig": kubeConfigContents},
 			}
 

--- a/tests-e2e/core/queryscoped_cluster_secrets_test.go
+++ b/tests-e2e/core/queryscoped_cluster_secrets_test.go
@@ -12,6 +12,7 @@ import (
 	dbutil "github.com/redhat-appstudio/managed-gitops/backend-shared/db/util"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 
+	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	gitopsDeplFixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/gitopsdeployment"
 	k8s "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
 	appsv1 "k8s.io/api/apps/v1"
@@ -154,7 +155,7 @@ var _ = Describe("Query-scoped GitOpsDeployment tests", func() {
 							Name:      "managed-env-deploys-to-" + userName,
 							Namespace: destUserNamespace,
 						},
-						Type:       "managed-gitops.redhat.com/managed-environment",
+						Type:       sharedutil.ManagedEnvironmentSecretType,
 						StringData: map[string]string{"kubeconfig": kubeConfigContents},
 					}
 					err = k8s.Create(&secret, k8sClient)

--- a/tests-e2e/fixture/gitopsdeploymentrepositorycredential/fixture.go
+++ b/tests-e2e/fixture/gitopsdeploymentrepositorycredential/fixture.go
@@ -17,7 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// HaveConditions will return a matcher that will check whether a GitOpsDeployment has the expected conditons.
+// HaveConditions will return a matcher that will check whether a GitOpsDeploymentRepositoryCredential has the expected conditons.
 // - When comparing conditions, it will ignore the LastProbeTime/LastTransitionTime fields.
 func HaveConditions(conditions []metav1.Condition) matcher.GomegaMatcher {
 

--- a/tests-e2e/fixture/k8s/fixture.go
+++ b/tests-e2e/fixture/k8s/fixture.go
@@ -170,7 +170,7 @@ func UpdateWithoutConflict(obj client.Object, k8sClient client.Client, modify fu
 }
 
 // CreateSecret creates a secret with the given stringData.
-func CreateSecret(namespace string, secretName string, stringData map[string]string, k8sClient client.Client) error {
+func CreateSecret(namespace string, secretName string, typeStr string, stringData map[string]string, k8sClient client.Client) (corev1.Secret, error) {
 
 	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{},
@@ -181,10 +181,15 @@ func CreateSecret(namespace string, secretName string, stringData map[string]str
 		Immutable:  nil,
 		Data:       nil,
 		StringData: stringData,
-		Type:       "",
+		Type:       corev1.SecretType(typeStr),
 	}
 
-	return Create(secret, k8sClient)
+	if err := Create(secret, k8sClient); err != nil {
+		return corev1.Secret{}, err
+	} else {
+		return *secret, err
+	}
+
 }
 
 // getOrCreateServiceAccountBearerToken returns a token if there is an existing token secret for a service account.

--- a/tests-e2e/fixture/managedenvironment/fixture.go
+++ b/tests-e2e/fixture/managedenvironment/fixture.go
@@ -11,6 +11,7 @@ import (
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
 
+	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -180,7 +181,7 @@ func BuildManagedEnvironment(apiServerURL string, kubeConfigContents string, cre
 			Name:      "my-managed-env-secret",
 			Namespace: fixture.GitOpsServiceE2ENamespace,
 		},
-		Type:       "managed-gitops.redhat.com/managed-environment",
+		Type:       sharedutil.ManagedEnvironmentSecretType,
 		StringData: map[string]string{"kubeconfig": kubeConfigContents},
 	}
 


### PR DESCRIPTION
#### Description:
- At present, the GitOpsRepositoryCredential reconciler is not watching Secret resources for changes. 
- This means that if a user changes the private Git repository credentials defined in a Secret (for example, changing their password), this will not be detected by the GitOpsRepositoryCredential reconciler.
- The fix is to add a watch for Secret resources to the controller, plus unit/E2E tests to verify


- Other PR Changes:
    - Fixed a bug where Operation was created in the Namespace of the GitOpsDeploymentReploymentCredential, rather than in the Argo CD namespace
    - Add a new function interface which allow us to mock the validation of Git repos from unit tests
    - Fix constant typos
    - Improved pointer hygiene
    - Change Secret watch type from `predicate.GenerationChangedPredicate` to `predicate.ResourceVersionChangedPredicate`, since Secrets don't have a generation
    - Refactor function signatures parameter order, so that `context` is first (which is a K8s pattern), followed by parameters relevant to what the function is doing, followed by generic parameters (database obj, log, etc). In general, parameters should be ordered in most important to least important.
    -  Move `managed-gitops.redhat.com/*` strings into a constant, and update references
    - Update E2E tests, and allow them to run if not all private repo credentials are defined

#### Link to JIRA Story (if applicable): https://issues.redhat.com/browse/GITOPSRVCE-788

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
