### PR TITLE
Move up ArgoCD CRs to v1beta1 API version

### DIFF
--- a/manifests/base/gitops-service-argocd/base/argo-cd.yaml
+++ b/manifests/base/gitops-service-argocd/base/argo-cd.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   finalizers:

--- a/manifests/base/gitops-service-argocd/overlays/appstudio-staging-and-prod/argo-cd-patch.yaml
+++ b/manifests/base/gitops-service-argocd/overlays/appstudio-staging-and-prod/argo-cd-patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: gitops-service-argocd

--- a/manifests/base/gitops-service-argocd/overlays/test-e2e/argo-cd-patch.yaml
+++ b/manifests/base/gitops-service-argocd/overlays/test-e2e/argo-cd-patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   finalizers:


### PR DESCRIPTION
#### Description:
- Latest version of OpenShift GitOps has a new API version `v1beta1` for `ArgoCD` resource. 
- Since there are issues with the conversion between the versions, it seems easiest to move to the new version.

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
