### PR TITLE
fix : SharedResourceManagedEnvContainer struct size reduction 

### DIFF
--- a/backend/eventloop/shared_resource_loop/sharedresourceloop.go
+++ b/backend/eventloop/shared_resource_loop/sharedresourceloop.go
@@ -372,14 +372,14 @@ func newSharedResourceManagedEnvContainer() SharedResourceManagedEnvContainer {
 // resources that were created by the reconciliation.
 type SharedResourceManagedEnvContainer struct {
 	ClusterUser          *db.ClusterUser
-	IsNewUser            bool
 	ManagedEnv           *db.ManagedEnvironment
-	IsNewManagedEnv      bool
 	GitopsEngineInstance *db.GitopsEngineInstance
-	IsNewInstance        bool
 	ClusterAccess        *db.ClusterAccess
-	IsNewClusterAccess   bool
 	GitopsEngineCluster  *db.GitopsEngineCluster
+	IsNewUser            bool
+	IsNewManagedEnv      bool
+	IsNewInstance        bool
+	IsNewClusterAccess   bool
 }
 
 type sharedResourceLoopMessage_getOrCreateClusterUserByNamespaceUIDRequest struct {


### PR DESCRIPTION
#### Description:
This PR fixes a performance issue in your codebase.

While triaging your project, our bug fixing tool found that - 
In file `sharedresourceloop.go`  theres is a struct `SharedResourceManagedEnvContainer` whose size can be reduced to improve memory efficiency.
[sharedresourceloop.go](https://github.com/redhat-appstudio/managed-gitops/blob/d212feec70d01a2f78fc1e64bf8ce2a7b36dca88/backend/eventloop/shared_resource_loop/sharedresourceloop.go#L373)
```go
type SharedResourceManagedEnvContainer struct {
	ClusterUser          *db.ClusterUser
	IsNewUser            bool
	ManagedEnv           *db.ManagedEnvironment
	IsNewManagedEnv      bool
	GitopsEngineInstance *db.GitopsEngineInstance
	IsNewInstance        bool
	ClusterAccess        *db.ClusterAccess
	IsNewClusterAccess   bool
	GitopsEngineCluster  *db.GitopsEngineCluster
}
```
The way the struct above is defined, memory allocation for it would look something like this - 
![StructReduction drawio(2)](https://github.com/redhat-appstudio/managed-gitops/assets/141129124/cea8371c-4734-43af-8b4f-18b7caa5590f)
Which results in a total of 72 bytes. The extra padding bytes comes from the fact that in case of structs memory is allocated in contiguous, byte-aligned blocks to fields in the order that they are defined. 
### Solution
The fix is to define the struct in such a way that least number of padding bytes are introduced. The following definition results in allocation of only 48 bytes of memory as opposed to previous 72 bytes.
```go
type SharedResourceManagedEnvContainer struct {
	ClusterUser          *db.ClusterUser
        ManagedEnv           *db.ManagedEnvironment
        GitopsEngineInstance *db.GitopsEngineInstance
        ClusterAccess        *db.ClusterAccess
	IsNewUser            bool
	IsNewManagedEnv      bool
	IsNewInstance        bool
	IsNewClusterAccess   bool
	GitopsEngineCluster  *db.GitopsEngineCluster
}
```
### References
- [Golang Writing memory efficient and CPU optimized Go Structs](https://dev.to/deadlock/golang-writing-memory-efficient-and-cpu-optimized-go-structs-2ick)

### CLA Requirements:
This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.

All contributed commits are already automatically signed off.

The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
- [Git Commit SignOff documentation](https://developercertificate.org/)

### Sponsorship and Support:
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed - to improve global software supply chain security.

The bug is found by running the iCR tool by [OpenRefactory, Inc.](https://openrefactory.com/) and then manually triaging the results.
