### PR TITLE
Add support for non-OpenShift K8s to managed-gitops, testing via k3d

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
           ARGO_CD_SERVER_ADDR=127.0.0.1:51212 make start-e2e &
 
-          OVERRIDE_APISERVER_ADDR_SOURCE="0.0.0.0" OVERRIDE_APISERVER_ADDR_DEST="kubernetes.default.svc"  make test-e2e     
+          GITHUB_K3D=true OVERRIDE_APISERVER_ADDR_SOURCE="0.0.0.0" OVERRIDE_APISERVER_ADDR_DEST="kubernetes.default.svc"  make test-e2e     
 
           make e2e-reset
           pkill go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
       - name: Run the tests
         run: |
           set -o pipefail
+          make download-deps
+
           make setup-e2e-local-k8s
 
           kubectl port-forward svc/argocd-server -n gitops-service-argocd 51212:443 &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
         k3s-version: [ v1.27.1 ]
     steps:
       - name: Public IP
-          id: ip
-          uses: haythem/public-ip@v1.3
+        id: ip
+        uses: haythem/public-ip@v1.3
 
       # - name: See IP Addresses
       #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: Build and test the operator
+on:
+  push:
+    branches:
+      - 'main'
+
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+
+  test-e2e:
+    name: Run end-to-end tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k3s-version: [ v1.27.1 ]
+    steps:
+      - name: Install k3d
+        run: |
+          set -x
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+          sudo mkdir -p $HOME/.kube && sudo chown -R runner $HOME/.kube
+          k3d cluster create --servers 3 --image rancher/k3s:${{ matrix.k3s-version }}-k3s1
+          kubectl version
+          k3d version
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Golang
+        uses: actions/setup-go@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: tests-e2e/go.mod
+
+      - name: GH actions workaround - Kill XSP4 process
+        run: |
+          sudo pkill mono || true
+
+      - name: Restore go build cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-v1-${{ github.run_id }}
+
+      - name: Add /usr/local/bin to PATH
+        run: |
+          echo "/usr/local/bin" >> $GITHUB_PATH
+
+      - name: Download Go dependencies
+        run: |
+          go mod download
+
+      - name: Run the tests
+        run: |
+          set -o pipefail
+          make setup-e2e-local-k8s
+
+          kubectl port-forward svc/argocd-server -n gitops-service-argocd 51212:443 &
+
+          ARGO_CD_SERVER_ADDR=127.0.0.1:51212 make start-e2e &
+
+          OVERRIDE_APISERVER_ADDR_SOURCE="0.0.0.0" OVERRIDE_APISERVER_ADDR_DEST="192.168.8.152"  make test-e2e     
+
+          make e2e-reset
+          pkill go
+          pkill main
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         k3s-version: [ v1.27.1 ]
     steps:
-      - name: Public IP
-        id: ip
-        uses: haythem/public-ip@v1.3
+      # - name: Public IP
+      #   id: ip
+      #   uses: haythem/public-ip@v1.3
 
       # - name: See IP Addresses
       #   run: |
@@ -69,7 +69,7 @@ jobs:
 
           ARGO_CD_SERVER_ADDR=127.0.0.1:51212 make start-e2e &
 
-          OVERRIDE_APISERVER_ADDR_SOURCE="0.0.0.0" OVERRIDE_APISERVER_ADDR_DEST="${{ steps.ip.outputs.ipv4 }}"  make test-e2e     
+          OVERRIDE_APISERVER_ADDR_SOURCE="0.0.0.0" OVERRIDE_APISERVER_ADDR_DEST="kubernetes.default.svc"  make test-e2e     
 
           make e2e-reset
           pkill go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,6 @@ jobs:
 
       - name: Setup Golang
         uses: actions/setup-go@v5
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
         with:
           go-version-file: tests-e2e/go.mod
 
@@ -50,10 +47,6 @@ jobs:
       - name: Add /usr/local/bin to PATH
         run: |
           echo "/usr/local/bin" >> $GITHUB_PATH
-
-      - name: Download Go dependencies
-        run: |
-          go mod download
 
       - name: Run the tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
 
+
   test-e2e:
     name: Run end-to-end tests
     runs-on: ubuntu-latest
@@ -17,6 +18,15 @@ jobs:
       matrix:
         k3s-version: [ v1.27.1 ]
     steps:
+      - name: Public IP
+          id: ip
+          uses: haythem/public-ip@v1.3
+
+      # - name: See IP Addresses
+      #   run: |
+      #     echo ${{ steps.ip.outputs.ipv4 }}
+      #     echo ${{ steps.ip.outputs.ipv6 }}
+
       - name: Install k3d
         run: |
           set -x
@@ -59,7 +69,7 @@ jobs:
 
           ARGO_CD_SERVER_ADDR=127.0.0.1:51212 make start-e2e &
 
-          OVERRIDE_APISERVER_ADDR_SOURCE="0.0.0.0" OVERRIDE_APISERVER_ADDR_DEST="192.168.8.152"  make test-e2e     
+          OVERRIDE_APISERVER_ADDR_SOURCE="0.0.0.0" OVERRIDE_APISERVER_ADDR_DEST="${{ steps.ip.outputs.ipv4 }}"  make test-e2e     
 
           make e2e-reset
           pkill go

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,8 @@ install-argocd-openshift: kustomize ## Using OpenShift GitOps, install Argo CD t
 	PATH=$(MAKEFILE_ROOT)/bin:$(PATH) $(MAKEFILE_ROOT)/manifests/scripts/openshift-argo-deploy/deploy.sh
 
 install-argocd-k8s: ## (Non-OpenShift): Install Argo CD to the gitops-service-argocd namespace
-	ARGO_CD_VERSION=$(ARGO_CD_VERSION) manifests/scripts/k8s-argo-deploy/deploy.sh
+	ARGO_CD_VERSION=$(ARGO_CD_VERSION) ./argocd.sh install
+	# manifests/scripts/k8s-argo-deploy/deploy.sh
 
 uninstall-argocd: ## Uninstall Argo CD from gitops-service-argocd namespace (from either OpenShift or K8s)
 	kubectl delete namespace "$(ARGO_CD_NAMESPACE)" || true
@@ -196,6 +197,8 @@ docker-push: ## Push docker image - note: you have to change the USERNAME var. O
 test: test-backend test-backend-shared test-cluster-agent test-appstudio-controller test-init-container-binary ## Run tests for all components
 
 setup-e2e-openshift: install-argocd-openshift devenv-k8s-e2e ## Setup steps for E2E tests to run with Openshift CI
+
+setup-e2e-local-k8s: install-argocd-k8s devenv-docker reset-db ## Setup steps for E2E tests to run with Local Openshift Cluster
 
 setup-e2e-local: install-argocd-openshift devenv-docker reset-db ## Setup steps for E2E tests to run with Local Openshift Cluster
 

--- a/manifests/k8s-argo-cd/kustomization.yaml
+++ b/manifests/k8s-argo-cd/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+-  https://raw.githubusercontent.com/argoproj/argo-cd/$ARGO_CD_VERSION/manifests/install.yaml
+
+namespace: $ARGO_CD_NAMESPACE
+
+patchesStrategicMerge:
+- |-
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:         
+    name: argocd-application-controller
+  subjects:         
+  - kind: ServiceAccount
+    name: argocd-application-controller
+    namespace: $ARGO_CD_NAMESPACE
+
+- |-
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:         
+    name: argocd-server
+  subjects:
+  - kind: ServiceAccount
+    name: argocd-server
+    namespace: $ARGO_CD_NAMESPACE
+

--- a/tests-e2e/.gitignore
+++ b/tests-e2e/.gitignore
@@ -3,5 +3,5 @@ cover.out
 vendor
 bin
 coverage.out
-
+ginkgo.report
 

--- a/tests-e2e/Makefile
+++ b/tests-e2e/Makefile
@@ -33,7 +33,7 @@ help: ## Display this help.
 
 .PHONY: test
 test: ## Run E2E tests.
-	ENABLE_APPPROJECT_ISOLATION="true" DEV_ONLY_ALLOW_NON_TLS_CONNECTION_TO_POSTGRESQL=true go test -v -p=1 -timeout=100m -race -count=1 -coverprofile=coverage.out ./...
+	ENABLE_APPPROJECT_ISOLATION="true" DEV_ONLY_ALLOW_NON_TLS_CONNECTION_TO_POSTGRESQL=true go test -v -p=1 -timeout=100m -race -count=1 -coverprofile=coverage.out ./core/ ./argocd/
 
 # go-get-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/tests-e2e/argocd/argocd_gitopsengine_instance_test.go
+++ b/tests-e2e/argocd/argocd_gitopsengine_instance_test.go
@@ -31,6 +31,8 @@ var _ = Describe("ArgoCD instance via GitOpsEngineInstance Operations Test", fun
 
 		It("ensures that a standalone ArgoCD gets created successfully when an operation CR of resource-type GitOpsEngineInstance is created", func() {
 
+			fixture.SkipIfArgoCDOperandRequired()
+
 			dbq, err := db.NewUnsafePostgresDBQueries(true, true)
 			Expect(err).ToNot(HaveOccurred())
 			defer dbq.CloseDatabase()

--- a/tests-e2e/argocd/argocd_instance_test.go
+++ b/tests-e2e/argocd/argocd_instance_test.go
@@ -44,6 +44,9 @@ var _ = Describe("Standalone ArgoCD instance E2E tests", func() {
 		})
 
 		testStandaloneArgoCD := func(testUpdate bool) {
+
+			fixture.SkipIfArgoCDOperandRequired()
+
 			By("creating ArgoCD resource")
 			ctx := context.Background()
 			log := log.FromContext(ctx)

--- a/tests-e2e/argocd/queryscoped_cluster_secrets_test.go
+++ b/tests-e2e/argocd/queryscoped_cluster_secrets_test.go
@@ -138,6 +138,11 @@ var _ = Describe("Argo CD Application tests", func() {
 
 			func(clusterScoped bool) {
 
+				if fixture.IsGitHubK3D() {
+					Skip("when running on GitHub CI via K3d, we don't have an API endpoint IP we can use, so skip")
+					return
+				}
+
 				createServiceAccountsAndSecretsForTest(clusterScoped)
 
 				for _, userName := range users {

--- a/tests-e2e/argocd/queryscoped_cluster_secrets_test.go
+++ b/tests-e2e/argocd/queryscoped_cluster_secrets_test.go
@@ -208,6 +208,11 @@ var _ = Describe("Argo CD Application tests", func() {
 
 		DescribeTable("ensure users cannot deploy to another user's namespace, when using different Argo CD cluster secrets for each user, each with a query parameter", func(clusterScoped bool) {
 
+			if fixture.IsGitHubK3D() {
+				Skip("when running on GitHub CI via K3d, we don't have an API endpoint IP we can use, so skip")
+				return
+			}
+
 			createServiceAccountsAndSecretsForTest(clusterScoped)
 
 			Expect(users).To(HaveLen(2))

--- a/tests-e2e/core/gitopsdeployment_status_test.go
+++ b/tests-e2e/core/gitopsdeployment_status_test.go
@@ -47,18 +47,6 @@ var _ = Describe("GitOpsDeployment Status Tests", func() {
 						},
 					},
 					{
-						Group:     "route.openshift.io",
-						Version:   "v1",
-						Kind:      "Route",
-						Namespace: fixture.GitOpsServiceE2ENamespace,
-						Name:      name,
-						Status:    managedgitopsv1alpha1.SyncStatusCodeSynced,
-						Health: &managedgitopsv1alpha1.HealthStatus{
-							Status:  managedgitopsv1alpha1.HeathStatusCodeHealthy,
-							Message: "Route is healthy",
-						},
-					},
-					{
 						Group:     "",
 						Version:   "v1",
 						Kind:      "Service",

--- a/tests-e2e/core/gitopsdeployment_syncrun_test.go
+++ b/tests-e2e/core/gitopsdeployment_syncrun_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 var _ = Describe("GitOpsDeploymentSyncRun E2E tests", func() {
+
 	Context("Create, update and delete GitOpsDeploymentSyncRun", func() {
 
 		var (
@@ -65,10 +66,14 @@ var _ = Describe("GitOpsDeploymentSyncRun E2E tests", func() {
 		})
 
 		AfterEach(func() {
-			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(argocdCR), argocdCR)
-			Expect(err == nil || apierr.IsNotFound(err)).To(BeTrue())
 
-			removeCustomHealthCheckForDeployment(ctx, k8sClient, argocdCR)
+			if fixture.IsArgoCDOperandAvailable() {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(argocdCR), argocdCR)
+				Expect(err == nil || apierr.IsNotFound(err)).To(BeTrue())
+
+				removeCustomHealthCheckForDeployment(ctx, k8sClient, argocdCR)
+			}
+
 		})
 
 		It("creating a new GitOpsDeploymentSyncRun should sync an Argo CD Application", func() {
@@ -197,6 +202,8 @@ var _ = Describe("GitOpsDeploymentSyncRun E2E tests", func() {
 		})
 
 		It("deleting the GitOpsDeploymentSyncRun should terminate a running Sync operation", func() {
+			fixture.SkipIfArgoCDOperandRequired()
+
 			gitOpsDeploymentResource = gitopsDeplFixture.BuildGitOpsDeploymentResource("test-deply-with-presync",
 				"https://github.com/managed-gitops-test-data/deployment-presync-hook", "guestbook",
 				managedgitopsv1alpha1.GitOpsDeploymentSpecType_Manual)
@@ -313,6 +320,8 @@ var _ = Describe("GitOpsDeploymentSyncRun E2E tests", func() {
 		})
 
 		It("should sync if the previous sync operation is terminated", func() {
+
+			fixture.SkipIfArgoCDOperandRequired()
 
 			gitOpsDeploymentResource = gitopsDeplFixture.BuildGitOpsDeploymentResource("test-deply-with-presync",
 				"https://github.com/managed-gitops-test-data/deployment-presync-hook", "guestbook",

--- a/tests-e2e/core/gitopsdeployment_test.go
+++ b/tests-e2e/core/gitopsdeployment_test.go
@@ -77,18 +77,6 @@ var _ = Describe("GitOpsDeployment E2E tests", func() {
 					},
 				},
 				{
-					Group:     "route.openshift.io",
-					Version:   "v1",
-					Kind:      "Route",
-					Namespace: fixture.GitOpsServiceE2ENamespace,
-					Name:      name,
-					Status:    managedgitopsv1alpha1.SyncStatusCodeSynced,
-					Health: &managedgitopsv1alpha1.HealthStatus{
-						Status:  managedgitopsv1alpha1.HeathStatusCodeHealthy,
-						Message: "Route is healthy",
-					},
-				},
-				{
 					Group:     "",
 					Version:   "v1",
 					Kind:      "Service",

--- a/tests-e2e/core/managed_environment_status_test.go
+++ b/tests-e2e/core/managed_environment_status_test.go
@@ -43,8 +43,12 @@ var _ = Describe("Managed Environment Status E2E tests", func() {
 			Expect(managedEnv.Status.Conditions).To(HaveLen(1))
 			condition := managedEnv.Status.Conditions[0]
 			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(string(managedgitopsv1alpha1.ConditionReasonUnableToCreateClient)))
+			Expect(condition.Reason).To(Or(
+				Equal(string(managedgitopsv1alpha1.ConditionReasonUnableToCreateClient)),
+				Equal(string(managedgitopsv1alpha1.ConditionReasonUnableToInstallServiceAccount)),
+			))
 			Expect(condition.Message).To(ContainSubstring("no such host"))
+
 		})
 
 		It("should have a connection status condition of False when the credentials are missing a required field", func() {

--- a/tests-e2e/fixture/fixture.go
+++ b/tests-e2e/fixture/fixture.go
@@ -930,6 +930,10 @@ func GetE2ETestUserWorkspaceKubeClient() (client.Client, error) {
 	return k8sClient, nil
 }
 
+func IsGitHubK3D() bool {
+	return strings.TrimSpace(strings.ToLower(os.Getenv("GITHUB_K3D"))) == "true"
+}
+
 // IsRunningInStonesoupEnvironment returns true if the tests are running in a Stonesoup environment, false otherwise
 func IsRunningInStonesoupEnvironment() bool {
 	// Stonesoup environment is bootstrapped by an AppOfApps Gitops Deployment.

--- a/tests-e2e/fixture/fixture.go
+++ b/tests-e2e/fixture/fixture.go
@@ -1017,6 +1017,8 @@ func ExtractKubeConfigValues() (string, string, error) {
 		kubeConfigContentsRes = strings.ReplaceAll(kubeConfigContentsRes, overrideAPIServiceAddrSrc, overrideAPIServiceAddrDest)
 	}
 
+	fmt.Println("JGW", kubeConfigContentsRes)
+
 	return kubeConfigContentsRes, serverValRes, nil
 }
 

--- a/tests-e2e/fixture/fixture.go
+++ b/tests-e2e/fixture/fixture.go
@@ -1041,14 +1041,14 @@ func SkipIfArgoCDOperandRequired() {
 func IsArgoCDOperandAvailable() bool {
 
 	k8sConfig, err := GetServiceProviderWorkspaceKubeConfig()
-	Expect(err).To(BeNil())
+	Expect(err).ToNot(HaveOccurred())
 
 	k8sClient, err := GetKubeClient(k8sConfig)
-	Expect(err).To(BeNil())
+	Expect(err).ToNot(HaveOccurred())
 
 	crdList := &apiexts.CustomResourceDefinitionList{}
 	err = k8sClient.List(context.Background(), crdList)
-	Expect(err).To(BeNil())
+	Expect(err).ToNot(HaveOccurred())
 
 	argoCDCRFound := false
 	for _, crd := range crdList.Items {

--- a/tests-e2e/go.mod
+++ b/tests-e2e/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/redhat-appstudio/managed-gitops/backend v0.0.0-00010101000000-000000000000
 	github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0
 	github.com/redhat-appstudio/managed-gitops/cluster-agent v0.0.0
+	k8s.io/apiextensions-apiserver v0.31.2
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v12.0.0+incompatible
 	sigs.k8s.io/controller-runtime v0.19.0
@@ -183,7 +184,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.31.0
-	k8s.io/apiextensions-apiserver v0.31.2 // indirect
 	k8s.io/component-base v0.31.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect


### PR DESCRIPTION
#### Description:
- Add support for non-OpenShift K8s to managed-gitops, primarily by removing references to Routes and ArgoCD CR
- Add initial testing via k3d

#### Link to JIRA Story (if applicable): N/A

<!-- Please add a link to this PR into the JIRA story, once this PR is open.  -->
