### PR TITLE
Update has references

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 This repo is the home for all the Managed GitOps Service components.
 It contains various tools and services that you can use to deploy, as well as the libraries you can use to develop the GitOps Service that will be integrated with the Stonesoup project.
 
-This repository is closely associated with the [application-api](https://github.com/redhat-appstudio/application-api/) repository, which contains the public Stonesoup APIs exposed by the application-service and appstudio-controller components.
+This repository is closely associated with the [application-api](https://github.com/konflux-ci/application-api/) repository, which contains the public Stonesoup APIs exposed by the application-service and appstudio-controller components.
 
 ---
 

--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttarget_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttarget_controller.go
@@ -23,8 +23,8 @@ import (
 
 	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	applicationv1alpha1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/go-logr/logr"
-	applicationv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	logutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util/log"
 	apierr "k8s.io/apimachinery/pkg/api/errors"

--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttarget_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttarget_controller_test.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/tests"
 	corev1 "k8s.io/api/core/v1"

--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetclaim_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetclaim_controller.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 
 	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	applicationv1alpha1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/go-logr/logr"
-	applicationv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	logutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util/log"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetclaim_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/deploymenttargetclaim_controller_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 
 	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/tests"
 	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"

--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller.go
@@ -25,7 +25,7 @@ import (
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	logutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util/log"
 
-	appstudioshared "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	appstudioshared "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/environment_controller_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"reflect"
 
+	appstudioshared "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appstudioshared "github.com/redhat-appstudio/application-api/api/v1alpha1"
 
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1/mocks"

--- a/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
+	appstudioshared "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/go-logr/logr"
-	appstudioshared "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	apibackend "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	logutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util/log"

--- a/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/promotionrun_controller_test.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	apibackend "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/tests"
 )

--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshot_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshot_controller.go
@@ -19,7 +19,7 @@ package appstudioredhatcom
 import (
 	"context"
 
-	appstudioshared "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	appstudioshared "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	logutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util/log"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"time"
 
+	appstudioshared "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/go-logr/logr"
-	appstudioshared "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	apibackend "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	logutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util/log"

--- a/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/snapshotenvironmentbinding_controller_test.go
@@ -21,7 +21,7 @@ import (
 
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	apibackend "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/tests"
 )

--- a/appstudio-controller/controllers/appstudio.redhat.com/spacerequest_controller.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/spacerequest_controller.go
@@ -25,8 +25,8 @@ import (
 
 	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	applicationv1alpha1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/go-logr/logr"
-	applicationv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	logutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util/log"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/appstudio-controller/controllers/appstudio.redhat.com/spacerequest_controller_test.go
+++ b/appstudio-controller/controllers/appstudio.redhat.com/spacerequest_controller_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 
 	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/util/tests"
 	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"

--- a/appstudio-controller/controllers/webhooks/environment_webhook.go
+++ b/appstudio-controller/controllers/webhooks/environment_webhook.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"net/url"
 
+	appstudiov1alpha1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/go-logr/logr"
-	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/appstudio-controller/controllers/webhooks/environment_webhook_unit_test.go
+++ b/appstudio-controller/controllers/webhooks/environment_webhook_unit_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	appstudiov1alpha1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zapcore"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/appstudio-controller/controllers/webhooks/promotionrun_webhook.go
+++ b/appstudio-controller/controllers/webhooks/promotionrun_webhook.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"reflect"
 
+	appstudiov1alpha1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/go-logr/logr"
-	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/appstudio-controller/controllers/webhooks/promotionrun_webhook_test.go
+++ b/appstudio-controller/controllers/webhooks/promotionrun_webhook_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	appstudiov1alpha1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"

--- a/appstudio-controller/controllers/webhooks/snapshot_webhook unit_test.go
+++ b/appstudio-controller/controllers/webhooks/snapshot_webhook unit_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	appstudiov1alpha1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"

--- a/appstudio-controller/controllers/webhooks/snapshot_webhook.go
+++ b/appstudio-controller/controllers/webhooks/snapshot_webhook.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"reflect"
 
+	appstudiov1alpha1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/go-logr/logr"
-	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/appstudio-controller/controllers/webhooks/snapshotenvironmentbinding_webhook.go
+++ b/appstudio-controller/controllers/webhooks/snapshotenvironmentbinding_webhook.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"reflect"
 
+	appstudiov1alpha1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/go-logr/logr"
-	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/appstudio-controller/controllers/webhooks/snapshotenvironmentbinding_webhook_test.go
+++ b/appstudio-controller/controllers/webhooks/snapshotenvironmentbinding_webhook_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	appstudiov1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	appstudiov1alpha1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zapcore"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/appstudio-controller/go.mod
+++ b/appstudio-controller/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/onsi/ginkgo/v2 v2.6.0
 	github.com/onsi/gomega v1.24.1
-	github.com/redhat-appstudio/application-api v0.0.0-20240106104232-18f545e48a03
+	github.com/github.com/konflux-ci/application-api v0.0.0-20240106104232-18f545e48a03
 	github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0
 	github.com/stretchr/testify v1.8.0
 	k8s.io/apimachinery v0.25.0

--- a/appstudio-controller/go.sum
+++ b/appstudio-controller/go.sum
@@ -343,8 +343,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
-github.com/redhat-appstudio/application-api v0.0.0-20240106104232-18f545e48a03 h1:UUgrEyvQJhEnvghkEaY9YlxeAk+D4cop+Bd3+8jh0eQ=
-github.com/redhat-appstudio/application-api v0.0.0-20240106104232-18f545e48a03/go.mod h1:YvckuKHe82eWloGk0/BpSw4YYG2owrGZAanztbOj3pQ=
+github.com/github.com/konflux-ci/application-api v0.0.0-20240106104232-18f545e48a03 h1:UUgrEyvQJhEnvghkEaY9YlxeAk+D4cop+Bd3+8jh0eQ=
+github.com/github.com/konflux-ci/application-api v0.0.0-20240106104232-18f545e48a03/go.mod h1:YvckuKHe82eWloGk0/BpSw4YYG2owrGZAanztbOj3pQ=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=

--- a/appstudio-controller/main.go
+++ b/appstudio-controller/main.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	applicationv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	applicationv1alpha1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	gitopsdeploymentv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 
 	appstudioredhatcomcontrollers "github.com/redhat-appstudio/managed-gitops/appstudio-controller/controllers/appstudio.redhat.com"

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,7 @@ The K8s resource *Go structs* defined in the `managed-gitops` repository, the `a
 ## Core vs App Studio Environment APIs
 
 The App Studio Environment APIs implement (opinionated) concepts and APIs that are specific to App Studio, including `Environment`s, `Application`s, and `Component`s.
-- Applications and Components are examples of App-Studio-specific concepts that relate to how an application is composed, and are primarily reconciled by the [application-service](https://github.com/redhat-appstudio/application-service) component.
+- Applications and Components are examples of App-Studio-specific concepts that relate to how an application is composed, and are primarily reconciled by the [application-service](https://github.com/konflux-ci/application-service) component.
 - App Studio Environment APIs implement promotion of application versions between environments, via APIs such as `Environment`, `Snapshot`, and `SnapshotEnvironmentBinding`.
 - App Studio API resources are translated by the AppStudio GitOps Service controllers into one or more Core GitOps Service API resources. For example:
     - A `SnapshotEnvironmentBinding` is reconciled into one or more `GitOpsDeployments`.
@@ -354,7 +354,7 @@ See the [GitOpsDeploymentSyncRun API reference](https://redhat-appstudio.github.
 
 ## GitOps Service: App Studio Environment APIs
 
-The App Studio Environment API is based on the [Application](https://redhat-appstudio.github.io/book/ref/application-environment-api.html#application), and [Component](https://redhat-appstudio.github.io/book/ref/application-environment-api.html#component) APIs, which are primarily handled by the [application-service](https://github.com/redhat-appstudio/application-service) component. 
+The App Studio Environment API is based on the [Application](https://redhat-appstudio.github.io/book/ref/application-environment-api.html#application), and [Component](https://redhat-appstudio.github.io/book/ref/application-environment-api.html#component) APIs, which are primarily handled by the [application-service](https://github.com/konflux-ci/application-service) component. 
 - These APIs are opinionated representations of the constituent parts of a user's application: a application (e.g. a loan application of a bank) contains multiple components (e.g. Node frontend, Java backend, Postgresql database).
 
 The App Studio Environment APIs -- which are simultaneously reconciled by multiple App Studio components -- are all related to provisioning or deploying K8s resources to external environments, such as external K8s clusters/namespaces or local namespaces.

--- a/docs/components.md
+++ b/docs/components.md
@@ -8,6 +8,7 @@ There are 4 separated, tightly-coupled components:
 - [Backend Shared]: Contains code that is shared among the rest of the components. This is where shared utility code lives, such as GitOpsDeployment resource Go types, database Go types, and database access functionality. Including code within this component ensures it is not duplicated within the other components.
 
 There is also a fifth component, which lives in a separate GitHub repository:
+
 - [application-api]: defines the public API of GitOps Service 'appstudio-controller' component (e.g the Environment API), and the App Studio 'application-service' component.
 
 For detailed step-by-step guide on how each component works, check the `README` file of each individual component.
@@ -24,9 +25,10 @@ For detailed step-by-step guide on how each component works, check the `README` 
 Plus, within each of the components there is a `Makefile`, which can be used for local development of that component.
 
 ## Deprecated components
+
 - GitOps Service Frontend: The 'frontend' component of the GitOps Service was an early UI prototype for interfacing with the GitOps Service via a Web UI based on PatternFly. The contents of this prototype can be found [under this commit](https://github.com/redhat-appstudio/managed-gitops/tree/52696fbb48070bf43170687a6a775ff80dfb13be/frontend).
 
-[application-api]: https://github.com/redhat-appstudio/application-api/
+[application-api]: https://github.com/github.com/konflux-ci/application-api/
 [App Studio Controller]: https://github.com/redhat-appstudio/managed-gitops/tree/main/appstudio-controller
 [App Studio Shared]: https://github.com/redhat-appstudio/managed-gitops/tree/main/appstudio-shared
 [Backend Shared]: https://github.com/redhat-appstudio/managed-gitops/tree/main/backend-shared

--- a/docs/designs/initial-api-design.md
+++ b/docs/designs/initial-api-design.md
@@ -187,7 +187,7 @@ The contents of this CR roughly translates into an [Argo CD repository secret](h
 
 ## Workflow: when an Application CR is first created (from the GitOps service perspective)
 
-The _Application_ CR definition can be found in [GitHub](https://github.com/redhat-appstudio/application-service/blob/main/api/v1alpha1/hasapplication_types.go). From the Application Service, the contents of the _‘gitOpsRepository_’ field are used.
+The _Application_ CR definition can be found in [GitHub](https://github.com/konflux-ci/application-service/blob/main/api/v1alpha1/hasapplication_types.go). From the Application Service, the contents of the _‘gitOpsRepository_’ field are used.
 
 The AppStudio GitOps service watches for creation/update/deletion of an Application CR, and creates a corresponding _GitOpsDeployment_ CR and _GitOpsDeploymentRepositoryCredentials_ CR.
 

--- a/docs/environment-api/introduction.md
+++ b/docs/environment-api/introduction.md
@@ -4,7 +4,8 @@ Written by Jonathan West (@jgwest) on February 1st, 2024.
 
 ## Konflux Environment API
 
-The Red Hat product/project that this is attached to has had many names: AppStudio, RHTAP (Red Hat Trusted Application Pipeline), Konflux, and more. 
+The Red Hat product/project that this is attached to has had many names: AppStudio, RHTAP (Red Hat Trusted Application Pipeline), Konflux, and more.
+
 - In the linked resources, you will see many of these names (mostly AppStudio). They all refer to the same code, but a succession of project/product names.
 - For the purposes of this document, I will use 'Konflux', the latest name, as of this writing, February 2024.
 - However, the code/API referenced in this document has been deprecated, will no longer be used, and will be removed from the Konflux project.
@@ -15,169 +16,174 @@ For more information on the Environment API, see the [detailed document I wrote]
 
 Within Konflux project, the need was identified to define a set of custom resources/concepts, that would allow users to progressively build/test/deploy different versions of their Applications across a set of Kubernetes Environments, with the deployment handled by Argo CD.
 
-Here's what those requirements became: 
+Here's what those requirements became:
+
 - Konflux concepts (and K8s custom resources): `Application`, `Component`, `Environment`, `Snapshot`, `SnapshotEnvironmentBinding`
 
 - You define an `Application`. (e.g. `bank-loan-app`)
-	- **NOTE**: ZERO relation to Argo CD's Application custom resource (CR)/concept, put this out of your mind here in this context. They just happen share a name 😀
-	- In this document, I'll use "Argo CD Application" when I specifically mean that.
+  - **NOTE**: ZERO relation to Argo CD's Application custom resource (CR)/concept, put this out of your mind here in this context. They just happen share a name 😀
+  - In this document, I'll use "Argo CD Application" when I specifically mean that.
 - You define `Components`, which are the child components of that Application (e.g. `frontend` in Node, `backend` in Java, `database` in PSQL)
-    - A Component is a single version of a single container
+  - A Component is a single version of a single container
 - You define `Environment`s, which are the K8s clusters that you wish to deploy that Application to (only K8s clusters are supported)
-    - e.g. `test`, `staging`, `prod-eu`, `prod-us`
-	- A DAG, e.g. dev -> test -> staging -> prod. Can be single or multiple children (for example, see last deployment in this example.)
+  - e.g. `test`, `staging`, `prod-eu`, `prod-us`
+  - A DAG, e.g. dev -> test -> staging -> prod. Can be single or multiple children (for example, see last deployment in this example.)
     - ![Relationships between resources](Stages.png)
     - Automated/Manual promotion in this diagram refers to whether human intervention is required to promote from a parent Enviroment to a child Environment:
-        - Automated: Immediately promote to the next child on status of Healthy.
-        - Manual: Wait for a human to tell us to promote to the next child in the DAG.
+      - Automated: Immediately promote to the next child on status of Healthy.
+      - Manual: Wait for a human to tell us to promote to the next child in the DAG.
 - You define a `Snapshot`, which is a particular version of your Application (and specifically, of its constituent Components). (e.g. `bank-loan-app-v2-(commit id)`)
-    - Snapshot defines container image for each component.
+  - Snapshot defines container image for each component.
 - The actual deployment of a Snapshot (specific version of an Application) to an Environment (specific k8s cluster) is performed via a `SnapshotEnvironmentBinding`
-	- `SnapshotEnvironmentBinding` (SEB) defines *(Application, Snapshot, Environment)* tuple
-	- tuple: Application A, of version S, should be deployed to Environment E
+  - `SnapshotEnvironmentBinding` (SEB) defines _(Application, Snapshot, Environment)_ tuple
+  - tuple: Application A, of version S, should be deployed to Environment E
     - Multiple SEBs can target a single environment
 - Finally, `SnapshotEnvironmentBinding` is translated (reconciled, via K8s controller) into 1 or more Argo CD Applications
 - Thus, all of these abstractions **ultimately boil down into 1 or more Argo CD Application CRs** (custom resources) deploying to K8s clusters.
 
-
-
 #### Relationships between the concepts:
+
 ![Relationships between resources](Relationships.png)
+
 - `Binding` seen in the image is just a `SnapshotEnvironmentBinding` (using shorter name in the diagram)
-
-
 
 ## Central Konflux Concepts
 
 All concepts mentioned have a corresponding CR (Kubernetes custom resource) of the same name. I use the two interchangeably, here.
 
 #### Application
+
 - NOTE: This does not refer to an Argo CD Application, neither the CR nor the overall concept. It is entirely different.
-    - When the API was defined I pushed to have them use a different, non-conflicting name, but was outvoted. 😀
-	- When thinking of an Application in the context of this document, it is best to put the Argo CD Application concept/CR entirely out of your mind. They are not compatible or related in any way.
+  - When the API was defined I pushed to have them use a different, non-conflicting name, but was outvoted. 😀
+  - When thinking of an Application in the context of this document, it is best to put the Argo CD Application concept/CR entirely out of your mind. They are not compatible or related in any way.
 - An `Application` is composed of 1 or more `Component`s
 - Applications are the atomic unit of deployment:
-	- All Components of an Application are deployed together.
-	- Components cannot be deployed outside of an Application.
+  - All Components of an Application are deployed together.
+  - Components cannot be deployed outside of an Application.
 - Example: If you're a bank that gives loans to customers, your Application might be 'loan-app', and your components might be 'front-end', 'backend', 'database'.
-- Application and Component are both CRs. 
-- [Application CR code](https://github.com/redhat-appstudio/application-api/blob/18f545e48a03cbc6df71fb0468dac9aa66209c4c/api/v1alpha1/application_types.go#L27)
+- Application and Component are both CRs.
+- [Application CR code](https://github.com/github.com/konflux-ci/application-api/blob/18f545e48a03cbc6df71fb0468dac9aa66209c4c/api/v1alpha1/application_types.go#L27)
 
 #### Component
+
 - A `Component` is a single container running as part of an `Application`.
 - A Component has a single, mandatory Application as a parent.
-    - Components are not shared between different Applications.
+  - Components are not shared between different Applications.
 - Each Component is a single container/container image.
 - Example: a bank might have a 'loan-app' Application, whose job is to provide bank loans. The Components of that Application might be:
-	- Application 'loan-app'
-	    - Component 'frontend': React frontend, served into the browser via a lightweight HTTP server
-    	- Component 'backend': Java-based backend application, containing business logic
-	    - Component 'database': Postgresql image
+  - Application 'loan-app'
+    - Component 'frontend': React frontend, served into the browser via a lightweight HTTP server
+      - Component 'backend': Java-based backend application, containing business logic
+    - Component 'database': Postgresql image
 - Application and Component are both CRs.
-- [Component CR code](https://github.com/redhat-appstudio/application-api/blob/18f545e48a03cbc6df71fb0468dac9aa66209c4c/api/v1alpha1/component_types.go#L75)
-
+- [Component CR code](https://github.com/github.com/konflux-ci/application-api/blob/18f545e48a03cbc6df71fb0468dac9aa66209c4c/api/v1alpha1/component_types.go#L75)
 
 ## Central Environment API Concepts, building on on top of Konflux concepts
 
 All concepts mentioned have a corresponding CR of the same name. I use the two interchangeably, here.
 
 #### Environment
+
 - One or more `Application`s can be deployed to an `Environment`.
 - An Environment is just a CR describing credentials for deploying to a target K8s cluster.
-    - Example Environments: 'staging K8s cluster NA', 'production K8s cluster NA', 'staging K8s cluster EU', 'dev K8s cluster AU', etc.
+  - Example Environments: 'staging K8s cluster NA', 'production K8s cluster NA', 'staging K8s cluster EU', 'dev K8s cluster AU', etc.
 - Environments form a directed acyclic graph (DAG), which describes the order in which a new version of an Application is promoted between environments.
-	- For example: dev NA -> test NA -> staging NA -> prod NA
+  - For example: dev NA -> test NA -> staging NA -> prod NA
     - See diagram above.
 - Example workflow:
-	- Snapshot 'v2' of an Application would first be tested on Environment 'dev NA' (North America)
-	- Once it passes some integration tests, Snapshot 'v2' would be promoted to run on Environment 'test NA'
-    - Next, once successful, v2 would be promoted to 'staging NA' Environment. 
-	- And so on, dev -> test -> staging, along the DAG.
+  - Snapshot 'v2' of an Application would first be tested on Environment 'dev NA' (North America)
+  - Once it passes some integration tests, Snapshot 'v2' would be promoted to run on Environment 'test NA'
+    - Next, once successful, v2 would be promoted to 'staging NA' Environment.
+  - And so on, dev -> test -> staging, along the DAG.
 - [API example/description](https://github.com/redhat-appstudio/managed-gitops/blob/main/docs/api.md#environment)
-- [Environment CR code](https://github.com/redhat-appstudio/application-api/blob/18f545e48a03cbc6df71fb0468dac9aa66209c4c/api/v1alpha1/environment_types.go#L24)
+- [Environment CR code](https://github.com/github.com/konflux-ci/application-api/blob/18f545e48a03cbc6df71fb0468dac9aa66209c4c/api/v1alpha1/environment_types.go#L24)
 
 #### Snapshot
+
 - `Application`s are deployed to `Environments` via `Snapshot`s.
 - `Snapshot` represent a single, atomic version of an Application.
-    - A Snapshot is only useful in the context of the Application it references: a Snapshot is not shared between multiple Applications.
+  - A Snapshot is only useful in the context of the Application it references: a Snapshot is not shared between multiple Applications.
 - A Snapshot is a set of container images, one for each component of an Application.
-	- If an Application has 3 components, the Snapshot will have 3 container images.
+  - If an Application has 3 components, the Snapshot will have 3 container images.
 - Example Snapshot 'v2':
-    - Application: loan-app
-	- Component 'frontend': `quay.io/my-bank/loan-app-frontend:v2` (or tag could be, version, git commit id, or date built, for example)
-	- Component 'backend': `quay.io/my-bank/loan-app-backend:v4`
-	- Component 'database': `postgres:16.1`
+  - Application: loan-app
+  - Component 'frontend': `quay.io/my-bank/loan-app-frontend:v2` (or tag could be, version, git commit id, or date built, for example)
+  - Component 'backend': `quay.io/my-bank/loan-app-backend:v4`
+  - Component 'database': `postgres:16.1`
 - Snapshots can be annotated with additional information, for example, whether or not the Snapshot passed integration tests (thus making the Snapshot ready for promotion to next child in the DAG).
 - You might be thinking: Why have the version be an independent concept from the Application/Component itself? Why not jjust set the version in `.spec` of Component?
-	- Well, the `Snapshot` concept ensures a specific set of constituent container images have necessarily been tested together
+  - Well, the `Snapshot` concept ensures a specific set of constituent container images have necessarily been tested together
     - You want to avoid the case where, for example, you deploy a version of your Application where the backend is incompatible with a newer version of the database software, because they were not tested together.
     - And thus, when deployed together as an Application, those specific Component versions have necessarily been tested together.
 - Snapshots are not shared between different Applications. A Snapshot will have a single Application as a mandatory parent.
 - [API example/description](https://github.com/redhat-appstudio/managed-gitops/blob/main/docs/api.md#snapshot)
-- [Snapshot CR code](https://github.com/redhat-appstudio/application-api/blob/18f545e48a03cbc6df71fb0468dac9aa66209c4c/api/v1alpha1/snapshot_types.go#L25)
+- [Snapshot CR code](https://github.com/github.com/konflux-ci/application-api/blob/18f545e48a03cbc6df71fb0468dac9aa66209c4c/api/v1alpha1/snapshot_types.go#L25)
 
 #### SnapshotEnvironmentBinding
+
 - This is the CR/concept that performs the actual deployment of everything described above. This is where the 'rubber meets the road'.
 - Behind the scenes, a single `SnapshotEnvironmentBinding` is reconciled into X corresponding Argo CD Applications, where X is the number of components of the Snapshot (Application).
 - Describes what Application/Snapshot (version) should be deployed to which Environment.
 - A SnapshotEnvironmentBinding (SEB) binds the following into a concrete deployment:
-	- Application
-	- Environment
-	- Snapshot
-    - tuple: Application A, of version S, should be deployed to Environment E    
+
+  - Application
+  - Environment
+  - Snapshot
+    - tuple: Application A, of version S, should be deployed to Environment E
 
 - Example SnapshotEnvironmentBinding:
-    - We want to deploy (snapshot) 'v2' of our Application to 'staging' Environment, and 'v1' (snapshot) to 'production' Environment.
-    - That would look like this:
-        - SEB 'loan-app-staging':
-            - application: loan-app
-            - environment: staging
-            - snapshot: v2
-        - SEB 'loan-app-production':
-            - application: loan-app
-            - environment: production
-            - snapshot: v1
-    - In this example, the `SnapshotEnvironmentBinding` controller would reconcile the above into 6 Argo CD Applications:
-        - 'loan-app-staging' would become:
-            - Argo CD Application 'loan-app-staging-frontend': deploy v2 of 'frontend' component to staging
-            - Argo CD Application 'loan-app-staging-backend': deploy v2 of 'backend' component to staging
-            - Argo CD Application 'loan-app-staging-database': deploy v2 of 'database' component to staging
-        - 'loan-app-prod' would become:
-            - Argo CD Application 'loan-app-prod-frontend': deploy v1 of 'frontend' component to prod
-            - Argo CD Application 'loan-app-prod-backend': deploy v1 of 'backend' component to prod
-            - Argo CD Application 'loan-app-prod-database': deploy v1 of 'database' component to prod
+  - We want to deploy (snapshot) 'v2' of our Application to 'staging' Environment, and 'v1' (snapshot) to 'production' Environment.
+  - That would look like this:
+    - SEB 'loan-app-staging':
+      - application: loan-app
+      - environment: staging
+      - snapshot: v2
+    - SEB 'loan-app-production':
+      - application: loan-app
+      - environment: production
+      - snapshot: v1
+  - In this example, the `SnapshotEnvironmentBinding` controller would reconcile the above into 6 Argo CD Applications:
+    - 'loan-app-staging' would become:
+      - Argo CD Application 'loan-app-staging-frontend': deploy v2 of 'frontend' component to staging
+      - Argo CD Application 'loan-app-staging-backend': deploy v2 of 'backend' component to staging
+      - Argo CD Application 'loan-app-staging-database': deploy v2 of 'database' component to staging
+    - 'loan-app-prod' would become:
+      - Argo CD Application 'loan-app-prod-frontend': deploy v1 of 'frontend' component to prod
+      - Argo CD Application 'loan-app-prod-backend': deploy v1 of 'backend' component to prod
+      - Argo CD Application 'loan-app-prod-database': deploy v1 of 'database' component to prod
 - [API example/description](https://github.com/redhat-appstudio/managed-gitops/blob/main/docs/api.md#snapshotenvironmentbinding)
-- [SnapshotEnvironmentBinding CR code](https://github.com/redhat-appstudio/application-api/blob/18f545e48a03cbc6df71fb0468dac9aa66209c4c/api/v1alpha1/snapshotenvironmentbinding_types.go#L33)
-
+- [SnapshotEnvironmentBinding CR code](https://github.com/github.com/konflux-ci/application-api/blob/18f545e48a03cbc6df71fb0468dac9aa66209c4c/api/v1alpha1/snapshotenvironmentbinding_types.go#L33)
 
 #### PromotionRun
+
 - A single use CR which will promote a particular Application/Snapshot to a particular Environment
 - For example: I could use a `PromotionRun` to promote Snapshot 'loan-app-v2' from 'staging NA' to 'prod NA'
 - This is the mechanism for manual promotion between Environments (versus 'automated promotion' which would trigger a new promotion once an Application between healthy in an Environment)
-- [API example/description](https://github.com/redhat-appstudio/application-api/blob/18f545e48a03cbc6df71fb0468dac9aa66209c4c/api/v1alpha1/promotionrun_types.go#L24)
-- [PromotionRun CR code](https://github.com/redhat-appstudio/application-api/blob/18f545e48a03cbc6df71fb0468dac9aa66209c4c/api/v1alpha1/promotionrun_types.go#L24)
+- [API example/description](https://github.com/github.com/konflux-ci/application-api/blob/18f545e48a03cbc6df71fb0468dac9aa66209c4c/api/v1alpha1/promotionrun_types.go#L24)
+- [PromotionRun CR code](https://github.com/github.com/konflux-ci/application-api/blob/18f545e48a03cbc6df71fb0468dac9aa66209c4c/api/v1alpha1/promotionrun_types.go#L24)
 
 ## Similarity to others: Kargo
 
 From my cursory look at Kargo,the Konflux Environment API is somewhat similar to Kargo (probably because we're working in the same problem space), but with Kargo having more support for advanced use cases.
 
 #### For example, API similarities:
+
 - Konflux `Environment` CR => Kargo `Stage` CR
-    - Both are a DAG of K8s clusters, with promotion between, and customizable logic to trigger.
+  - Both are a DAG of K8s clusters, with promotion between, and customizable logic to trigger.
 - Konflux `Snapshot` CR => Kargo `Freight` CR
-    - `Snapshot` is just a set of container images, while `Freight` is container images but can ALSO be other resources (e.g. helm chart versions)
-- Konflux `PromotionRun` CR => `Promotion` CR 
-    - Both are a CR which manually triggers a promotion between environments.
+  - `Snapshot` is just a set of container images, while `Freight` is container images but can ALSO be other resources (e.g. helm chart versions)
+- Konflux `PromotionRun` CR => `Promotion` CR
+  - Both are a CR which manually triggers a promotion between environments.
 - Custom Konflux controllers => `Warehouse` CR
-    - Konflux has custom controllers that enable specific, supported workflows, implemented by other Konflux teams. These custom controllers produce `Snapshot`. In contrast, Konflux has the `Warehouse` concept, which generalizes the concept into a CR.
-- _(N/A)_ => `PromotionPolicy` CR / `Verification` CR 
-    - No specific equivalent in Konflux, but only because we never had specfic requirement requests, here. The Kargo concepts appear sound and would fit right in.
+  - Konflux has custom controllers that enable specific, supported workflows, implemented by other Konflux teams. These custom controllers produce `Snapshot`. In contrast, Konflux has the `Warehouse` concept, which generalizes the concept into a CR.
+- _(N/A)_ => `PromotionPolicy` CR / `Verification` CR
+  - No specific equivalent in Konflux, but only because we never had specfic requirement requests, here. The Kargo concepts appear sound and would fit right in.
 
 ## External Resources
 
 [Environment API CR descriptions and concepts](https://github.com/redhat-appstudio/managed-gitops/blob/main/docs/api.md#gitops-service-app-studio-environment-apis)
 
-[Konflux Application/Component/Environment Go APIs live here](https://github.com/redhat-appstudio/application-api/tree/main/api/v1alpha1)
+[Konflux Application/Component/Environment Go APIs live here](https://github.com/github.com/konflux-ci/application-api/tree/main/api/v1alpha1)
 
 [K8s controllers that implement the Environment API live here](https://github.com/redhat-appstudio/managed-gitops/tree/main/appstudio-controller/controllers/appstudio.redhat.com)
 

--- a/manifests/base/crd/overlays/local-dev/kustomization.yaml
+++ b/manifests/base/crd/overlays/local-dev/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/redhat-appstudio/application-api/config/crd?ref=18f545e48a03cbc6df71fb0468dac9aa66209c4c
+- https://github.com/konflux-ci/application-api/config/crd?ref=18f545e48a03cbc6df71fb0468dac9aa66209c4c
 - https://github.com/codeready-toolchain/host-operator/config/crd?ref=6c9e07da3665f542448ff46fc91d7fa1bfd83853
 - ../../base

--- a/tests-e2e/appstudio/deploymenttargetclaim_binder_test.go
+++ b/tests-e2e/appstudio/deploymenttargetclaim_binder_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	appstudiocontrollers "github.com/redhat-appstudio/managed-gitops/appstudio-controller/controllers/appstudio.redhat.com"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	dtfixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/deploymenttarget"

--- a/tests-e2e/appstudio/devsandboxdeployment_test.go
+++ b/tests-e2e/appstudio/devsandboxdeployment_test.go
@@ -5,9 +5,9 @@ import (
 
 	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 
 	appstudiocontrollers "github.com/redhat-appstudio/managed-gitops/appstudio-controller/controllers/appstudio.redhat.com"

--- a/tests-e2e/appstudio/dt_dtc_dtclass_test.go
+++ b/tests-e2e/appstudio/dt_dtc_dtclass_test.go
@@ -12,7 +12,7 @@ import (
 	appstudiocontrollers "github.com/redhat-appstudio/managed-gitops/appstudio-controller/controllers/appstudio.redhat.com"
 
 	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	dtfixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/deploymenttarget"
 	dtcfixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/deploymenttargetclaim"

--- a/tests-e2e/appstudio/environment_test.go
+++ b/tests-e2e/appstudio/environment_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/managedenvironment"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appstudioshared "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	appstudioshared "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	app "github.com/redhat-appstudio/managed-gitops/appstudio-controller/controllers/appstudio.redhat.com"
 	appstudiocontrollers "github.com/redhat-appstudio/managed-gitops/appstudio-controller/controllers/appstudio.redhat.com"
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"

--- a/tests-e2e/appstudio/promotionrun_controller_seb_test.go
+++ b/tests-e2e/appstudio/promotionrun_controller_seb_test.go
@@ -3,9 +3,9 @@ package appstudio
 import (
 	"strings"
 
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
 	promotionRunFixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/promotionrun"

--- a/tests-e2e/appstudio/promotionrun_controller_test.go
+++ b/tests-e2e/appstudio/promotionrun_controller_test.go
@@ -3,9 +3,9 @@ package appstudio
 import (
 	"context"
 
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	appstudiocontroller "github.com/redhat-appstudio/managed-gitops/appstudio-controller/controllers/appstudio.redhat.com"
 	"github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	dbutil "github.com/redhat-appstudio/managed-gitops/backend-shared/db/util"

--- a/tests-e2e/appstudio/sandboxprovisioner_test.go
+++ b/tests-e2e/appstudio/sandboxprovisioner_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	appstudiocontrollers "github.com/redhat-appstudio/managed-gitops/appstudio-controller/controllers/appstudio.redhat.com"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	dtcfixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/deploymenttargetclaim"

--- a/tests-e2e/appstudio/snapshotenvironmentbinding_test.go
+++ b/tests-e2e/appstudio/snapshotenvironmentbinding_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	appstudiocontroller "github.com/redhat-appstudio/managed-gitops/appstudio-controller/controllers/appstudio.redhat.com"
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"

--- a/tests-e2e/appstudio/webhook_test.go
+++ b/tests-e2e/appstudio/webhook_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"

--- a/tests-e2e/fixture/binding/fixture.go
+++ b/tests-e2e/fixture/binding/fixture.go
@@ -11,8 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	matcher "github.com/onsi/gomega/types"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	k8sFixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
 )
 

--- a/tests-e2e/fixture/deploymenttarget/fixture.go
+++ b/tests-e2e/fixture/deploymenttarget/fixture.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	. "github.com/onsi/gomega"
 	matcher "github.com/onsi/gomega/types"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	k8sFixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/tests-e2e/fixture/deploymenttargetclaim/fixture.go
+++ b/tests-e2e/fixture/deploymenttargetclaim/fixture.go
@@ -6,9 +6,9 @@ import (
 
 	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	. "github.com/onsi/gomega"
 	matcher "github.com/onsi/gomega/types"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	appstudiocontrollers "github.com/redhat-appstudio/managed-gitops/appstudio-controller/controllers/appstudio.redhat.com"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 	k8sFixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"

--- a/tests-e2e/fixture/environment/fixture.go
+++ b/tests-e2e/fixture/environment/fixture.go
@@ -10,8 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	matcher "github.com/onsi/gomega/types"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	k8sFixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
 )
 

--- a/tests-e2e/fixture/fixture.go
+++ b/tests-e2e/fixture/fixture.go
@@ -12,9 +12,9 @@ import (
 
 	argocdoperator "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	appv1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
 

--- a/tests-e2e/fixture/promotionrun/fixture.go
+++ b/tests-e2e/fixture/promotionrun/fixture.go
@@ -11,8 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	matcher "github.com/onsi/gomega/types"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	k8sFixture "github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture/k8s"
 )
 

--- a/tests-e2e/fixture/spacerequest/fixture.go
+++ b/tests-e2e/fixture/spacerequest/fixture.go
@@ -6,10 +6,10 @@ import (
 
 	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	appstudiosharedv1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	matcher "github.com/onsi/gomega/types"
-	appstudiosharedv1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	appstudiocontrollers "github.com/redhat-appstudio/managed-gitops/appstudio-controller/controllers/appstudio.redhat.com"
 	"github.com/redhat-appstudio/managed-gitops/tests-e2e/fixture"
 

--- a/tests-e2e/go.mod
+++ b/tests-e2e/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/codeready-toolchain/api v0.0.0-20230417183849-f62ccbf3bd40
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20230417235430-8258a3281250
 	github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible
-	github.com/redhat-appstudio/application-api v0.0.0-20240106104232-18f545e48a03
+	github.com/github.com/konflux-ci/application-api v0.0.0-20240106104232-18f545e48a03
 	github.com/redhat-appstudio/managed-gitops/appstudio-controller v0.0.0
 	github.com/redhat-appstudio/managed-gitops/backend v0.0.0-00010101000000-000000000000
 	github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0

--- a/tests-e2e/go.sum
+++ b/tests-e2e/go.sum
@@ -648,8 +648,8 @@ github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPH
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/r3labs/diff v1.1.0 h1:V53xhrbTHrWFWq3gI4b94AjgEJOerO1+1l0xyHOBi8M=
 github.com/r3labs/diff v1.1.0/go.mod h1:7WjXasNzi0vJetRcB/RqNl5dlIsmXcTTLmF5IoH6Xig=
-github.com/redhat-appstudio/application-api v0.0.0-20240106104232-18f545e48a03 h1:UUgrEyvQJhEnvghkEaY9YlxeAk+D4cop+Bd3+8jh0eQ=
-github.com/redhat-appstudio/application-api v0.0.0-20240106104232-18f545e48a03/go.mod h1:YvckuKHe82eWloGk0/BpSw4YYG2owrGZAanztbOj3pQ=
+github.com/github.com/konflux-ci/application-api v0.0.0-20240106104232-18f545e48a03 h1:UUgrEyvQJhEnvghkEaY9YlxeAk+D4cop+Bd3+8jh0eQ=
+github.com/github.com/konflux-ci/application-api v0.0.0-20240106104232-18f545e48a03/go.mod h1:YvckuKHe82eWloGk0/BpSw4YYG2owrGZAanztbOj3pQ=
 github.com/redis/go-redis/v9 v9.0.0-rc.4/go.mod h1:Vo3EsyWnicKnSKCA7HhgnvnyA74wOA69Cd2Meli5mmA=
 github.com/redis/go-redis/v9 v9.0.5 h1:CuQcn5HIEeK7BgElubPP8CGtE0KakrnbBSTLjathl5o=
 github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=

--- a/tests-e2e/main.go
+++ b/tests-e2e/main.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	applicationv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	applicationv1alpha1 "github.com/github.com/konflux-ci/application-api/api/v1alpha1"
 	gitopsdeploymentv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 
 	sharedutil "github.com/redhat-appstudio/managed-gitops/backend-shared/util"

--- a/utilities/load-test/go.mod
+++ b/utilities/load-test/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
-	github.com/redhat-appstudio/application-api v0.0.0-20240106104232-18f545e48a03 // indirect
+	github.com/github.com/konflux-ci/application-api v0.0.0-20240106104232-18f545e48a03 // indirect
 	github.com/redis/go-redis/v9 v9.0.5 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect

--- a/utilities/load-test/go.sum
+++ b/utilities/load-test/go.sum
@@ -595,8 +595,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-appstudio/application-api v0.0.0-20240106104232-18f545e48a03 h1:UUgrEyvQJhEnvghkEaY9YlxeAk+D4cop+Bd3+8jh0eQ=
-github.com/redhat-appstudio/application-api v0.0.0-20240106104232-18f545e48a03/go.mod h1:YvckuKHe82eWloGk0/BpSw4YYG2owrGZAanztbOj3pQ=
+github.com/github.com/konflux-ci/application-api v0.0.0-20240106104232-18f545e48a03 h1:UUgrEyvQJhEnvghkEaY9YlxeAk+D4cop+Bd3+8jh0eQ=
+github.com/github.com/konflux-ci/application-api v0.0.0-20240106104232-18f545e48a03/go.mod h1:YvckuKHe82eWloGk0/BpSw4YYG2owrGZAanztbOj3pQ=
 github.com/redis/go-redis/v9 v9.0.0-rc.4/go.mod h1:Vo3EsyWnicKnSKCA7HhgnvnyA74wOA69Cd2Meli5mmA=
 github.com/redis/go-redis/v9 v9.0.5 h1:CuQcn5HIEeK7BgElubPP8CGtE0KakrnbBSTLjathl5o=
 github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=


### PR DESCRIPTION
#### Description:

This PR simply updates the documentation to mention the new location of the `application-service` & `application-api` repos (is getting migrated from `redhat-appstudio` to `konflux-ci`

#### Link to JIRA Story (if applicable):

https://issues.redhat.com/browse/DEVHAS-657