### PR TITLE
Use updated Environment API .

### DIFF
--- a/appstudio-controller/controllers/webhooks/environment_webhook.go
+++ b/appstudio-controller/controllers/webhooks/environment_webhook.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"reflect"
 
 	"github.com/go-logr/logr"
 	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
@@ -92,7 +93,7 @@ func (r *EnvironmentWebhook) ValidateDelete(ctx context.Context, obj runtime.Obj
 // validateEnvironment validates the ingress domain and API URL
 func validateEnvironment(r *appstudiov1alpha1.Environment) error {
 
-	unstableConfig := r.Spec.UnstableConfigurationFields
+	unstableConfig := r.Spec.Target
 	if unstableConfig != nil {
 		// if cluster type is Kubernetes, then Ingress Domain should be set
 		if unstableConfig.ClusterType == appstudiov1alpha1.ConfigurationClusterType_Kubernetes && unstableConfig.IngressDomain == "" {
@@ -106,8 +107,8 @@ func validateEnvironment(r *appstudiov1alpha1.Environment) error {
 
 	}
 
-	if r.Spec.UnstableConfigurationFields != nil && r.Spec.UnstableConfigurationFields.KubernetesClusterCredentials.APIURL != "" {
-		if _, err := url.ParseRequestURI(r.Spec.UnstableConfigurationFields.KubernetesClusterCredentials.APIURL); err != nil {
+	if r.Spec.Target != nil && !reflect.ValueOf(r.Spec.Target.KubernetesClusterCredentials).IsZero() && r.Spec.Target.KubernetesClusterCredentials.APIURL != "" {
+		if _, err := url.ParseRequestURI(r.Spec.Target.KubernetesClusterCredentials.APIURL); err != nil {
 			return fmt.Errorf(err.Error() + appstudiov1alpha1.InvalidAPIURL)
 		}
 	}

--- a/appstudio-controller/go.mod
+++ b/appstudio-controller/go.mod
@@ -104,6 +104,7 @@ require (
 )
 
 replace (
+	github.com/redhat-appstudio/application-api => github.com/jparsai/application-api v0.0.0-20231130073333-292c289fba98
 	github.com/redhat-appstudio/managed-gitops/backend => ../backend
 	github.com/redhat-appstudio/managed-gitops/backend-shared => ../backend-shared
 	github.com/redhat-appstudio/managed-gitops/utilities/db-migration => ../utilities/db-migration

--- a/appstudio-controller/go.sum
+++ b/appstudio-controller/go.sum
@@ -252,6 +252,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jparsai/application-api v0.0.0-20231130073333-292c289fba98 h1:ALKrFI38XeUY2pEKEY4Di0vAndfOYjfrejt1JU3fLQM=
+github.com/jparsai/application-api v0.0.0-20231130073333-292c289fba98/go.mod h1:YvckuKHe82eWloGk0/BpSw4YYG2owrGZAanztbOj3pQ=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -343,8 +345,6 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
-github.com/redhat-appstudio/application-api v0.0.0-20231025105224-2790bb451725 h1:9808yVdQmzCLGrbedW6h4brggYqdnMpyMwKhFpx9/pE=
-github.com/redhat-appstudio/application-api v0.0.0-20231025105224-2790bb451725/go.mod h1:OvmeiVOItG2OSX/QE+vQwzOYfbOMBhBy43ZFxkWZJyc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=

--- a/manifests/base/crd/overlays/local-dev/kustomization.yaml
+++ b/manifests/base/crd/overlays/local-dev/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/redhat-appstudio/application-api/config/crd?ref=8d112632297181de2d5f209ab98015457d0abf31
+- https://github.com/jparsai/application-api/config/crd?ref=49b788bdf462cc1065edc06f061ffa3ffd520bc5
 - https://github.com/codeready-toolchain/host-operator/config/crd?ref=6c9e07da3665f542448ff46fc91d7fa1bfd83853
 - ../../base

--- a/tests-e2e/appstudio/dt_dtc_dtclass_test.go
+++ b/tests-e2e/appstudio/dt_dtc_dtclass_test.go
@@ -89,7 +89,9 @@ var _ = Describe("DeploymentTarget DeploymentTargetClaim and Class tests", func(
 						Env: []appstudiosharedv1.EnvVarPair{
 							{Name: "e1", Value: "v1"},
 						},
-						Target: appstudiosharedv1.EnvironmentTarget{
+					},
+					Target: &appstudiosharedv1.TargetConfiguration{
+						Claim: appstudiosharedv1.TargetClaim{
 							DeploymentTargetClaim: appstudiosharedv1.DeploymentTargetClaimConfig{
 								ClaimName: dtc.Name,
 							},

--- a/tests-e2e/appstudio/promotionrun_controller_test.go
+++ b/tests-e2e/appstudio/promotionrun_controller_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Application Promotion Run E2E Tests.", func() {
 			// Staging environment must be in a different namespace from the production environment, else we get a
 			// problem with the same resource being owned by two different applications.
 			// See Jira issue https://issues.redhat.com/browse/GITOPSRVCE-544
-			environmentStage.Spec.UnstableConfigurationFields = &appstudiosharedv1.UnstableEnvironmentConfiguration{
+			environmentStage.Spec.Target = &appstudiosharedv1.TargetConfiguration{
 				KubernetesClusterCredentials: appstudiosharedv1.KubernetesClusterCredentials{
 					TargetNamespace:            secondNamespace,
 					APIURL:                     apiServerURL,

--- a/tests-e2e/appstudio/snapshotenvironmentbinding_test.go
+++ b/tests-e2e/appstudio/snapshotenvironmentbinding_test.go
@@ -584,7 +584,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 						},
 					},
 					// The cluster doesn't need to be real for this test
-					UnstableConfigurationFields: &appstudiosharedv1.UnstableEnvironmentConfiguration{
+					Target: &appstudiosharedv1.TargetConfiguration{
 						KubernetesClusterCredentials: appstudiosharedv1.KubernetesClusterCredentials{
 							TargetNamespace:            "namespace1",
 							APIURL:                     "https://fake-url-does-not-exist.redhat.com",
@@ -617,7 +617,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 				},
 			}
 			Eventually(gitopsDepl, "60s", "1s").
-				Should(gitopsDeplFixture.HaveTargetNamespace(environment.Spec.UnstableConfigurationFields.TargetNamespace),
+				Should(gitopsDeplFixture.HaveTargetNamespace(environment.Spec.Target.TargetNamespace),
 					"should match the Environment's current target ns value")
 
 			By("updating the Environment to target another namespace")
@@ -626,7 +626,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 				envObj, ok := obj.(*appstudiosharedv1.Environment)
 
 				Expect(ok).To(BeTrue())
-				envObj.Spec.UnstableConfigurationFields.TargetNamespace = "another-namespace"
+				envObj.Spec.Target.TargetNamespace = "another-namespace"
 
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -670,15 +670,14 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 
 				envObj, ok := obj.(*appstudiosharedv1.Environment)
 				Expect(ok).To(BeTrue())
-				envObj.Spec.UnstableConfigurationFields = nil
+				envObj.Spec.Target.Claim = appstudiosharedv1.TargetClaim{
+					DeploymentTargetClaim: appstudiosharedv1.DeploymentTargetClaimConfig{
+						ClaimName: dtc.Name,
+					},
+				}
 				envObj.Spec.Configuration = appstudiosharedv1.EnvironmentConfiguration{
 					Env: []appstudiosharedv1.EnvVarPair{
 						{Name: "e1", Value: "v1"},
-					},
-					Target: appstudiosharedv1.EnvironmentTarget{
-						DeploymentTargetClaim: appstudiosharedv1.DeploymentTargetClaimConfig{
-							ClaimName: dtc.Name,
-						},
 					},
 				}
 
@@ -712,7 +711,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 						{Name: "e1", Value: "v1"},
 					},
 				}
-				envObj.Spec.UnstableConfigurationFields = &appstudiosharedv1.UnstableEnvironmentConfiguration{
+				envObj.Spec.Target = &appstudiosharedv1.TargetConfiguration{
 					KubernetesClusterCredentials: appstudiosharedv1.KubernetesClusterCredentials{
 						TargetNamespace:            "namespace1",
 						APIURL:                     "https://fake-url-does-not-exist.redhat.com",
@@ -747,7 +746,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 			err = k8s.Get(&environment, k8sClient)
 			Expect(err).ToNot(HaveOccurred())
 
-			environment.Spec.UnstableConfigurationFields = &appstudiosharedv1.UnstableEnvironmentConfiguration{
+			environment.Spec.Target = &appstudiosharedv1.TargetConfiguration{
 				KubernetesClusterCredentials: appstudiosharedv1.KubernetesClusterCredentials{
 					TargetNamespace:          fixture.GitOpsServiceE2ENamespace,
 					APIURL:                   "https://api-url",
@@ -788,7 +787,7 @@ var _ = Describe("SnapshotEnvironmentBinding Reconciler E2E tests", func() {
 			Expect(gitopsDeployment.Spec.Destination.Environment).To(Equal("managed-environment-"+environment.Name),
 				"the destination should be the environment")
 			Expect(gitopsDeployment.Spec.Destination.Namespace).
-				To(Equal(environment.Spec.UnstableConfigurationFields.KubernetesClusterCredentials.TargetNamespace),
+				To(Equal(environment.Spec.Target.KubernetesClusterCredentials.TargetNamespace),
 					"the namespace of the GitOpsDeployment should come from the Environment")
 		})
 

--- a/tests-e2e/appstudio/webhook_test.go
+++ b/tests-e2e/appstudio/webhook_test.go
@@ -272,7 +272,7 @@ var _ = Describe("Webhook E2E tests", func() {
 
 			By("create environment with invalid kubernetesClusterCredentials API URL.")
 			environment := buildEnvironmentResource("staging", "my-environment", "", appstudiosharedv1.EnvironmentType_POC)
-			environment.Spec.UnstableConfigurationFields = &appstudiosharedv1.UnstableEnvironmentConfiguration{
+			environment.Spec.Target = &appstudiosharedv1.TargetConfiguration{
 				KubernetesClusterCredentials: appstudiosharedv1.KubernetesClusterCredentials{
 					TargetNamespace:            fixture.GitOpsServiceE2ENamespace,
 					APIURL:                     "api/test-url.com:6443",
@@ -285,7 +285,7 @@ var _ = Describe("Webhook E2E tests", func() {
 			Expect(strings.Contains(err.Error(), "API URL must be an absolute URL starting with an 'https' scheme")).To(BeTrue())
 
 			By("create environment with valid kubernetesClusterCredentials API URL.")
-			environment.Spec.UnstableConfigurationFields = &appstudiosharedv1.UnstableEnvironmentConfiguration{
+			environment.Spec.Target = &appstudiosharedv1.TargetConfiguration{
 				KubernetesClusterCredentials: appstudiosharedv1.KubernetesClusterCredentials{
 					TargetNamespace:            fixture.GitOpsServiceE2ENamespace,
 					APIURL:                     apiServerURL,
@@ -305,7 +305,7 @@ var _ = Describe("Webhook E2E tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("update environment with invalid kubernetesClusterCredentials API URL.")
-			environment.Spec.UnstableConfigurationFields = &appstudiosharedv1.UnstableEnvironmentConfiguration{
+			environment.Spec.Target = &appstudiosharedv1.TargetConfiguration{
 				KubernetesClusterCredentials: appstudiosharedv1.KubernetesClusterCredentials{
 					TargetNamespace:            fixture.GitOpsServiceE2ENamespace,
 					APIURL:                     "api/test-url.com:6443",

--- a/tests-e2e/go.mod
+++ b/tests-e2e/go.mod
@@ -195,6 +195,7 @@ require (
 
 replace (
 	// Monorepo
+	github.com/redhat-appstudio/application-api => github.com/jparsai/application-api v0.0.0-20231130073333-292c289fba98
 	github.com/redhat-appstudio/managed-gitops/appstudio-controller => ../appstudio-controller
 	github.com/redhat-appstudio/managed-gitops/backend => ../backend
 	github.com/redhat-appstudio/managed-gitops/backend-shared => ../backend-shared

--- a/tests-e2e/go.sum
+++ b/tests-e2e/go.sum
@@ -445,6 +445,8 @@ github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9q
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jparsai/application-api v0.0.0-20231130073333-292c289fba98 h1:ALKrFI38XeUY2pEKEY4Di0vAndfOYjfrejt1JU3fLQM=
+github.com/jparsai/application-api v0.0.0-20231130073333-292c289fba98/go.mod h1:YvckuKHe82eWloGk0/BpSw4YYG2owrGZAanztbOj3pQ=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -641,8 +643,6 @@ github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPH
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/r3labs/diff v1.1.0 h1:V53xhrbTHrWFWq3gI4b94AjgEJOerO1+1l0xyHOBi8M=
 github.com/r3labs/diff v1.1.0/go.mod h1:7WjXasNzi0vJetRcB/RqNl5dlIsmXcTTLmF5IoH6Xig=
-github.com/redhat-appstudio/application-api v0.0.0-20231025105224-2790bb451725 h1:9808yVdQmzCLGrbedW6h4brggYqdnMpyMwKhFpx9/pE=
-github.com/redhat-appstudio/application-api v0.0.0-20231025105224-2790bb451725/go.mod h1:OvmeiVOItG2OSX/QE+vQwzOYfbOMBhBy43ZFxkWZJyc=
 github.com/redis/go-redis/v9 v9.0.0-rc.4/go.mod h1:Vo3EsyWnicKnSKCA7HhgnvnyA74wOA69Cd2Meli5mmA=
 github.com/redis/go-redis/v9 v9.0.5 h1:CuQcn5HIEeK7BgElubPP8CGtE0KakrnbBSTLjathl5o=
 github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=


### PR DESCRIPTION
## Description
This PR is to use latest version of of v1alha1 Environment API which will be updated by [this PR](https://github.com/redhat-appstudio/application-api/pull/79). 
Now managed-gitops controllers and tests will use `Target` field instead of `UnstableConfigurationFields` and `Target.Claim.DeploymentTargetClaim.ClaimName` instead of `Configuration.Target.DeploymentTargetClaim.ClaimName`.
Also there are few changes that were suggested by SonarCloud.

## Jira Ticket
https://issues.redhat.com/browse/GITOPSRVCE-664